### PR TITLE
Repair dogfood loop: SSE /sessions, prism_install -> settings.json, loud hook logging

### DIFF
--- a/services/prism-service/app/assets/feedback_signal_hook.py
+++ b/services/prism-service/app/assets/feedback_signal_hook.py
@@ -102,8 +102,12 @@ def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
     )
     try:
         urllib.request.urlopen(req, timeout=4).read()
-    except Exception:
-        pass
+    except Exception as e:
+        try:
+            from hook_logger import log_hook_failure
+            log_hook_failure(f"mcp_call:{tool}", e)
+        except Exception:
+            pass
 
 
 def _parse_search_response(tool_response) -> list[dict]:

--- a/services/prism-service/app/assets/hook_logger.py
+++ b/services/prism-service/app/assets/hook_logger.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Loud-but-non-blocking failure logging for PRISM hooks.
+
+Hooks MUST NOT interrupt Claude's tool execution, so every hook wraps
+its body in `except Exception: pass`. That silence is what hid a month
+of dogfood breakage: the Stop hook was failing in the MCP client and
+no operator signal reached anyone.
+
+Use this module inside the except block instead of a bare pass:
+
+    from hook_logger import log_hook_failure
+    try:
+        ...
+    except Exception as e:
+        log_hook_failure("record_session_outcome", e)
+
+Writes to stderr (always) and to `.prism/logs/hooks.log` (best-effort).
+All functions swallow their own exceptions — a broken logger must not
+break a hook.
+"""
+
+from __future__ import annotations
+
+import sys
+import traceback
+from datetime import datetime, timezone
+from pathlib import Path
+
+_MAX_LOG_BYTES = 2 * 1024 * 1024  # rotate at 2 MB
+
+
+def _project_root() -> Path | None:
+    cur = Path.cwd()
+    for d in [cur, *cur.parents]:
+        if (d / ".mcp.json").exists():
+            return d
+    return None
+
+
+def _log_path() -> Path | None:
+    root = _project_root()
+    if root is None:
+        return None
+    try:
+        log_dir = root / ".prism" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        return log_dir / "hooks.log"
+    except OSError:
+        return None
+
+
+def _rotate_if_needed(path: Path) -> None:
+    try:
+        if path.exists() and path.stat().st_size > _MAX_LOG_BYTES:
+            path.rename(path.with_suffix(".log.old"))
+    except OSError:
+        pass
+
+
+def log_hook_failure(context: str, exc: BaseException) -> None:
+    """Record a hook failure. Never raises."""
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    hook = Path(sys.argv[0]).name if sys.argv else "hook"
+    line = f"{ts} {hook} {context}: {type(exc).__name__}: {exc}"
+    try:
+        print(f"[prism-hook] {line}", file=sys.stderr, flush=True)
+    except Exception:
+        pass
+    path = _log_path()
+    if path is None:
+        return
+    try:
+        _rotate_if_needed(path)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            tb = traceback.format_exception(type(exc), exc, exc.__traceback__)
+            fh.write("".join(tb) + "\n")
+    except OSError:
+        pass

--- a/services/prism-service/app/assets/skill_usage_hook.py
+++ b/services/prism-service/app/assets/skill_usage_hook.py
@@ -56,8 +56,12 @@ def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
     )
     try:
         urllib.request.urlopen(req, timeout=4).read()
-    except Exception:
-        pass
+    except Exception as e:
+        try:
+            from hook_logger import log_hook_failure
+            log_hook_failure(f"mcp_call:{tool}", e)
+        except Exception:
+            pass
 
 
 def main() -> int:

--- a/services/prism-service/app/assets/stop_record_hook.py
+++ b/services/prism-service/app/assets/stop_record_hook.py
@@ -64,8 +64,12 @@ def _mcp_call(base: str, project: str, tool: str, args: dict,
     )
     try:
         urllib.request.urlopen(req, timeout=timeout).read()
-    except Exception:
-        pass
+    except Exception as e:
+        try:
+            from hook_logger import log_hook_failure
+            log_hook_failure(f"mcp_call:{tool}", e)
+        except Exception:
+            pass
 
 
 def _parse_transcript(transcript_path: str) -> dict:

--- a/services/prism-service/app/assets/subagent_record_hook.py
+++ b/services/prism-service/app/assets/subagent_record_hook.py
@@ -61,8 +61,12 @@ def _mcp_call(base: str, project: str, tool: str, args: dict) -> None:
     )
     try:
         urllib.request.urlopen(req, timeout=4).read()
-    except Exception:
-        pass
+    except Exception as e:
+        try:
+            from hook_logger import log_hook_failure
+            log_hook_failure(f"mcp_call:{tool}", e)
+        except Exception:
+            pass
 
 
 def _parse_recommendation(text: str) -> str:

--- a/services/prism-service/app/events.py
+++ b/services/prism-service/app/events.py
@@ -1,0 +1,60 @@
+"""Cross-loop event bus for server-push UI updates.
+
+Publishers run in the MCP server thread (its own uvicorn + event loop)
+while SSE subscribers run in the NiceGUI UI thread. Each subscriber
+registers an asyncio.Queue bound to its own loop; publish() delivers
+via loop.call_soon_threadsafe so there is no cross-thread awaiting.
+
+Events are dicts shaped like:
+    {"project": "prism", "type": "session_outcome", "session_id": "..."}
+
+Scope is by project_id — the /sse endpoint filters incoming events.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any
+
+
+class EventBus:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._subs: list[tuple[asyncio.AbstractEventLoop, asyncio.Queue]] = []
+
+    def subscribe(self) -> asyncio.Queue:
+        """Register the calling coroutine's loop as a subscriber.
+
+        Must be called from within a running asyncio loop (SSE handler).
+        """
+        loop = asyncio.get_running_loop()
+        q: asyncio.Queue = asyncio.Queue(maxsize=256)
+        with self._lock:
+            self._subs.append((loop, q))
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        with self._lock:
+            self._subs = [(l, sq) for (l, sq) in self._subs if sq is not q]
+
+    def publish(self, event: dict[str, Any]) -> None:
+        """Thread-safe fan-out. Drops events if any queue is full."""
+        with self._lock:
+            targets = list(self._subs)
+        for loop, q in targets:
+            try:
+                loop.call_soon_threadsafe(self._put_nowait, q, event)
+            except RuntimeError:
+                # Loop is closed — subscriber will be cleaned up on disconnect.
+                pass
+
+    @staticmethod
+    def _put_nowait(q: asyncio.Queue, event: dict[str, Any]) -> None:
+        try:
+            q.put_nowait(event)
+        except asyncio.QueueFull:
+            pass
+
+
+bus = EventBus()

--- a/services/prism-service/app/main.py
+++ b/services/prism-service/app/main.py
@@ -123,6 +123,7 @@ from app.ui import (
     dashboard, brain_page, graph_page, memory_page,
     tasks_page, conductor_page, sessions_page, retrievals_page,
     learning_page, consolidation_page,
+    sse,  # /sse/sessions endpoint
 )
 
 # Guard against double-start using file lock

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -439,10 +439,10 @@ TOOLS: list[Tool] = [
         description=(
             "Return the install manifest a coding agent should apply to "
             "the current project on first onboard: files to create "
-            "(.claude/hooks.json + hook script), step-by-step instructions, "
-            "and verification steps. The MCP is self-describing — no "
-            "external docs needed. Call this inside project_onboard's flow "
-            "or any time you want to re-install the client-side hooks."
+            "(.claude/settings.json hooks block + hook scripts), step-by-step "
+            "instructions, and verification steps. The MCP is self-describing "
+            "— no external docs needed. Call this inside project_onboard's "
+            "flow or any time you want to re-install the client-side hooks."
         ),
         inputSchema={"type": "object", "properties": {}},
     ),
@@ -1428,6 +1428,7 @@ _FEEDBACK_HOOK_SCRIPT = _load_asset("feedback_signal_hook.py")
 _STOP_HOOK_SCRIPT = _load_asset("stop_record_hook.py")
 _SUBAGENT_HOOK_SCRIPT = _load_asset("subagent_record_hook.py")
 _SKILL_HOOK_SCRIPT = _load_asset("skill_usage_hook.py")
+_HOOK_LOGGER_SCRIPT = _load_asset("hook_logger.py")
 # LL-10 — subagent definition + slash command shipped alongside the
 # hook scripts so Claude has something to match on when it sees the
 # SessionStart additionalContext nudge or the MCP-response header.
@@ -1440,7 +1441,11 @@ def _install_manifest(project_id: str) -> dict:
     The PRISM service is the single source of truth — if the hook logic
     changes in a future release, a re-onboard serves the new version."""
     hook_script = _HOOK_SCRIPT.replace("__PRISM_VERSION__", PRISM_VERSION)
-    hooks_json = {
+    # Claude Code reads hooks from .claude/settings.json under a top-level
+    # "hooks" key. A bare .claude/hooks.json is ignored (only plugin-shipped
+    # hooks/hooks.json is loaded, via a different code path). Wrap the event
+    # map under "hooks" and target settings.json so the hooks actually fire.
+    hooks_map = {
         "SessionStart": [
             {
                 "type": "command",
@@ -1508,15 +1513,23 @@ def _install_manifest(project_id: str) -> dict:
             },
         ],
     }
+    settings_json = {"hooks": hooks_map}
     return {
         "prism_version": PRISM_VERSION,
         "version_notes": PRISM_VERSION_NOTES,
         "project_id": project_id,
         "instructions_for_agent": [
             "Use the Write tool to create each entry in install_files.",
-            "If .claude/hooks.json already exists, MERGE each top-level "
-            "array (SessionStart, PostToolUse, Stop, SubagentStop) by "
-            "appending — do not overwrite the whole file.",
+            "If .claude/settings.json already exists, MERGE by reading it "
+            "first, then deep-merging the 'hooks' object: for each event "
+            "(SessionStart, PostToolUse, Stop, SubagentStop) append the new "
+            "entries to any existing array. Do NOT overwrite other top-level "
+            "keys like 'permissions', 'statusLine', or 'enabledPlugins'.",
+            "Claude Code only reads hooks from settings.json (user, project, "
+            "or local) — a bare .claude/hooks.json is ignored, so writing "
+            "there is a silent no-op. If you find an old .claude/hooks.json "
+            "from a pre-fix install, migrate its contents into settings.json "
+            "under 'hooks' and delete the old file.",
             "After writing, tell the user: 'Restart Claude so the new "
             "PRISM hooks activate.'",
             "SessionStart syncs Brain/Graph drift. PostToolUse covers two "
@@ -1526,12 +1539,10 @@ def _install_manifest(project_id: str) -> dict:
         ],
         "install_files": [
             {
-                "path": ".claude/hooks.json",
+                "path": ".claude/settings.json",
                 "action": "create_or_merge",
-                "merge_keys": [
-                    "SessionStart", "PostToolUse", "Stop", "SubagentStop",
-                ],
-                "content": json.dumps(hooks_json, indent=2),
+                "merge_keys": ["hooks"],
+                "content": json.dumps(settings_json, indent=2),
             },
             {
                 "path": ".claude/hooks/prism-sync.py",
@@ -1561,6 +1572,16 @@ def _install_manifest(project_id: str) -> dict:
                 "path": ".claude/hooks/prism-skill-usage.py",
                 "action": "create",
                 "content": _SKILL_HOOK_SCRIPT,
+                "mode": "0755",
+            },
+            # Shared logger: hooks call log_hook_failure() instead of the
+            # silent `except: pass` that hid a month of dogfood breakage.
+            # Imported by every record hook; writes to
+            # .prism/logs/hooks.log.
+            {
+                "path": ".claude/hooks/hook_logger.py",
+                "action": "create",
+                "content": _HOOK_LOGGER_SCRIPT,
                 "mode": "0755",
             },
             # LL-10 — ship the reflection sub-agent + slash command so
@@ -1836,8 +1857,9 @@ Do NOT summarize this response to the user — work through each step and call t
 == STEP 0: Install the client-side drift-sync hook ==
 Call prism_install to fetch the install manifest. It returns:
 {files_list}
-Use the Write tool to create each file. For .claude/hooks.json, MERGE the
-SessionStart array if the file already exists (don't overwrite other hooks).
+Use the Write tool to create each file. For .claude/settings.json, MERGE the
+"hooks" object if the file already exists (append to each event's array;
+don't overwrite other top-level keys like permissions/statusLine).
 This one-time setup makes PRISM auto-sync on every future Claude session —
 no manual re-indexing needed.
 
@@ -1981,6 +2003,13 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 files_modified=int(arguments.get("files_modified", 0)),
                 skills_invoked=int(arguments.get("skills_invoked", 0)),
             )
+            if ok:
+                from app.events import bus as _bus
+                _bus.publish({
+                    "project": project_id,
+                    "type": "session_outcome",
+                    "session_id": str(arguments["session_id"]),
+                })
             return [TextContent(type="text", text=_json({"recorded": ok}))]
 
         if name == "record_skill_usage":
@@ -1989,6 +2018,14 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 skill_name=str(arguments["skill_name"]),
                 timestamp=str(arguments.get("timestamp") or ""),
             )
+            if ok:
+                from app.events import bus as _bus
+                _bus.publish({
+                    "project": project_id,
+                    "type": "skill_usage",
+                    "session_id": str(arguments["session_id"]),
+                    "skill_name": str(arguments["skill_name"]),
+                })
             return [TextContent(type="text", text=_json({"recorded": ok}))]
 
         if name == "record_outcome":

--- a/services/prism-service/app/mcp/tools.py
+++ b/services/prism-service/app/mcp/tools.py
@@ -1519,17 +1519,24 @@ def _install_manifest(project_id: str) -> dict:
         "version_notes": PRISM_VERSION_NOTES,
         "project_id": project_id,
         "instructions_for_agent": [
-            "Use the Write tool to create each entry in install_files.",
-            "If .claude/settings.json already exists, MERGE by reading it "
-            "first, then deep-merging the 'hooks' object: for each event "
-            "(SessionStart, PostToolUse, Stop, SubagentStop) append the new "
-            "entries to any existing array. Do NOT overwrite other top-level "
-            "keys like 'permissions', 'statusLine', or 'enabledPlugins'.",
-            "Claude Code only reads hooks from settings.json (user, project, "
-            "or local) — a bare .claude/hooks.json is ignored, so writing "
-            "there is a silent no-op. If you find an old .claude/hooks.json "
-            "from a pre-fix install, migrate its contents into settings.json "
-            "under 'hooks' and delete the old file.",
+            "prism_install is idempotent. Safe to re-run on any project — "
+            "the file actions ('upsert' / 'create_or_merge') below describe "
+            "how each file heals drift. Treat this as a migration step, "
+            "not a first-install-only step.",
+            "For every install_file with action='upsert': write the file "
+            "unconditionally with the manifest content (overwriting any "
+            "existing copy). These are server-authoritative artefacts — a "
+            "local edit means the install is stale.",
+            "For .claude/settings.json (action='create_or_merge'): if the "
+            "file exists, read it, deep-merge the 'hooks' object (append new "
+            "entries into each event array without duplicating commands), "
+            "and write it back. Preserve every other top-level key "
+            "('permissions', 'statusLine', 'enabledPlugins', etc). If the "
+            "file does not exist, write the manifest content verbatim.",
+            "Migration: Claude Code only reads hooks from settings.json. If "
+            ".claude/hooks.json exists (from a pre-fix install), its entries "
+            "are dead. Read it, deep-merge its top-level arrays into "
+            "settings.json under 'hooks', then delete .claude/hooks.json.",
             "After writing, tell the user: 'Restart Claude so the new "
             "PRISM hooks activate.'",
             "SessionStart syncs Brain/Graph drift. PostToolUse covers two "
@@ -1546,31 +1553,31 @@ def _install_manifest(project_id: str) -> dict:
             },
             {
                 "path": ".claude/hooks/prism-sync.py",
-                "action": "create",
+                "action": "upsert",
                 "content": hook_script,
                 "mode": "0755",
             },
             {
                 "path": ".claude/hooks/prism-feedback-signal.py",
-                "action": "create",
+                "action": "upsert",
                 "content": _FEEDBACK_HOOK_SCRIPT,
                 "mode": "0755",
             },
             {
                 "path": ".claude/hooks/prism-stop.py",
-                "action": "create",
+                "action": "upsert",
                 "content": _STOP_HOOK_SCRIPT,
                 "mode": "0755",
             },
             {
                 "path": ".claude/hooks/prism-subagent.py",
-                "action": "create",
+                "action": "upsert",
                 "content": _SUBAGENT_HOOK_SCRIPT,
                 "mode": "0755",
             },
             {
                 "path": ".claude/hooks/prism-skill-usage.py",
-                "action": "create",
+                "action": "upsert",
                 "content": _SKILL_HOOK_SCRIPT,
                 "mode": "0755",
             },
@@ -1580,7 +1587,7 @@ def _install_manifest(project_id: str) -> dict:
             # .prism/logs/hooks.log.
             {
                 "path": ".claude/hooks/hook_logger.py",
-                "action": "create",
+                "action": "upsert",
                 "content": _HOOK_LOGGER_SCRIPT,
                 "mode": "0755",
             },
@@ -1590,12 +1597,12 @@ def _install_manifest(project_id: str) -> dict:
             # header from LL-09.
             {
                 "path": ".claude/agents/prism-reflect.md",
-                "action": "create",
+                "action": "upsert",
                 "content": _REFLECT_AGENT_MD,
             },
             {
                 "path": ".claude/commands/prism-reflect.md",
-                "action": "create",
+                "action": "upsert",
                 "content": _REFLECT_COMMAND_MD,
             },
         ],

--- a/services/prism-service/app/ui/sessions_page.py
+++ b/services/prism-service/app/ui/sessions_page.py
@@ -1,5 +1,7 @@
 """Sessions history page -- session outcomes, skill usage, and summary stats."""
 
+import json
+
 from nicegui import ui, app
 
 from app.project_context import get_project
@@ -82,16 +84,49 @@ def _build_session_table(container, outcomes: list[dict]):
     container.clear()
     with container:
         if not outcomes:
+            # Empty state is also our canary for a broken Stop hook — the
+            # dogfood loop was silently dead for a month because this spot
+            # just said "No sessions recorded yet." Say what's likely wrong
+            # and where to look.
             with ui.card().classes(
-                'w-full bg-white shadow-sm rounded-lg p-8 text-center'
+                'w-full bg-amber-50 border border-amber-200 '
+                'shadow-sm rounded-lg p-6'
             ):
-                ui.icon("inbox", color="gray").classes("text-4xl mb-3")
-                ui.label("No sessions recorded yet").classes(
-                    "text-base font-medium text-gray-500"
-                )
-                ui.label(
-                    "Sessions appear after PRISM workflow runs produce outcomes."
-                ).classes("text-sm text-gray-400 mt-2")
+                with ui.row().classes('items-start gap-3'):
+                    ui.icon("warning", color="amber").classes("text-3xl")
+                    with ui.column().classes('gap-1'):
+                        ui.label(
+                            "No session_outcomes rows for this project"
+                        ).classes(
+                            "text-base font-semibold text-amber-900"
+                        )
+                        ui.label(
+                            "If you've been using Claude Code on this project, "
+                            "the Stop hook is probably failing."
+                        ).classes("text-sm text-amber-800")
+                        ui.label("Quick checks:").classes(
+                            "text-xs font-semibold text-amber-900 mt-2"
+                        )
+                        ui.html(
+                            "<ul class='list-disc pl-5 text-xs "
+                            "text-amber-800 space-y-0.5'>"
+                            "<li>Confirm the right project is selected in "
+                            "the header — outcomes are scoped per "
+                            "<code>?project=</code>.</li>"
+                            "<li>Tail <code>.prism/logs/hooks.log</code> "
+                            "in your project root for recent hook "
+                            "exceptions.</li>"
+                            "<li>Make sure "
+                            "<code>prism-devtools@prism</code> is on "
+                            ">= 3.14.3 (<code>claude plugin update</code>). "
+                            "Earlier versions wrote to a local DB that "
+                            "nothing reads.</li>"
+                            "<li>Smoke-test the MCP directly: "
+                            "<code>POST /mcp/?project=&lt;id&gt;</code> "
+                            "with <code>record_session_outcome</code> — "
+                            "a row should appear here live via SSE.</li>"
+                            "</ul>"
+                        )
             return
 
         rows = []
@@ -264,6 +299,21 @@ def sessions_page():
 
     create_nav()
 
+    # SSE push: refresh only when MCP writes a session_outcome / skill_usage
+    # event for the active project. No polling, no visible redraws when idle.
+    project_id = app.storage.user.get('project', 'default')
+    ui.add_head_html(
+        '<script>'
+        'document.addEventListener("DOMContentLoaded", () => {'
+        '  const p = ' + json.dumps(project_id) + ';'
+        '  const es = new EventSource('
+        '    "/sse/sessions?project=" + encodeURIComponent(p)'
+        '  );'
+        '  es.onmessage = (ev) => emitEvent("prism_data_changed", ev.data);'
+        '});'
+        '</script>'
+    )
+
     with page_container():
         # Page heading
         ui.label("Session History").classes(
@@ -294,11 +344,24 @@ def sessions_page():
             )
             skill_container = ui.column().classes('w-full')
 
-    # Refresh logic
+    # Refresh logic — runs on page load and on every SSE event.
+    # Signature-skip is belt-and-braces against duplicate event flurries.
+    state: dict = {"sig": None}
+
+    def _signature(outcomes: list[dict], skills: list[dict]) -> tuple:
+        latest_outcome = outcomes[0].get("recorded_at", "") if outcomes else ""
+        latest_skill = skills[0].get("timestamp", "") if skills else ""
+        return (len(outcomes), latest_outcome, len(skills), latest_skill)
+
     def refresh():
         conductor_svc = _conductor_svc()
-
         outcomes = conductor_svc.get_session_outcomes(limit=50)
+        skills = conductor_svc.get_skill_usage()
+
+        sig = _signature(outcomes, skills)
+        if sig == state["sig"]:
+            return
+        state["sig"] = sig
 
         _build_summary_stats(stats_container, outcomes)
         _build_trend_chart(trend_container, outcomes)
@@ -306,4 +369,4 @@ def sessions_page():
         _build_skill_usage(skill_container)
 
     refresh()
-    ui.timer(5.0, refresh)
+    ui.on('prism_data_changed', lambda _e: refresh())

--- a/services/prism-service/app/ui/sse.py
+++ b/services/prism-service/app/ui/sse.py
@@ -1,0 +1,60 @@
+"""SSE endpoint for server-push UI updates.
+
+Subscribes to the event bus and streams filtered events for a given
+project. UI pages open `new EventSource('/sse/sessions?project=X')`
+and rebuild only when a relevant event arrives.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+from fastapi import Request
+from nicegui import app
+from starlette.responses import StreamingResponse
+
+from app.events import bus
+
+_KEEPALIVE_SECONDS = 25.0
+
+
+@app.get("/sse/sessions")
+async def sse_sessions(request: Request, project: str = "default"):
+    """Stream session/skill events for one project as SSE.
+
+    Emits `data: {...}\\n\\n` on every matching event, and a comment
+    keepalive (`:\\n\\n`) every 25s so proxies don't idle us out.
+    """
+
+    async def gen():
+        q = bus.subscribe()
+        try:
+            # First message so the client transitions from "connecting" to "open".
+            yield b": connected\n\n"
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    event = await asyncio.wait_for(
+                        q.get(), timeout=_KEEPALIVE_SECONDS
+                    )
+                except asyncio.TimeoutError:
+                    yield b": keepalive\n\n"
+                    continue
+                if event.get("project") != project:
+                    continue
+                payload = json.dumps(event, separators=(",", ":"))
+                yield f"data: {payload}\n\n".encode("utf-8")
+        finally:
+            bus.unsubscribe(q)
+
+    return StreamingResponse(
+        gen(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )


### PR DESCRIPTION
## Summary

Three stacked fixes that turn PRISM's own observability loop back on:

- **/sessions is now SSE-push, not 5s polling.** New cross-loop `EventBus` lets the MCP thread fan events out to UI subscribers; `record_session_outcome` + `record_skill_usage` publish on success; the page idles silently and repaints only when scores.db actually changes. Empty state replaced with an amber diagnostic (project selector, `.prism/logs/hooks.log`, plugin version, MCP smoke) instead of a polite "no sessions yet" that hid a dead Stop hook for a month.
- **`prism_install` manifest writes `.claude/settings.json` instead of `.claude/hooks.json`.** Claude Code only reads hooks from settings.json; a bare hooks.json is a silent no-op. Install manifest now emits the hooks map wrapped under the `"hooks"` key with deep-merge instructions that preserve `permissions`/`statusLine`/`enabledPlugins`.
- **Loud-but-non-blocking hook failure logging.** New `hook_logger.py` (shipped via install manifest) writes to stderr + `.prism/logs/hooks.log` with 2 MB rotation. The four MCP-writing hooks swap their silent `except: pass` for `log_hook_failure(f"mcp_call:{tool}", e)` — hooks still exit 0, failures just become audible.

Scope note: changes target `services/` (the `prism_install` distribution path). The `plugins/prism-devtools/` hook files aren't touched here — plugin-based distribution is on its way out, and mixing the two would invite the same version-drift that caused the original regression.

## Test plan
- [x] SSE smoke: `GET /sse/sessions?project=prism` holds open, `POST record_session_outcome` over MCP → `data: {...}` arrives within ~1s on the stream.
- [x] Project scope: a write to `project=default` does not leak to a subscriber on `project=prism`.
- [x] Install manifest: `POST tools/call prism_install` returns `install_files[0].path = .claude/settings.json` with content wrapped under `"hooks"`; `install_files` now includes `.claude/hooks/hook_logger.py`.
- [x] End-to-end hook: feeding `{"session_id":"dogfood-verify-...", "transcript_path":""}` into the installed Stop hook lands a row in `/data/projects/prism/scores.db` and is visible on `/sessions` via SSE.
- [ ] Confirm `.prism/logs/hooks.log` captures a failure when the MCP is unreachable (simulate by stopping the container between hook fires).

🤖 Generated with [Claude Code](https://claude.com/claude-code)