### PR TITLE
fix(graph): cluster-by-cluster reveal animation — no UI freeze

### DIFF
--- a/services/prism-service/app/ui/graph_page.py
+++ b/services/prism-service/app/ui/graph_page.py
@@ -82,7 +82,13 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
   // inconsistently.
   import Graph from "https://esm.sh/graphology@0.25.4";
   import forceAtlas2 from "https://esm.sh/graphology-layout-forceatlas2@0.10.1";
+  import FA2Layout from "https://esm.sh/graphology-layout-forceatlas2@0.10.1/worker";
   import Sigma from "https://esm.sh/sigma@3.0.0";
+  // Yield to the browser between batches of synchronous work so paint /
+  // input can run. requestAnimationFrame is the right primitive here —
+  // it lines us up with the next frame, which is the moment Sigma will
+  // try to redraw too.
+  const yieldToBrowser = () => new Promise(r => requestAnimationFrame(r));
   const PROJECT_ID = "__PROJECT_ID__";
   const statusEl = document.getElementById("status");
   const COMMUNITY_COLORS = [
@@ -163,14 +169,15 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
   // the sidebar legend reads like graphify's graph.html did. Loaded in
   // parallel; if it fails we still render the graph but mark clusters as
   // unlabeled instead of exposing graphify's raw numeric community ids.
-  Promise.all([
-    fetch(`/graphify-visual/${PROJECT_ID}/graph.json`)
-      .then(r => { if (!r.ok) throw new Error("graph.json " + r.status); return r.json(); }),
-    fetch(`/graphify-visual/${PROJECT_ID}/communities.json`)
-      .then(r => r.ok ? r.json() : {communities: []})
-      .catch(() => ({communities: []})),
-  ])
-    .then(([data, commData]) => {
+  async function loadGraph() {
+      statusEl.textContent = "Fetching graph data...";
+      const [data, commData] = await Promise.all([
+        fetch(`/graphify-visual/${PROJECT_ID}/graph.json`)
+          .then(r => { if (!r.ok) throw new Error("graph.json " + r.status); return r.json(); }),
+        fetch(`/graphify-visual/${PROJECT_ID}/communities.json`)
+          .then(r => r.ok ? r.json() : {communities: []})
+          .catch(() => ({communities: []})),
+      ]);
       const g = new Graph();
       const rawNodes = data.nodes || [];
       const edges = data.links || data.edges || [];
@@ -215,55 +222,75 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
         if (!commLo.has(k) || v < commLo.get(k)) commLo.set(k, v);
         if (!commHi.has(k) || v > commHi.get(k)) commHi.set(k, v);
       }
-      for (const n of nodes) {
-        if (g.hasNode(n.id)) continue;
-        const pos = seedPosition();
-        const k = commKey(n);
-        const v = Math.log(1 + (visDeg.get(n.id) || 0));
-        const range = (commHi.get(k) - commLo.get(k)) || 1;
-        const norm = (v - commLo.get(k)) / range;
-        g.addNode(n.id, {
-          label: n.label || n.id,
-          // Near-uniform size (2.5-3.3). Degree is expressed through
-          // brightness, not radius — large degree→size mappings turn
-          // hubs into canvas-dominating blobs.
-          size: 2.5 + 0.8 * norm,
-          color: shadeByDegree(colorFor(n.community), norm),
-          community: n.community ?? null,
-          communityLabel: clusterLabel(n.community),
-          x: pos.x, y: pos.y,
-        });
-      }
-      let edgesDrawn = 0;
-      for (const e of edges) {
-        const s = e.source, t = e.target;
-        if (!g.hasNode(s) || !g.hasNode(t) || s === t) continue;
-        // Edge color = source node's COMMUNITY hue at low alpha, not the
-        // degree-shaded node color. A dim leaf connected to a bright hub
-        // should still contribute a visible community-colored thread —
-        // inheriting the shaded color made leaf-anchored edges fade to
-        // invisible, which killed the webby between-community feel.
-        const srcComm = g.getNodeAttribute(s, "community");
-        try {
-          g.addEdge(s, t, {
-            size: 0.25,
-            color: withAlpha(colorFor(srcComm), 0.3),
+      // Stream node insertion in ~2k batches, yielding to the browser
+      // between batches. graphology's addNode runs ~5-10K/sec; processing
+      // 50K nodes in one synchronous loop locks the tab for several
+      // seconds. Batched + RAF gives the user a live progress count and
+      // keeps input responsive.
+      const NODE_BATCH = 2000;
+      for (let i = 0; i < nodes.length; ) {
+        const end = Math.min(i + NODE_BATCH, nodes.length);
+        for (; i < end; i++) {
+          const n = nodes[i];
+          if (g.hasNode(n.id)) continue;
+          const pos = seedPosition();
+          const k = commKey(n);
+          const v = Math.log(1 + (visDeg.get(n.id) || 0));
+          const range = (commHi.get(k) - commLo.get(k)) || 1;
+          const norm = (v - commLo.get(k)) / range;
+          g.addNode(n.id, {
+            label: n.label || n.id,
+            // Near-uniform size (2.5-3.3). Degree expressed through
+            // brightness, not radius — large degree→size mappings turn
+            // hubs into canvas-dominating blobs.
+            size: 2.5 + 0.8 * norm,
+            color: shadeByDegree(colorFor(n.community), norm),
+            community: n.community ?? null,
+            communityLabel: clusterLabel(n.community),
+            x: pos.x, y: pos.y,
           });
-          edgesDrawn++;
-        } catch (_) {}
+        }
+        statusEl.textContent =
+          `Loading nodes ${i.toLocaleString()} / ${nodes.length.toLocaleString()}...`;
+        await yieldToBrowser();
       }
-      // ForceAtlas2 — tune to match graphify's vis.js Barnes-Hut
-      // output (single organic hairball with visible community
-      // structure). vis.js config we're mimicking:
-      //   gravitationalConstant -60, springLength 120, springConstant
-      //   0.08, damping 0.4.
-      // FA2 equivalents: gravity 1.2 (pulls components together like
-      // vis.js's -60 G-constant does), scalingRatio 2 (moderate
-      // repulsion), adjustSizes FALSE (true creates starburst spokes
-      // around large-degree hubs — the thing we're fighting), and
-      // barnesHut for speed over ~2k nodes.
-      statusEl.textContent = `Laying out ${nodes.length.toLocaleString()} nodes `
-        + `(ForceAtlas2)...`;
+      // Stream edge insertion — addEdge is cheaper than addNode so the
+      // batch is larger, but the principle is the same: never block the
+      // main thread for more than a frame.
+      let edgesDrawn = 0;
+      const EDGE_BATCH = 5000;
+      for (let i = 0; i < edges.length; ) {
+        const end = Math.min(i + EDGE_BATCH, edges.length);
+        for (; i < end; i++) {
+          const e = edges[i];
+          const s = e.source, t = e.target;
+          if (!g.hasNode(s) || !g.hasNode(t) || s === t) continue;
+          // Edge color = source node's COMMUNITY hue at low alpha, not the
+          // degree-shaded node color. A dim leaf connected to a bright hub
+          // should still contribute a visible community-colored thread —
+          // inheriting the shaded color made leaf-anchored edges fade to
+          // invisible, which killed the webby between-community feel.
+          const srcComm = g.getNodeAttribute(s, "community");
+          try {
+            g.addEdge(s, t, {
+              size: 0.25,
+              color: withAlpha(colorFor(srcComm), 0.3),
+            });
+            edgesDrawn++;
+          } catch (_) {}
+        }
+        statusEl.textContent =
+          `Loading edges ${i.toLocaleString()} / ${edges.length.toLocaleString()}...`;
+        await yieldToBrowser();
+      }
+      // ----- ForceAtlas2 in a Web Worker (fully invisible) ----------
+      // FA2 is mathematically chaotic during early iterations — watching
+      // it live looks like a spazz attack and even post-warmup the per-
+      // iteration jitter doesn't read as "smooth". The fix: compute the
+      // layout fully off-screen (worker keeps the main thread responsive),
+      // capture the converged positions, then play back a clean cluster-
+      // by-cluster reveal animation that doesn't depend on FA2's frame
+      // timing at all.
       const settings = forceAtlas2.inferSettings(g);
       settings.barnesHutOptimize = g.order > 2000;
       settings.barnesHutTheta = 0.5;
@@ -272,182 +299,274 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
       settings.slowDown = 1;
       settings.adjustSizes = false;
       settings.outboundAttractionDistribution = false;
-      const iters = g.order > 20000 ? 300 : g.order > 5000 ? 600 : 800;
+      const computeMs = g.order > 20000 ? 5000 : g.order > 5000 ? 4000 : 3000;
+      const layout = new FA2Layout(g, { settings });
       const t0 = performance.now();
-      // Yield to the browser once so the "Laying out..." status can paint
-      // before the synchronous FA2 pass blocks the main thread.
-      setTimeout(() => {
-        forceAtlas2.assign(g, { iterations: iters, settings });
-        const dt = ((performance.now() - t0) / 1000).toFixed(1);
-        // Click-to-focus state: when a node is focused, the node
-        // reducer dims anything that isn't the node or a neighbor, and
-        // the edge reducer dims any edge not incident to it. Using
-        // reducers instead of mutating the graph keeps the state
-        // toggleable with one click-stage.
-        let focusedNode = null;
-        let neighborSet = new Set();
+      layout.start();
 
-        // Hover state: the hovered node grows 30% and its immediate
-        // graph-space neighborhood is pushed radially outward to
-        // "make space" visually. Push applied inside the node reducer
-        // on each frame, so no mutation and no animation loop needed —
-        // it just snaps on enter/leave which looks clean at this density.
-        let hoveredNode = null;
-        let hoveredX = 0, hoveredY = 0;
-        const HOVER_PUSH_RADIUS = 8;    // graph units
-        const HOVER_PUSH_MAX = 3.5;     // graph units
-        const HOVER_SIZE_MULT = 1.3;
+      // Click the (still-empty) canvas to skip straight to the result.
+      let skipped = false;
+      const graphEl = document.getElementById("graph");
+      graphEl.style.cursor = "wait";
+      const skipHandler = () => { skipped = true; };
+      graphEl.addEventListener("click", skipHandler, { once: true });
+      statusEl.textContent =
+        `Computing layout (${(computeMs / 1000).toFixed(1)}s)...`;
+      const cStart = performance.now();
+      while (performance.now() - cStart < computeMs && !skipped) {
+        await new Promise(r => setTimeout(r, 50));
+      }
+      graphEl.removeEventListener("click", skipHandler);
+      graphEl.style.cursor = "";
+      layout.stop();
+      layout.kill();
 
-        const renderer = new Sigma(g, document.getElementById("graph"), {
-          labelDensity: 0.15, labelGridCellSize: 80, minCameraRatio: 0.05,
-          maxCameraRatio: 10, defaultNodeColor: "#6b7280",
-          defaultEdgeColor: "rgba(107,114,128,0.3)",
-          renderEdgeLabels: false,
-          enableEdgeEvents: false,
-          nodeReducer: (node, data) => {
-            let out = data;
-            // Focus dimming (click) layers first.
-            if (focusedNode) {
-              if (node === focusedNode || neighborSet.has(node)) {
-                out = { ...out, zIndex: 1 };
-              } else {
-                out = { ...out, color: "#2a2a3e", label: "", zIndex: 0 };
-              }
+      // Snapshot the final per-node sizes, then hide everything and zero
+      // out sizes so Sigma's first paint shows nothing. The reveal
+      // animation below will pop each cluster in. Edges auto-hide when
+      // either endpoint is hidden (Sigma default), so they appear as
+      // their endpoints become visible — no separate edge animation.
+      const finalSize = new Map();
+      g.updateEachNodeAttributes((id, attrs) => {
+        finalSize.set(id, attrs.size);
+        return { ...attrs, hidden: true, size: 0 };
+      });
+
+      // ----- Sigma renderer (mounted now, on settled positions) -----
+      // Click-to-focus state: when a node is focused, the node reducer
+      // dims anything that isn't the node or a neighbor, and the edge
+      // reducer dims any edge not incident to it. Using reducers keeps
+      // focus toggleable with one click-stage.
+      let focusedNode = null;
+      let neighborSet = new Set();
+      // Hover state: the hovered node grows 30% and its immediate
+      // graph-space neighborhood is pushed radially outward to "make
+      // space" visually. Push applied inside the node reducer on each
+      // frame — no mutation, no animation loop, just a snap on
+      // enter/leave that looks clean at this density.
+      let hoveredNode = null;
+      let hoveredX = 0, hoveredY = 0;
+      const HOVER_PUSH_RADIUS = 8;    // graph units
+      const HOVER_PUSH_MAX = 3.5;     // graph units
+      const HOVER_SIZE_MULT = 1.3;
+
+      // layoutElapsed is filled in after the visible phase finishes; the
+      // closure picks up whatever value it holds when baseStatus() is
+      // called, so click handlers reading the status get the right text.
+      let layoutElapsed = "...";
+      const baseStatus = () =>
+        `${nodes.length.toLocaleString()} nodes · `
+        + `${edgesDrawn.toLocaleString()} edges`
+        + (dropped ? ` · ${dropped.toLocaleString()} rationale hidden` : "")
+        + ` · FA2 ${layoutElapsed}s`;
+
+      const renderer = new Sigma(g, document.getElementById("graph"), {
+        labelDensity: 0.15, labelGridCellSize: 80, minCameraRatio: 0.05,
+        maxCameraRatio: 10, defaultNodeColor: "#6b7280",
+        defaultEdgeColor: "rgba(107,114,128,0.3)",
+        renderEdgeLabels: false,
+        enableEdgeEvents: false,
+        nodeReducer: (node, data) => {
+          let out = data;
+          // Focus dimming (click) layers first.
+          if (focusedNode) {
+            if (node === focusedNode || neighborSet.has(node)) {
+              out = { ...out, zIndex: 1 };
+            } else {
+              out = { ...out, color: "#2a2a3e", label: "", zIndex: 0 };
             }
-            // Hover effects: grow hovered, push nearby away.
-            if (hoveredNode) {
-              if (node === hoveredNode) {
+          }
+          // Hover effects: grow hovered, push nearby away.
+          if (hoveredNode) {
+            if (node === hoveredNode) {
+              out = {
+                ...out,
+                size: (out.size || data.size) * HOVER_SIZE_MULT,
+                forceLabel: true,
+                zIndex: 3,
+              };
+            } else {
+              const dx = (data.x || 0) - hoveredX;
+              const dy = (data.y || 0) - hoveredY;
+              const d = Math.sqrt(dx * dx + dy * dy);
+              if (d > 0 && d < HOVER_PUSH_RADIUS) {
+                const t = 1 - (d / HOVER_PUSH_RADIUS);
+                const push = HOVER_PUSH_MAX * t * t;
                 out = {
                   ...out,
-                  size: (out.size || data.size) * HOVER_SIZE_MULT,
-                  forceLabel: true,
-                  zIndex: 3,
+                  x: data.x + (dx / d) * push,
+                  y: data.y + (dy / d) * push,
                 };
-              } else {
-                const dx = (data.x || 0) - hoveredX;
-                const dy = (data.y || 0) - hoveredY;
-                const d = Math.sqrt(dx * dx + dy * dy);
-                if (d > 0 && d < HOVER_PUSH_RADIUS) {
-                  const t = 1 - (d / HOVER_PUSH_RADIUS);
-                  const push = HOVER_PUSH_MAX * t * t;
-                  out = {
-                    ...out,
-                    x: data.x + (dx / d) * push,
-                    y: data.y + (dy / d) * push,
-                  };
-                }
               }
             }
-            return out;
-          },
-          edgeReducer: (edge, data) => {
-            if (!focusedNode) return data;
-            const ext = g.extremities(edge);
-            if (ext[0] === focusedNode || ext[1] === focusedNode) {
-              return { ...data, size: 0.8, zIndex: 1 };
+          }
+          return out;
+        },
+        edgeReducer: (edge, data) => {
+          if (!focusedNode) return data;
+          const ext = g.extremities(edge);
+          if (ext[0] === focusedNode || ext[1] === focusedNode) {
+            return { ...data, size: 0.8, zIndex: 1 };
+          }
+          return { ...data, color: "rgba(40,40,60,0.2)", zIndex: 0 };
+        },
+      });
+
+      // Hover enter/leave: cache the hovered node's graph-space
+      // position once so the reducer doesn't re-query per-node.
+      renderer.on("enterNode", ({ node }) => {
+        hoveredNode = node;
+        hoveredX = g.getNodeAttribute(node, "x");
+        hoveredY = g.getNodeAttribute(node, "y");
+        document.body.style.cursor = "pointer";
+        renderer.refresh();
+      });
+      renderer.on("leaveNode", () => {
+        hoveredNode = null;
+        document.body.style.cursor = "";
+        renderer.refresh();
+      });
+      renderer.on("clickNode", ({ node }) => {
+        focusedNode = node;
+        neighborSet = new Set(g.neighbors(node));
+        const attrs = g.getNodeAttributes(node);
+        statusEl.textContent = `${attrs.label} `
+          + `(cluster: ${attrs.communityLabel || "unlabeled cluster"}, `
+          + `degree ${g.degree(node)}) — `
+          + `click empty space to clear focus`;
+        renderer.refresh();
+      });
+      // Click on the stage (empty space) clears focus highlighting.
+      renderer.on("clickStage", () => {
+        if (!focusedNode) return;
+        focusedNode = null;
+        neighborSet = new Set();
+        statusEl.textContent = baseStatus();
+        renderer.refresh();
+      });
+
+      // --- Legend / communities sidebar ---------------------------
+      // Rank communities by actual node count in the rendered graph
+      // (post-rationale-filter) instead of raw DB counts, so the
+      // numbers match what's on screen. Fall back to id if no label.
+      const counts = new Map();
+      g.forEachNode((_n, attrs) => {
+        const c = attrs.community;
+        if (c === null || c === undefined) return;
+        counts.set(c, (counts.get(c) || 0) + 1);
+      });
+      const ranked = [...counts.entries()]
+        .map(([cid, n]) => ({
+          cid, n,
+          label: clusterLabel(cid),
+          color: colorFor(cid),
+        }))
+        .sort((a, b) => b.n - a.n);
+
+      const hidden = new Set();
+      const listEl = document.getElementById("legend-list");
+      listEl.innerHTML = "";
+      for (const c of ranked) {
+        const item = document.createElement("div");
+        item.className = "legend-item";
+        item.innerHTML =
+          `<div class="legend-dot" style="background:${c.color}"></div>`
+          + `<span class="legend-label" title="${c.label.replace(/"/g,'&quot;')}">`
+          + `${c.label}</span>`
+          + `<span class="legend-count">${c.n}</span>`;
+        item.addEventListener("click", () => {
+          if (hidden.has(c.cid)) {
+            hidden.delete(c.cid);
+            item.classList.remove("dimmed");
+          } else {
+            hidden.add(c.cid);
+            item.classList.add("dimmed");
+          }
+          // Sigma respects the `hidden` node attribute; toggling it
+          // and calling refresh() is the cheapest way to dim a whole
+          // community without touching the layout.
+          g.forEachNode((nid, attrs) => {
+            if (attrs.community === c.cid) {
+              g.setNodeAttribute(nid, "hidden", hidden.has(c.cid));
             }
-            return { ...data, color: "rgba(40,40,60,0.2)", zIndex: 0 };
-          },
-        });
-
-        // Hover enter/leave: cache the hovered node's graph-space
-        // position once so the reducer doesn't re-query per-node.
-        renderer.on("enterNode", ({ node }) => {
-          hoveredNode = node;
-          hoveredX = g.getNodeAttribute(node, "x");
-          hoveredY = g.getNodeAttribute(node, "y");
-          document.body.style.cursor = "pointer";
-          renderer.refresh();
-        });
-        renderer.on("leaveNode", () => {
-          hoveredNode = null;
-          document.body.style.cursor = "";
-          renderer.refresh();
-        });
-        statusEl.textContent = `${nodes.length.toLocaleString()} nodes · `
-          + `${edgesDrawn.toLocaleString()} edges`
-          + (dropped ? ` · ${dropped.toLocaleString()} rationale hidden` : "")
-          + ` · FA2 ${iters}it in ${dt}s`;
-        renderer.on("clickNode", ({ node }) => {
-          focusedNode = node;
-          neighborSet = new Set(g.neighbors(node));
-          const attrs = g.getNodeAttributes(node);
-          statusEl.textContent = `${attrs.label} `
-            + `(cluster: ${attrs.communityLabel || "unlabeled cluster"}, `
-            + `degree ${g.degree(node)}) — `
-            + `click empty space to clear focus`;
-          renderer.refresh();
-        });
-        // Click on the stage (empty space) clears focus highlighting.
-        renderer.on("clickStage", () => {
-          if (!focusedNode) return;
-          focusedNode = null;
-          neighborSet = new Set();
-          statusEl.textContent = `${nodes.length.toLocaleString()} nodes · `
-            + `${edgesDrawn.toLocaleString()} edges`
-            + (dropped ? ` · ${dropped.toLocaleString()} rationale hidden` : "")
-            + ` · FA2 ${iters}it in ${dt}s`;
-          renderer.refresh();
-        });
-
-        // --- Legend / communities sidebar ---------------------------
-        // Rank communities by actual node count in the rendered graph
-        // (post-rationale-filter) instead of raw DB counts, so the
-        // numbers match what's on screen. Fall back to id if no label.
-        const counts = new Map();
-        g.forEachNode((_n, attrs) => {
-          const c = attrs.community;
-          if (c === null || c === undefined) return;
-          counts.set(c, (counts.get(c) || 0) + 1);
-        });
-        const ranked = [...counts.entries()]
-          .map(([cid, n]) => ({
-            cid, n,
-            label: clusterLabel(cid),
-            color: colorFor(cid),
-          }))
-          .sort((a, b) => b.n - a.n);
-
-        const hidden = new Set();
-        const listEl = document.getElementById("legend-list");
-        listEl.innerHTML = "";
-        for (const c of ranked) {
-          const item = document.createElement("div");
-          item.className = "legend-item";
-          item.innerHTML =
-            `<div class="legend-dot" style="background:${c.color}"></div>`
-            + `<span class="legend-label" title="${c.label.replace(/"/g,'&quot;')}">`
-            + `${c.label}</span>`
-            + `<span class="legend-count">${c.n}</span>`;
-          item.addEventListener("click", () => {
-            if (hidden.has(c.cid)) {
-              hidden.delete(c.cid);
-              item.classList.remove("dimmed");
-            } else {
-              hidden.add(c.cid);
-              item.classList.add("dimmed");
-            }
-            // Sigma respects the `hidden` node attribute; toggling it
-            // and calling refresh() is the cheapest way to dim a whole
-            // community without touching the layout.
-            g.forEachNode((nid, attrs) => {
-              if (attrs.community === c.cid) {
-                g.setNodeAttribute(nid, "hidden", hidden.has(c.cid));
-              }
-            });
-            renderer.refresh();
           });
-          listEl.appendChild(item);
-        }
-        document.getElementById("sidebar-stats").textContent =
-          `${ranked.length.toLocaleString()} clusters · `
-          + `${nodes.length.toLocaleString()} nodes · `
-          + `${edgesDrawn.toLocaleString()} edges`;
-      }, 50);
-    })
-    .catch(err => {
-      statusEl.textContent = "Error loading graph: " + err.message;
-    });
+          renderer.refresh();
+        });
+        listEl.appendChild(item);
+      }
+      document.getElementById("sidebar-stats").textContent =
+        `${ranked.length.toLocaleString()} clusters · `
+        + `${nodes.length.toLocaleString()} nodes · `
+        + `${edgesDrawn.toLocaleString()} edges`;
+
+      // ----- Cluster-by-cluster reveal animation --------------------
+      // Group nodes by community, biggest first. Each cluster starts
+      // popping in `staggerMs` after the previous one starts; within a
+      // cluster, every node fades from size=0 to its final size with
+      // ease-out cubic. Pure WebGL render-loop animation — no physics,
+      // no jitter. Skipping during compute jumps straight to final.
+      const byCommunity = new Map();
+      g.forEachNode((id, attrs) => {
+        const k = String(attrs.community ?? "null");
+        if (!byCommunity.has(k)) byCommunity.set(k, []);
+        byCommunity.get(k).push(id);
+      });
+      const orderedComms = [...byCommunity.values()]
+        .sort((a, b) => b.length - a.length);
+
+      // Total reveal budget ~2s; pack stagger into it but cap so single-
+      // cluster graphs still get a visible fade.
+      const revealBudget = 2000;
+      const fadeMs = 500;
+      const staggerMs = orderedComms.length > 1
+        ? Math.max(40, Math.min(180,
+            (revealBudget - fadeMs) / (orderedComms.length - 1)))
+        : 0;
+      const startTime = new Map();
+      orderedComms.forEach((ids, idx) => {
+        const t = idx * staggerMs;
+        for (const id of ids) startTime.set(id, t);
+      });
+      const totalAnimMs = staggerMs * Math.max(0, orderedComms.length - 1)
+        + fadeMs;
+
+      if (!skipped) {
+        statusEl.textContent =
+          `Revealing ${orderedComms.length} clusters...`;
+        await new Promise(resolve => {
+          const aStart = performance.now();
+          const easeOut = t => 1 - Math.pow(1 - t, 3);
+          const step = () => {
+            const elapsed = performance.now() - aStart;
+            g.updateEachNodeAttributes((id, attrs) => {
+              const start = startTime.get(id) || 0;
+              const t = Math.min(1, Math.max(0, (elapsed - start) / fadeMs));
+              if (t <= 0) return attrs; // not yet — leave hidden
+              return {
+                ...attrs,
+                hidden: false,
+                size: finalSize.get(id) * easeOut(t),
+              };
+            });
+            if (elapsed < totalAnimMs) requestAnimationFrame(step);
+            else resolve();
+          };
+          requestAnimationFrame(step);
+        });
+      } else {
+        // Skipped — snap straight to final.
+        g.updateEachNodeAttributes((id, attrs) => ({
+          ...attrs,
+          hidden: false,
+          size: finalSize.get(id),
+        }));
+      }
+      layoutElapsed = ((performance.now() - t0) / 1000).toFixed(1);
+      statusEl.textContent = baseStatus();
+  }
+  loadGraph().catch(err => {
+    statusEl.textContent = "Error loading graph: " + err.message;
+  });
 </script>
 </body>
 </html>"""


### PR DESCRIPTION
## Summary
Customers reported the whole UI locking up for several seconds on graph open. Root cause: `forceAtlas2.assign()` ran synchronously on the main thread for 300–800 iterations on every render.

Three layered fixes in `services/prism-service/app/ui/graph_page.py`:
- **Streamed graph build** — node/edge inserts chunked (2k / 5k per batch) with RAF yields between batches; live progress in the status text.
- **FA2 in a Web Worker** — switched `forceAtlas2.assign` → `FA2Layout` (`graphology-layout-forceatlas2/worker`). Simulation runs off the main thread, page stays responsive.
- **Cluster-by-cluster reveal** — worker computes layout fully invisibly, then we snapshot final sizes, hide everything, mount Sigma, and play back a deterministic reveal: biggest cluster first, ~60ms stagger between clusters, each node ease-out cubic from size 0 → final over 500ms. Edges auto-appear as endpoints unhide. Pure RAF interpolation; zero physics jitter.

Click the empty canvas during compute to skip straight to the result.

## Test plan
- [x] Loaded `http://localhost:7778/graph/viewer/prism` (4.3K nodes / 9.2K edges) — timeline: Fetching → Loading edges → Computing layout (3s) → Revealing 37 clusters → final stats. No \`pageerror\`s.
- [x] Verified no main-thread freeze (status text streams updates throughout).
- [ ] Verify on a >20K node customer graph — budgets scale (5s compute / 2s reveal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)