### PR TITLE
fix(v5.1.9): surface clone failures from ensure_cloned()

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,20 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.1.8"
+PRISM_VERSION = "5.1.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.1.9: Private-repo clone failures now surface as a clean HTTP "
+    "400 from /api/projects and /api/understand/configure instead of "
+    "silently creating an unscannable, head-less project. ensure_cloned() "
+    "checks the return code of `git clone` and `git fetch`, raises "
+    "SourceUnavailable with a credential-scrubbed message (PATs in the "
+    "URL are stripped before the error reaches API responses or logs), "
+    "and wipes the half-initialized source/ dir so a retry with corrected "
+    "credentials starts clean. Customers can pick any credential shape "
+    "they want — PAT-in-URL, SSH deploy key + git@ remote, or a "
+    "credential helper baked into the container. "
     "v5.1.8: Settings is now a sidebar mode, not a page. Clicking "
     "`Settings` in the footer replaces the left sidebar's Knowledge + "
     "Activity groups with the Settings categories (Projects, Claude "

--- a/services/prism-service/app/services/source_service.py
+++ b/services/prism-service/app/services/source_service.py
@@ -15,6 +15,7 @@ issued.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -22,6 +23,34 @@ from pathlib import Path
 from typing import Optional
 
 from app.config import project_data_dir
+
+
+# Strip `user[:password]@` userinfo from any URL we surface in errors so a
+# PAT-in-URL clone failure doesn't leak the token into API responses or logs.
+_URL_USERINFO_RE = re.compile(r"(\b[a-z][a-z0-9+.\-]*://)[^/@\s]+@")
+
+
+def _scrub_credentials(text: str) -> str:
+    return _URL_USERINFO_RE.sub(r"\1", text or "")
+
+
+def _clear_dir(path: Path) -> None:
+    """Remove everything inside `path` but leave `path` itself in place.
+
+    Used to wipe a half-initialized clone so a retry with corrected
+    credentials starts from a clean slate. Never traverses outside `path`.
+    """
+    import shutil
+    if not path.is_dir():
+        return
+    for child in path.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child, ignore_errors=True)
+        else:
+            try:
+                child.unlink()
+            except OSError:
+                pass
 
 
 # Per-project locks so concurrent threads can't race on the same clone.
@@ -107,13 +136,28 @@ def ensure_cloned(
                 )
             prior_sha = _rev_parse(src, tracked_ref) or ""
             if fetch:
-                _run_git(["fetch", "--prune", "origin"], src, timeout=180)
+                rc, _, err = _run_git(
+                    ["fetch", "--prune", "origin"], src, timeout=180,
+                )
+                if rc != 0:
+                    raise SourceUnavailable(
+                        f"git fetch failed for project {project!r}: "
+                        f"{_scrub_credentials(err.strip()) or f'exit {rc}'}"
+                    )
         else:
             src.mkdir(parents=True, exist_ok=True)
-            _run_git(
+            rc, _, err = _run_git(
                 ["clone", "--filter=blob:none", remote_url, "."],
                 src, timeout=300,
             )
+            if rc != 0:
+                # Leave the half-initialized source dir empty so a retry
+                # with corrected credentials starts from a clean slate.
+                _clear_dir(src)
+                raise SourceUnavailable(
+                    f"git clone failed for project {project!r}: "
+                    f"{_scrub_credentials(err.strip()) or f'exit {rc}'}"
+                )
         _run_git(["reset", "--hard", tracked_ref], src)
         state.head_sha = _rev_parse(src, "HEAD") or ""
         state.advanced = bool(prior_sha) and state.head_sha != prior_sha

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.1.8",
+  "version": "5.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/tests/unit/test_source_service.py
+++ b/services/prism-service/tests/unit/test_source_service.py
@@ -160,6 +160,32 @@ def test_ensure_cloned_raises_without_remote(isolated_projects_root):
         ss.ensure_cloned("proj-a", remote_url="")
 
 
+def test_ensure_cloned_surfaces_clone_failure(isolated_projects_root, tmp_path):
+    """A clone against a nonexistent path must raise, not silently 'succeed'."""
+    nonexistent = tmp_path / "does-not-exist.git"
+    with pytest.raises(ss.SourceUnavailable) as excinfo:
+        ss.ensure_cloned("proj-a", str(nonexistent), "origin/main")
+    assert "clone failed" in str(excinfo.value)
+    # Source dir is left clean for retry: no leftover .git from the
+    # half-initialized clone.
+    assert not (ss.source_dir_for("proj-a") / ".git").exists()
+
+
+def test_ensure_cloned_scrubs_credentials_from_errors(
+    isolated_projects_root, tmp_path,
+):
+    """A PAT embedded in remote_url must not appear in surfaced errors."""
+    pat = "ghp_secrettoken1234567890"
+    bad_url = (
+        f"https://x-access-token:{pat}@127.0.0.1:1/resolve-io/private.git"
+    )
+    with pytest.raises(ss.SourceUnavailable) as excinfo:
+        ss.ensure_cloned("proj-a", bad_url, "origin/main")
+    msg = str(excinfo.value)
+    assert pat not in msg
+    assert "x-access-token" not in msg
+
+
 def test_threaded_ensure_cloned_does_not_corrupt(fake_remote, isolated_projects_root):
     """Two threads racing ensure_cloned must converge on one healthy clone."""
     errors: list[Exception] = []


### PR DESCRIPTION
## Summary

- `ensure_cloned()` no longer silently swallows `git clone` / `git fetch` failures. It checks the return code, raises `SourceUnavailable`, and the existing `/api/projects` + `/api/understand/configure` handlers convert that into a clean `400 clone failed: …` instead of a 200 OK that creates an unscannable, head-less project.
- On clone failure, the half-initialized `source/` is wiped so a retry with corrected credentials starts from a clean slate.
- Error messages are scrubbed through `_scrub_credentials()` so a PAT-in-URL clone failure can't leak the token into API responses, logs, or task records. Customers can still pick whichever credential shape they want — PAT-in-URL, SSH deploy key + `git@` remote, or a credential helper baked into the container.

## Repro of the original bug

Configure PRISM to track a private repo with no credentials in the container:

```bash
curl -X POST http://localhost:7778/api/projects \
  -H 'content-type: application/json' \
  -d '{"name":"resolve-platform","remote_url":"https://github.com/resolve-io/resolve-platform.git"}'
```

Before: `200 OK`, `head_sha: ""`, refresh quietly bails with `status=\"no_source\"`.
After: `400 Bad Request — git clone failed for project 'resolve-platform': fatal: could not read Username for 'https://github.com': No such device or address`.

## Test plan

- [x] `pytest tests/unit/test_source_service.py` — 11/11 pass (2 new: clone-failure surfacing, PAT scrubbing)
- [x] `pytest tests/unit/test_source_service_bootstrap.py` — 3/3 pass
- [x] `pytest tests/unit -k "projects or understand"` — 62/62 pass
- [ ] Smoke: POST `/api/projects` against `https://github.com/resolve-io/resolve-platform.git` from the container — expect `400`
- [ ] Smoke: same POST with a working PAT-in-URL — expect `200` + non-empty `head_sha`

🤖 Generated with [Claude Code](https://claude.com/claude-code)