### PR TITLE
feat(v5.1.10): GitHub connection lives next to Claude auth

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,22 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.1.9"
+PRISM_VERSION = "5.1.10"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.1.10: GitHub connection lives next to Claude auth in the new "
+    "`Connections` sidebar section (renamed from `Claude auth`). Paste "
+    "a Personal Access Token, click `Connect`, and PRISM stores it at "
+    "`/data/.git-credentials` (volume-backed, chmod 600). Every `git "
+    "clone` and `git fetch` PRISM runs picks the token up automatically "
+    "via `git -c credential.helper=…`, so the next time you point a "
+    "project at a private GitHub repo the clone Just Works. The token "
+    "never appears in `understand_state.json`, in logs, or in API "
+    "responses — only a `user:•••last4` fingerprint is shown back. "
+    "Service tab gained a `GitHub` status row alongside `Claude auth`. "
+    "Legacy `/settings/auth` redirects to the new `/settings/connections` "
+    "URL so any bookmarks keep working. "
     "v5.1.9: Private-repo clone failures now surface as a clean HTTP "
     "400 from /api/projects and /api/understand/configure instead of "
     "silently creating an unscannable, head-less project. ensure_cloned() "

--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,20 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.1.8"
+PRISM_VERSION = "5.1.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.1.9: Private-repo clone failures now surface as a clean HTTP "
+    "400 from /api/projects and /api/understand/configure instead of "
+    "silently creating an unscannable, head-less project. ensure_cloned() "
+    "checks the return code of `git clone` and `git fetch`, raises "
+    "SourceUnavailable with a credential-scrubbed message (PATs in the "
+    "URL are stripped before the error reaches API responses or logs), "
+    "and wipes the half-initialized source/ dir so a retry with corrected "
+    "credentials starts clean. Customers can pick any credential shape "
+    "they want — PAT-in-URL, SSH deploy key + git@ remote, or a "
+    "credential helper baked into the container. "
     "v5.1.8: Settings is now a sidebar mode, not a page. Clicking "
     "`Settings` in the footer replaces the left sidebar's Knowledge + "
     "Activity groups with the Settings categories (Projects, Claude "

--- a/services/prism-service/app/api/__init__.py
+++ b/services/prism-service/app/api/__init__.py
@@ -16,6 +16,7 @@ from app.api.claude_runs import router as claude_runs_router
 from app.api.consolidation import router as consolidation_router
 from app.api.conductor import router as conductor_router
 from app.api.dashboard import router as dashboard_router
+from app.api.github_auth import router as github_auth_router
 from app.api.graph import router as graph_router
 from app.api.jobs import router as jobs_router
 from app.api.learning import router as learning_router
@@ -36,6 +37,7 @@ api_router.include_router(claude_runs_router, prefix="/claude-runs", tags=["clau
 api_router.include_router(consolidation_router, prefix="/consolidation", tags=["consolidation"])
 api_router.include_router(conductor_router, prefix="/conductor", tags=["conductor"])
 api_router.include_router(dashboard_router, prefix="/dashboard", tags=["dashboard"])
+api_router.include_router(github_auth_router, prefix="/github-auth", tags=["github-auth"])
 api_router.include_router(graph_router, prefix="/graph", tags=["graph"])
 api_router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 api_router.include_router(learning_router, prefix="/learning", tags=["learning"])

--- a/services/prism-service/app/api/github_auth.py
+++ b/services/prism-service/app/api/github_auth.py
@@ -1,0 +1,57 @@
+"""/api/github-auth — manage the GitHub credentials PRISM uses for clones.
+
+Mirrors /api/claude-auth in shape: a status endpoint the SPA polls, plus
+configure/clear write endpoints driven from the Connections panel. The
+token itself is never echoed back — only a fingerprint (user + last-4
+of the token) is exposed.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from app.services import github_auth as gh
+
+router = APIRouter()
+
+
+class ConfigureBody(BaseModel):
+    token: str
+    user: str = "x-access-token"
+
+
+def _status_payload() -> dict:
+    authed = gh.is_authenticated()
+    return {
+        "authenticated": authed,
+        "credentials_path": str(gh.credentials_path()),
+        "fingerprint": gh.token_fingerprint() if authed else "",
+        "instructions": (
+            "Create a fine-grained Personal Access Token at "
+            "https://github.com/settings/tokens with `Contents: read` "
+            "for the repos PRISM should clone. Paste it below — it's "
+            "stored only in the data volume (chmod 600) and never "
+            "echoed back."
+        ),
+    }
+
+
+@router.get("/status")
+def status() -> dict:
+    return _status_payload()
+
+
+@router.post("/configure")
+def configure(body: ConfigureBody) -> dict:
+    try:
+        gh.set_token(body.token, user=body.user or "x-access-token")
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return _status_payload()
+
+
+@router.post("/clear")
+def clear() -> dict:
+    gh.clear_token()
+    return _status_payload()

--- a/services/prism-service/app/api/service_info.py
+++ b/services/prism-service/app/api/service_info.py
@@ -19,6 +19,7 @@ from app.config import (
     GOVERNANCE_INTERVAL_SECONDS,
     QUALITY_INTERVAL_SECONDS,
 )
+from app.services import github_auth as gh
 
 router = APIRouter()
 
@@ -51,6 +52,8 @@ def service_info() -> dict:
         "container": _container_name(),
         "claude_config_dir": str(cfg),
         "claude_authenticated": (cfg / ".credentials.json").is_file(),
+        "github_authenticated": gh.is_authenticated(),
+        "github_credentials_path": str(gh.credentials_path()),
         "understand_drain_interval_s": _drain_interval(),
         "drift_interval_s": DRIFT_INTERVAL_SECONDS,
         "governance_interval_s": GOVERNANCE_INTERVAL_SECONDS,

--- a/services/prism-service/app/services/github_auth.py
+++ b/services/prism-service/app/services/github_auth.py
@@ -1,0 +1,124 @@
+"""GitHub credentials management for PRISM's git operations.
+
+Customers configure a Personal Access Token (or any github username +
+token pair) through the SPA Connections panel. We store them in
+`/data/.git-credentials` (volume-backed, chmod 600, so they survive
+container swaps) and inject git's `store` credential helper into every
+_run_git call when the file exists. The token never lands in
+remote_url, understand_state.json, logs, or API responses — only a
+fingerprint (user + last-4 of the token) is ever returned.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from app.config import DATA_DIR
+
+CREDS_FILENAME = ".git-credentials"
+CREDS_PATH = DATA_DIR / CREDS_FILENAME
+
+# Matches a `https://user:token@github.com` line — we use this both to
+# detect whether a github.com entry is present and to scrub/replace it.
+_GITHUB_LINE_RE = re.compile(r"^https://[^@\s]+@github\.com\b", re.MULTILINE)
+_GITHUB_PARSE_RE = re.compile(r"https://([^:]+):([^@]+)@github\.com")
+
+
+def credentials_path() -> Path:
+    return CREDS_PATH
+
+
+def is_authenticated() -> bool:
+    if not CREDS_PATH.is_file():
+        return False
+    try:
+        body = CREDS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return bool(_GITHUB_LINE_RE.search(body))
+
+
+def token_fingerprint() -> str:
+    """Return a UI-safe identifier — never the token itself.
+
+    Format: `<user>:•••<last4>` so the operator can recognize which
+    token is in use without it leaking through the API surface.
+    """
+    if not CREDS_PATH.is_file():
+        return ""
+    try:
+        body = CREDS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    m = _GITHUB_PARSE_RE.search(body)
+    if not m:
+        return ""
+    user, token = m.group(1), m.group(2)
+    tail = token[-4:] if len(token) >= 4 else token
+    return f"{user}:•••{tail}"
+
+
+def set_token(token: str, user: str = "x-access-token") -> None:
+    """Atomically write a github.com credential line, preserving other hosts."""
+    token = (token or "").strip()
+    user = (user or "x-access-token").strip() or "x-access-token"
+    if not token:
+        raise ValueError("token is required")
+    CREDS_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = ""
+    if CREDS_PATH.is_file():
+        try:
+            existing = CREDS_PATH.read_text(encoding="utf-8")
+        except OSError:
+            existing = ""
+    kept = [
+        ln for ln in existing.splitlines()
+        if ln.strip() and not _GITHUB_LINE_RE.match(ln)
+    ]
+    kept.append(f"https://{user}:{token}@github.com")
+    body = "\n".join(kept) + "\n"
+
+    tmp = CREDS_PATH.with_suffix(CREDS_PATH.suffix + ".tmp")
+    tmp.write_text(body, encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        # Best-effort: Windows / restricted filesystems may not support chmod.
+        pass
+    os.replace(tmp, CREDS_PATH)
+
+
+def clear_token() -> bool:
+    """Remove the github.com line. Returns True if a line was removed."""
+    if not CREDS_PATH.is_file():
+        return False
+    try:
+        body = CREDS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    lines = body.splitlines()
+    kept = [ln for ln in lines if not _GITHUB_LINE_RE.match(ln)]
+    if len(kept) == len(lines):
+        return False
+    if any(ln.strip() for ln in kept):
+        CREDS_PATH.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    else:
+        try:
+            CREDS_PATH.unlink()
+        except OSError:
+            pass
+    return True
+
+
+def git_credential_helper_args() -> list[str]:
+    """Return `-c credential.helper=…` args to inject into every git call.
+
+    Empty list when no creds file exists, so the no-auth path stays
+    untouched (and existing tests against local bare repos keep passing).
+    """
+    if not CREDS_PATH.is_file():
+        return []
+    return ["-c", f"credential.helper=store --file={CREDS_PATH}"]

--- a/services/prism-service/app/services/source_service.py
+++ b/services/prism-service/app/services/source_service.py
@@ -84,9 +84,17 @@ class SourceUnavailable(RuntimeError):
 
 
 def _run_git(args: list[str], cwd: Path, timeout: int = 60) -> tuple[int, str, str]:
-    """Run git with explicit cwd, no shell. Returns (rc, stdout, stderr)."""
+    """Run git with explicit cwd, no shell. Returns (rc, stdout, stderr).
+
+    Injects the github credential helper from app.services.github_auth
+    when a `/data/.git-credentials` file exists, so private-repo clones
+    Just Work after the operator pastes a PAT into the Connections
+    panel. Imported lazily to avoid a circular import on module load.
+    """
+    from app.services import github_auth
+    pre = github_auth.git_credential_helper_args()
     proc = subprocess.run(
-        ["git", *args],
+        ["git", *pre, *args],
         cwd=str(cwd),
         capture_output=True, text=True, timeout=timeout,
     )

--- a/services/prism-service/app/services/source_service.py
+++ b/services/prism-service/app/services/source_service.py
@@ -15,6 +15,7 @@ issued.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -22,6 +23,34 @@ from pathlib import Path
 from typing import Optional
 
 from app.config import project_data_dir
+
+
+# Strip `user[:password]@` userinfo from any URL we surface in errors so a
+# PAT-in-URL clone failure doesn't leak the token into API responses or logs.
+_URL_USERINFO_RE = re.compile(r"(\b[a-z][a-z0-9+.\-]*://)[^/@\s]+@")
+
+
+def _scrub_credentials(text: str) -> str:
+    return _URL_USERINFO_RE.sub(r"\1", text or "")
+
+
+def _clear_dir(path: Path) -> None:
+    """Remove everything inside `path` but leave `path` itself in place.
+
+    Used to wipe a half-initialized clone so a retry with corrected
+    credentials starts from a clean slate. Never traverses outside `path`.
+    """
+    import shutil
+    if not path.is_dir():
+        return
+    for child in path.iterdir():
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child, ignore_errors=True)
+        else:
+            try:
+                child.unlink()
+            except OSError:
+                pass
 
 
 # Per-project locks so concurrent threads can't race on the same clone.
@@ -107,13 +136,28 @@ def ensure_cloned(
                 )
             prior_sha = _rev_parse(src, tracked_ref) or ""
             if fetch:
-                _run_git(["fetch", "--prune", "origin"], src, timeout=180)
+                rc, _, err = _run_git(
+                    ["fetch", "--prune", "origin"], src, timeout=180,
+                )
+                if rc != 0:
+                    raise SourceUnavailable(
+                        f"git fetch failed for project {project!r}: "
+                        f"{_scrub_credentials(err.strip()) or f'exit {rc}'}"
+                    )
         else:
             src.mkdir(parents=True, exist_ok=True)
-            _run_git(
+            rc, _, err = _run_git(
                 ["clone", "--filter=blob:none", remote_url, "."],
                 src, timeout=300,
             )
+            if rc != 0:
+                # Leave the half-initialized source dir empty so a retry
+                # with corrected credentials starts from a clean slate.
+                _clear_dir(src)
+                raise SourceUnavailable(
+                    f"git clone failed for project {project!r}: "
+                    f"{_scrub_credentials(err.strip()) or f'exit {rc}'}"
+                )
         _run_git(["reset", "--hard", tracked_ref], src)
         state.head_sha = _rev_parse(src, "HEAD") or ""
         state.advanced = bool(prior_sha) and state.head_sha != prior_sha

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.1.9",
+  "version": "5.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.1.8",
+  "version": "5.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/src/components/Sidebar.tsx
+++ b/services/prism-service/app/web/src/components/Sidebar.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
-  AppWindow, BookOpen, Brain, Eye, FolderTree, Info, KeyRound,
-  Layers, LayoutDashboard, ListChecks, MessageSquare, Network,
+  AppWindow, BookOpen, Brain, Eye, FolderTree, Info,
+  Layers, LayoutDashboard, ListChecks, MessageSquare, Network, Plug,
   ScrollText, Search, Settings, Sparkles, Workflow,
   type LucideIcon,
 } from "lucide-react";
@@ -64,7 +64,7 @@ const SETTINGS_SECTIONS: Section[] = [
     label: "Settings",
     items: [
       { to: "/settings/projects", label: "Projects", icon: FolderTree },
-      { to: "/settings/auth", label: "Claude auth", icon: KeyRound },
+      { to: "/settings/connections", label: "Connections", icon: Plug },
       { to: "/settings/jobs", label: "Jobs", icon: ListChecks },
       { to: "/settings/logs", label: "Logs", icon: ScrollText },
       { to: "/settings/service", label: "Service", icon: Info },

--- a/services/prism-service/app/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/app/web/src/pages/SettingsPage.tsx
@@ -8,16 +8,16 @@ import { api } from "@/lib/api";
 import { notifyProjectsChanged, useProject } from "@/lib/project";
 import { Card, Empty, ErrorBanner, Page, SectionLabel } from "@/components/ui";
 
-type SectionId = "projects" | "auth" | "jobs" | "logs" | "service";
+type SectionId = "projects" | "connections" | "jobs" | "logs" | "service";
 
 const SECTION_META: Record<SectionId, { title: string; description: string }> = {
   projects: {
     title: "Projects",
     description: "Add, configure, sync, and delete tracked repos.",
   },
-  auth: {
-    title: "Claude auth",
-    description: "OAuth subscription used by the in-container CLI.",
+  connections: {
+    title: "Connections",
+    description: "Claude OAuth subscription and GitHub access for private-repo clones.",
   },
   jobs: {
     title: "Jobs",
@@ -33,9 +33,12 @@ const SECTION_META: Record<SectionId, { title: string; description: string }> = 
   },
 };
 
-const KNOWN_SECTIONS: SectionId[] = ["projects", "auth", "jobs", "logs", "service"];
+const KNOWN_SECTIONS: SectionId[] = ["projects", "connections", "jobs", "logs", "service"];
 
 function resolveSection(raw: string | undefined): SectionId {
+  // `/settings/auth` is the legacy v5.1.8 URL for what's now Connections.
+  // Keep it working so bookmarked links don't 404.
+  if (raw === "auth") return "connections";
   return (raw && (KNOWN_SECTIONS as string[]).includes(raw)) ? (raw as SectionId) : "projects";
 }
 
@@ -179,11 +182,17 @@ export default function SettingsPage() {
         </Card>
       )}
 
-      {section === "auth" && (
-        <Card>
-          <SectionLabel>Claude authentication</SectionLabel>
-          <ClaudeAuthCard />
-        </Card>
+      {section === "connections" && (
+        <div className="space-y-6">
+          <Card>
+            <SectionLabel>Claude</SectionLabel>
+            <ClaudeAuthCard />
+          </Card>
+          <Card>
+            <SectionLabel>GitHub</SectionLabel>
+            <GithubAuthCard />
+          </Card>
+        </div>
       )}
 
       {section === "jobs" && (
@@ -299,6 +308,160 @@ function ClaudeAuthCard() {
         soon as the OAuth flow completes.
       </p>
     </div>
+  );
+}
+
+
+type GithubAuthStatus = {
+  authenticated: boolean;
+  credentials_path: string;
+  fingerprint: string;
+  instructions: string;
+};
+
+function GithubAuthCard() {
+  const [status, setStatus] = useState<GithubAuthStatus | null>(null);
+  const [token, setToken] = useState("");
+  const [user, setUser] = useState("x-access-token");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    api.get<GithubAuthStatus>("/api/github-auth/status")
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const connect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const next = await api.post<GithubAuthStatus>("/api/github-auth/configure", {
+        token: token.trim(),
+        user: user.trim() || "x-access-token",
+      });
+      setStatus(next);
+      setToken("");
+    } catch (e) {
+      setError(String((e as Error).message ?? e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const disconnect = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const next = await api.post<GithubAuthStatus>("/api/github-auth/clear", {});
+      setStatus(next);
+    } catch (e) {
+      setError(String((e as Error).message ?? e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!status) {
+    return <div className="text-sm opacity-60">Loading…</div>;
+  }
+
+  if (status.authenticated) {
+    return (
+      <div className="space-y-3">
+        <div className="inline-flex items-center gap-2 text-sm">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-200 text-[9px] uppercase tracking-wider">
+            connected
+          </span>
+          <span className="opacity-70">
+            PRISM can clone private GitHub repos for any project.
+          </span>
+        </div>
+        {status.fingerprint && (
+          <div className="text-[11px] opacity-60 font-mono">
+            using <span className="opacity-90">{status.fingerprint}</span>
+          </div>
+        )}
+        <div className="text-[11px] opacity-50 font-mono">
+          credentials → {status.credentials_path}
+        </div>
+        {error && (
+          <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+            {error}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={disconnect}
+          disabled={submitting}
+          className="inline-flex items-center gap-2 px-3 py-2 rounded-md border border-[color:var(--midground-base)]/30 text-[11px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10 disabled:opacity-40"
+        >
+          {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+          {submitting ? "Disconnecting…" : "Disconnect"}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={connect} className="space-y-3">
+      <div className="inline-flex items-center gap-2 text-sm">
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-200 text-[9px] uppercase tracking-wider">
+          not connected
+        </span>
+        <span className="opacity-70">
+          Paste a Personal Access Token to clone private repos:
+        </span>
+      </div>
+      <div className="grid grid-cols-[1fr_180px] gap-3">
+        <label className="flex flex-col gap-1 min-w-0">
+          <span className="text-[10px] uppercase tracking-wider opacity-60">
+            Token
+          </span>
+          <input
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="ghp_… or github_pat_…"
+            autoComplete="off"
+            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[10px] uppercase tracking-wider opacity-60">
+            User <span className="opacity-50 normal-case">(optional)</span>
+          </span>
+          <input
+            value={user}
+            onChange={(e) => setUser(e.target.value)}
+            placeholder="x-access-token"
+            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+          />
+        </label>
+      </div>
+      {error && (
+        <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+          {error}
+        </div>
+      )}
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="submit"
+          disabled={submitting || !token.trim()}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-30"
+        >
+          {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
+          {submitting ? "Connecting…" : "Connect"}
+        </button>
+      </div>
+      <p className="text-[11px] opacity-60 leading-snug">
+        {status.instructions}
+      </p>
+    </form>
   );
 }
 
@@ -474,6 +637,8 @@ type ServiceInfo = {
   container: string;
   claude_config_dir: string;
   claude_authenticated: boolean;
+  github_authenticated: boolean;
+  github_credentials_path: string;
   understand_drain_interval_s: number;
   drift_interval_s: number;
   governance_interval_s: number;
@@ -509,9 +674,19 @@ function ServiceInfoPanel() {
         <dd className="text-xs">
           {info.claude_authenticated
             ? <span className="text-emerald-200">logged in</span>
-            : <span className="text-amber-200">not logged in — see Claude auth tab</span>}
+            : <span className="text-amber-200">not logged in — see Connections tab</span>}
           <div className="opacity-60 font-mono mt-1">
             config dir → {info.claude_config_dir}
+          </div>
+        </dd>
+
+        <dt className="opacity-60">GitHub</dt>
+        <dd className="text-xs">
+          {info.github_authenticated
+            ? <span className="text-emerald-200">connected</span>
+            : <span className="text-amber-200">not connected — see Connections tab</span>}
+          <div className="opacity-60 font-mono mt-1">
+            credentials → {info.github_credentials_path}
           </div>
         </dd>
 

--- a/services/prism-service/tests/unit/test_github_auth.py
+++ b/services/prism-service/tests/unit/test_github_auth.py
@@ -1,0 +1,115 @@
+"""Unit tests for app.services.github_auth.
+
+Covers: write/read round-trip, atomic replace preserves other-host
+lines, fingerprint never exposes the full token, clear_token removes
+only the github.com line, and git_credential_helper_args() returns an
+empty list when no creds file exists so existing tests against local
+bare repos keep working.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app import config
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path: Path, monkeypatch):
+    """Point app.config.DATA_DIR (and the github_auth CREDS_PATH derived
+    from it) at a tmp dir, then reimport the module so the constant
+    re-resolves. Returns the tmp data dir."""
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    # github_auth captures DATA_DIR at import time, so re-import in
+    # this test process before the test body runs.
+    import importlib
+    from app.services import github_auth as gh_mod
+    importlib.reload(gh_mod)
+    yield tmp_path
+    importlib.reload(gh_mod)  # restore for subsequent test files
+
+
+def test_no_creds_file_means_not_authenticated(isolated_data_dir):
+    from app.services import github_auth as gh
+    assert gh.is_authenticated() is False
+    assert gh.token_fingerprint() == ""
+    assert gh.git_credential_helper_args() == []
+
+
+def test_set_token_round_trip_and_fingerprint(isolated_data_dir):
+    from app.services import github_auth as gh
+    gh.set_token("ghp_supersecret_abcd1234", user="alice")
+    assert gh.is_authenticated() is True
+    fp = gh.token_fingerprint()
+    assert fp.startswith("alice:")
+    assert "•••" in fp
+    assert "1234" in fp  # last 4 visible
+    # Crucially: the body of the fingerprint never contains the full token.
+    assert "supersecret" not in fp
+    assert "abcd" not in fp.replace("1234", "")
+
+
+def test_set_token_strips_default_user(isolated_data_dir):
+    from app.services import github_auth as gh
+    gh.set_token("ghp_x", user="")
+    body = (isolated_data_dir / ".git-credentials").read_text()
+    assert "x-access-token:ghp_x@github.com" in body
+
+
+def test_set_token_replaces_prior_github_line(isolated_data_dir):
+    from app.services import github_auth as gh
+    gh.set_token("ghp_one", user="alice")
+    gh.set_token("ghp_two", user="bob")
+    body = (isolated_data_dir / ".git-credentials").read_text()
+    assert "ghp_one" not in body
+    assert "ghp_two" in body
+    # Exactly one github.com line.
+    assert body.count("@github.com") == 1
+
+
+def test_set_token_preserves_other_host_lines(isolated_data_dir):
+    from app.services import github_auth as gh
+    creds = isolated_data_dir / ".git-credentials"
+    creds.write_text("https://user:tok@gitlab.example.com\n", encoding="utf-8")
+    gh.set_token("ghp_one")
+    body = creds.read_text(encoding="utf-8")
+    assert "gitlab.example.com" in body
+    assert "github.com" in body
+
+
+def test_clear_token_removes_github_line(isolated_data_dir):
+    from app.services import github_auth as gh
+    creds = isolated_data_dir / ".git-credentials"
+    gh.set_token("ghp_one", user="alice")
+    assert gh.clear_token() is True
+    assert gh.is_authenticated() is False
+    # File is removed when no other lines remain.
+    assert not creds.exists()
+
+
+def test_clear_token_keeps_other_hosts(isolated_data_dir):
+    from app.services import github_auth as gh
+    creds = isolated_data_dir / ".git-credentials"
+    creds.write_text("https://user:tok@gitlab.example.com\n", encoding="utf-8")
+    gh.set_token("ghp_one")
+    assert gh.clear_token() is True
+    body = creds.read_text(encoding="utf-8")
+    assert "gitlab" in body
+    assert "github.com" not in body
+
+
+def test_helper_args_when_authenticated(isolated_data_dir):
+    from app.services import github_auth as gh
+    gh.set_token("ghp_one")
+    args = gh.git_credential_helper_args()
+    assert args[0] == "-c"
+    assert args[1].startswith("credential.helper=store --file=")
+    assert str(gh.credentials_path()) in args[1]
+
+
+def test_empty_token_rejected(isolated_data_dir):
+    from app.services import github_auth as gh
+    with pytest.raises(ValueError):
+        gh.set_token("   ")

--- a/services/prism-service/tests/unit/test_source_service.py
+++ b/services/prism-service/tests/unit/test_source_service.py
@@ -160,6 +160,32 @@ def test_ensure_cloned_raises_without_remote(isolated_projects_root):
         ss.ensure_cloned("proj-a", remote_url="")
 
 
+def test_ensure_cloned_surfaces_clone_failure(isolated_projects_root, tmp_path):
+    """A clone against a nonexistent path must raise, not silently 'succeed'."""
+    nonexistent = tmp_path / "does-not-exist.git"
+    with pytest.raises(ss.SourceUnavailable) as excinfo:
+        ss.ensure_cloned("proj-a", str(nonexistent), "origin/main")
+    assert "clone failed" in str(excinfo.value)
+    # Source dir is left clean for retry: no leftover .git from the
+    # half-initialized clone.
+    assert not (ss.source_dir_for("proj-a") / ".git").exists()
+
+
+def test_ensure_cloned_scrubs_credentials_from_errors(
+    isolated_projects_root, tmp_path,
+):
+    """A PAT embedded in remote_url must not appear in surfaced errors."""
+    pat = "ghp_secrettoken1234567890"
+    bad_url = (
+        f"https://x-access-token:{pat}@127.0.0.1:1/resolve-io/private.git"
+    )
+    with pytest.raises(ss.SourceUnavailable) as excinfo:
+        ss.ensure_cloned("proj-a", bad_url, "origin/main")
+    msg = str(excinfo.value)
+    assert pat not in msg
+    assert "x-access-token" not in msg
+
+
 def test_threaded_ensure_cloned_does_not_corrupt(fake_remote, isolated_projects_root):
     """Two threads racing ensure_cloned must converge on one healthy clone."""
     errors: list[Exception] = []


### PR DESCRIPTION
## Summary

- New `Connections` sidebar section replaces `Claude auth` — same place, more credentials. Inside it: the existing Claude OAuth card, plus a new GitHub card.
- GitHub card: paste a PAT, click `Connect`. PRISM stores it at `/data/.git-credentials` (chmod 600) and every `git clone`/`git fetch` picks it up via `git -c credential.helper=…`. Shows a `user:•••last4` fingerprint when connected. `Disconnect` removes the line; non-github entries in the file are preserved.
- `/api/github-auth/{status,configure,clear}` mirrors `/api/claude-auth`. `/api/service-info` gained `github_authenticated` + `github_credentials_path`; Service tab gained a `GitHub` row.
- Legacy `/settings/auth` URL aliases to `/settings/connections`, so v5.1.8/9 bookmarks keep working.

## Why

Right now configuring a project against `https://github.com/<org>/<private>.git` returns a clean `400 clone failed: …` (thanks to v5.1.9), but there's nowhere in the UI to give PRISM credentials. This closes that gap with the simplest possible UX — same shape as the Claude auth card.

## Test plan

- [x] `pytest tests/unit` — 335/335 pass (9 new in `test_github_auth.py`)
- [x] `tsc -b` + `vite build` — clean, no new warnings
- [ ] Smoke: paste a fine-grained PAT into Connections → GitHub → Connect, then POST `/api/understand/configure` against a private repo → expect `200` + non-empty `head_sha`
- [ ] Smoke: click `Disconnect`, retry the same `/configure` → expect `400 clone failed: …` from v5.1.9
- [ ] Smoke: `/settings/auth` redirects to `/settings/connections`

🤖 Generated with [Claude Code](https://claude.com/claude-code)