### PR TITLE
feat(v5.1.11): one-click GitHub connect via OAuth Device Flow

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,25 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.1.10"
+PRISM_VERSION = "5.1.11"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.1.11: GitHub connect is now a one-click button, not a paste-a-PAT "
+    "form. The Connections panel walks you through registering a `PRISM` "
+    "OAuth App once (deep-link to `github.com/settings/applications/new` "
+    "pre-fills the name/URL; flip on `Enable Device Flow`), then `Connect "
+    "with GitHub` runs the standard OAuth Device Flow — PRISM hands you "
+    "a 6-char code, auto-opens `github.com/login/device`, polls until you "
+    "confirm, and stores the resulting access_token at `/data/.git-credentials` "
+    "the same way the v5.1.10 PAT path did. Connected state shows your "
+    "avatar, login, and scopes instead of a fingerprint. Project source "
+    "editor gained a `Browse my repos` button that opens a searchable "
+    "list of your GitHub repos and one-clicks the URL + tracked ref into "
+    "the form. PAT paste is still available under `Or paste a Personal "
+    "Access Token instead →` for anyone who can't register an OAuth app. "
+    "Client ID is stored at `/data/.github-client-id` (volume-backed, "
+    "chmod 600); env var `PRISM_GITHUB_CLIENT_ID` takes precedence if set. "
     "v5.1.10: GitHub connection lives next to Claude auth in the new "
     "`Connections` sidebar section (renamed from `Claude auth`). Paste "
     "a Personal Access Token, click `Connect`, and PRISM stores it at "

--- a/services/prism-service/app/api/github_auth.py
+++ b/services/prism-service/app/api/github_auth.py
@@ -1,38 +1,85 @@
 """/api/github-auth — manage the GitHub credentials PRISM uses for clones.
 
-Mirrors /api/claude-auth in shape: a status endpoint the SPA polls, plus
-configure/clear write endpoints driven from the Connections panel. The
-token itself is never echoed back — only a fingerprint (user + last-4
-of the token) is exposed.
+Two paths, same storage:
+
+1.  **OAuth Device Flow** (the click-buttons path, v5.1.11+). The operator
+    registers a PRISM OAuth App on github.com once, pastes the Client ID
+    into Settings → Connections, then `Connect GitHub` runs the standard
+    device-flow dance. PRISM polls until the user confirms in the browser
+    and writes the resulting access_token via github_auth.set_token().
+
+2.  **Personal Access Token paste** (the v5.1.10 path). Still supported as
+    a fallback for users who can't or won't register an OAuth app.
+
+In both cases the token lands at `/data/.git-credentials` and is picked
+up by the same credential helper at clone time. The token never leaves
+the server — only a `user:•••last4` fingerprint is exposed.
 """
 
 from __future__ import annotations
+
+from typing import Optional
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from app.services import github_auth as gh
+from app.services import github_oauth as ghoauth
 
 router = APIRouter()
 
+# In-process device-flow state. We keep only the device_code (which is
+# short-lived, GitHub-issued, and useless without our client_id) plus the
+# polling interval, keyed by a fresh nonce we hand the SPA.
+_DEVICE_FLOWS: dict[str, dict] = {}
+
+
+# --- payload shapes -----------------------------------------------------
+
 
 class ConfigureBody(BaseModel):
+    """PAT-paste path — kept for back-compat with v5.1.10 callers."""
     token: str
     user: str = "x-access-token"
 
 
+class ClientIdBody(BaseModel):
+    client_id: str
+
+
+class DevicePollBody(BaseModel):
+    flow_id: str
+
+
+# --- status / clear (shared by both paths) ------------------------------
+
+
 def _status_payload() -> dict:
     authed = gh.is_authenticated()
+    meta = ghoauth.read_meta()
+    client_id = ghoauth.get_client_id()
     return {
         "authenticated": authed,
         "credentials_path": str(gh.credentials_path()),
         "fingerprint": gh.token_fingerprint() if authed else "",
+        # OAuth metadata (empty when the active token came from the PAT path)
+        "login": meta.get("login", ""),
+        "avatar_url": meta.get("avatar_url", ""),
+        "scopes": meta.get("scopes", ""),
+        "connected_at": meta.get("connected_at", 0),
+        # Device-flow setup state
+        "client_id_configured": bool(client_id),
+        "client_id_preview": (client_id[:6] + "…" + client_id[-4:]) if client_id else "",
+        "register_url": (
+            "https://github.com/settings/applications/new"
+            "?oauth_application%5Bname%5D=PRISM"
+            "&oauth_application%5Burl%5D=http%3A%2F%2Flocalhost%3A7778"
+            "&oauth_application%5Bcallback_url%5D=http%3A%2F%2Flocalhost%3A7778%2Fsettings%2Fconnections"
+        ),
         "instructions": (
-            "Create a fine-grained Personal Access Token at "
-            "https://github.com/settings/tokens with `Contents: read` "
-            "for the repos PRISM should clone. Paste it below — it's "
-            "stored only in the data volume (chmod 600) and never "
-            "echoed back."
+            "Register a `PRISM` OAuth App at github.com/settings/applications/new "
+            "(any callback URL works; flip on `Enable Device Flow`), then paste "
+            "the Client ID below. Or paste a Personal Access Token directly."
         ),
     }
 
@@ -42,16 +89,151 @@ def status() -> dict:
     return _status_payload()
 
 
+@router.post("/clear")
+def clear() -> dict:
+    gh.clear_token()
+    ghoauth.clear_meta()
+    return _status_payload()
+
+
+# --- PAT-paste path (v5.1.10 compat) ------------------------------------
+
+
 @router.post("/configure")
 def configure(body: ConfigureBody) -> dict:
     try:
         gh.set_token(body.token, user=body.user or "x-access-token")
     except ValueError as e:
         raise HTTPException(400, str(e))
+    # PAT-paste leaves OAuth metadata empty so the UI knows it's the
+    # less-magical path and renders the fingerprint instead of the avatar.
+    ghoauth.clear_meta()
     return _status_payload()
 
 
-@router.post("/clear")
-def clear() -> dict:
-    gh.clear_token()
-    return _status_payload()
+# --- OAuth Device Flow path (v5.1.11+) ----------------------------------
+
+
+@router.get("/client-id")
+def get_client_id() -> dict:
+    cid = ghoauth.get_client_id()
+    return {
+        "configured": bool(cid),
+        "preview": (cid[:6] + "…" + cid[-4:]) if cid else "",
+        "from_env": bool(__import__("os").environ.get("PRISM_GITHUB_CLIENT_ID")),
+    }
+
+
+@router.post("/client-id")
+def set_client_id(body: ClientIdBody) -> dict:
+    try:
+        ghoauth.set_client_id(body.client_id)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return get_client_id()
+
+
+@router.post("/client-id/clear")
+def clear_client_id() -> dict:
+    ghoauth.clear_client_id()
+    return get_client_id()
+
+
+@router.post("/device/start")
+def device_start() -> dict:
+    client_id = ghoauth.get_client_id()
+    if not client_id:
+        raise HTTPException(
+            400,
+            "no Client ID configured — register a PRISM OAuth App on "
+            "github.com and paste the Client ID into Settings → Connections "
+            "first, or paste a Personal Access Token instead."
+        )
+    try:
+        code = ghoauth.start_device_flow(client_id)
+    except RuntimeError as e:
+        raise HTTPException(502, f"github device-code request failed: {e}")
+    flow_id = __import__("secrets").token_urlsafe(16)
+    _DEVICE_FLOWS[flow_id] = {
+        "device_code": code.device_code,
+        "interval": code.interval,
+        "client_id": client_id,
+    }
+    payload = code.public()
+    payload["flow_id"] = flow_id
+    return payload
+
+
+@router.post("/device/poll")
+def device_poll(body: DevicePollBody) -> dict:
+    flow = _DEVICE_FLOWS.get(body.flow_id)
+    if not flow:
+        raise HTTPException(404, "unknown flow_id — start a new device flow")
+    try:
+        result = ghoauth.poll_device_flow(flow["client_id"], flow["device_code"])
+    except RuntimeError as e:
+        raise HTTPException(502, f"github poll failed: {e}")
+
+    status_ = result.get("status")
+    if status_ == "pending":
+        out = {"status": "pending"}
+        if result.get("slow_down"):
+            flow["interval"] = flow["interval"] + 5
+            out["interval"] = flow["interval"]
+        return out
+    if status_ in ("expired", "denied", "error"):
+        # One-shot — drop the flow either way.
+        _DEVICE_FLOWS.pop(body.flow_id, None)
+        out = {"status": status_}
+        if status_ == "error":
+            out["error"] = result.get("error", "unknown error")
+        return out
+
+    # Success — exchange token for user info, store both.
+    token = result["access_token"]
+    try:
+        user = ghoauth.fetch_user(token)
+    except RuntimeError:
+        user = {}
+    login = user.get("login") or "x-access-token"
+    avatar = user.get("avatar_url") or ""
+    gh.set_token(token, user=login)
+    ghoauth.write_meta(
+        login=login,
+        scopes=result.get("scope", ""),
+        avatar_url=avatar,
+    )
+    _DEVICE_FLOWS.pop(body.flow_id, None)
+    return {"status": "success", "login": login}
+
+
+# --- Authenticated GitHub queries (used by the repo picker) -------------
+
+
+@router.get("/repos")
+def list_repos(q: str = "", page: int = 1) -> dict:
+    """Read the current token out of the credentials file and ask GitHub
+    for the operator's repos. Token never leaves the process."""
+    token = _current_token()
+    if not token:
+        raise HTTPException(400, "not connected to GitHub")
+    try:
+        return ghoauth.fetch_repos(token, q=q, page=page)
+    except RuntimeError as e:
+        raise HTTPException(502, f"github repo list failed: {e}")
+
+
+def _current_token() -> Optional[str]:
+    """Pull the token out of `/data/.git-credentials` by reading the
+    github.com line. We don't keep a long-lived in-memory copy — the
+    credentials file is the single source of truth."""
+    if not gh.CREDS_PATH.is_file():
+        return None
+    try:
+        body = gh.CREDS_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = gh._GITHUB_PARSE_RE.search(body)
+    if not m:
+        return None
+    return m.group(2)

--- a/services/prism-service/app/services/github_oauth.py
+++ b/services/prism-service/app/services/github_oauth.py
@@ -1,0 +1,294 @@
+"""GitHub OAuth Device Flow — the click-buttons-to-connect path.
+
+The operator registers a `PRISM` OAuth App at github.com/settings/applications/new
+(Authorization callback URL can be anything; device flow doesn't use it),
+enables the "Device Flow" checkbox, and pastes the resulting Client ID into
+PRISM once. From then on `Connect GitHub` runs the standard device-flow
+dance: request a short code, show it to the user, poll until they confirm
+in the browser, store the access_token via github_auth.set_token().
+
+We intentionally keep this stdlib-only — no httpx dependency to add — and
+expose three small helpers the API layer calls in sequence. Token storage
+lives in github_auth.py so the existing clone-time credential helper path
+keeps working unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from app.config import DATA_DIR
+
+CLIENT_ID_PATH = DATA_DIR / ".github-client-id"
+META_PATH = DATA_DIR / ".github-auth.json"
+
+DEVICE_CODE_URL = "https://github.com/login/device/code"
+ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token"
+USER_URL = "https://api.github.com/user"
+REPOS_URL = "https://api.github.com/user/repos"
+
+# Scopes PRISM needs: `repo` is the only one that lets us clone private
+# repos. `read:user` lets us look up the login name to display.
+DEFAULT_SCOPES = "repo read:user"
+
+# Standard OAuth App ID format is 20 hex chars. We don't enforce — GitHub
+# can change format — but we use this to spot obvious paste errors.
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9_.\-]{8,128}$")
+
+
+# --- client_id persistence ----------------------------------------------
+
+def get_client_id() -> str:
+    env = os.environ.get("PRISM_GITHUB_CLIENT_ID", "").strip()
+    if env:
+        return env
+    if not CLIENT_ID_PATH.is_file():
+        return ""
+    try:
+        return CLIENT_ID_PATH.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def set_client_id(client_id: str) -> None:
+    client_id = (client_id or "").strip()
+    if not client_id:
+        raise ValueError("client_id is required")
+    if not _CLIENT_ID_RE.match(client_id):
+        raise ValueError(
+            "client_id looks malformed — expected the 20-char ID "
+            "from github.com/settings/applications/new"
+        )
+    CLIENT_ID_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = CLIENT_ID_PATH.with_suffix(CLIENT_ID_PATH.suffix + ".tmp")
+    tmp.write_text(client_id + "\n", encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, CLIENT_ID_PATH)
+
+
+def clear_client_id() -> None:
+    try:
+        CLIENT_ID_PATH.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+# --- OAuth metadata (login/scopes, never the token) ---------------------
+
+def write_meta(login: str, scopes: str, avatar_url: str = "") -> None:
+    META_PATH.parent.mkdir(parents=True, exist_ok=True)
+    body = json.dumps({
+        "login": login,
+        "scopes": scopes,
+        "avatar_url": avatar_url,
+        "connected_at": int(time.time()),
+    })
+    tmp = META_PATH.with_suffix(META_PATH.suffix + ".tmp")
+    tmp.write_text(body, encoding="utf-8")
+    try:
+        os.chmod(tmp, 0o600)
+    except OSError:
+        pass
+    os.replace(tmp, META_PATH)
+
+
+def read_meta() -> dict:
+    if not META_PATH.is_file():
+        return {}
+    try:
+        return json.loads(META_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def clear_meta() -> None:
+    try:
+        META_PATH.unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+# --- HTTP helpers (stdlib, no httpx dep) --------------------------------
+
+def _post_form(url: str, data: dict, accept: str = "application/json") -> dict:
+    body = urllib.parse.urlencode(data).encode("ascii")
+    req = urllib.request.Request(
+        url, data=body, method="POST",
+        headers={"Accept": accept, "User-Agent": "prism-service"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        raise RuntimeError(f"github http {e.code}: {raw[:200]}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"github network error: {e.reason}") from e
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"github returned non-json: {raw[:200]}") from e
+
+
+def _get_json(url: str, token: str, params: dict | None = None) -> tuple[dict | list, dict]:
+    if params:
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(
+        url, method="GET",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "prism-service",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            raw = r.read().decode("utf-8")
+            headers = dict(r.headers)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        raise RuntimeError(f"github http {e.code}: {body[:200]}") from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"github network error: {e.reason}") from e
+    return json.loads(raw), headers
+
+
+# --- Device flow operations ---------------------------------------------
+
+@dataclass
+class DeviceCode:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+    def public(self) -> dict:
+        # `device_code` stays server-side — the SPA only needs the
+        # short code + verification URL + a polling cadence.
+        return {
+            "user_code": self.user_code,
+            "verification_uri": self.verification_uri,
+            "expires_in": self.expires_in,
+            "interval": self.interval,
+        }
+
+
+def start_device_flow(client_id: str, scopes: str = DEFAULT_SCOPES) -> DeviceCode:
+    if not client_id:
+        raise ValueError("client_id is required — set one in Settings → Connections")
+    resp = _post_form(DEVICE_CODE_URL, {"client_id": client_id, "scope": scopes})
+    try:
+        return DeviceCode(
+            device_code=resp["device_code"],
+            user_code=resp["user_code"],
+            verification_uri=resp.get("verification_uri", "https://github.com/login/device"),
+            expires_in=int(resp.get("expires_in", 900)),
+            interval=max(1, int(resp.get("interval", 5))),
+        )
+    except (KeyError, TypeError, ValueError) as e:
+        raise RuntimeError(f"device_code response missing fields: {resp}") from e
+
+
+def poll_device_flow(client_id: str, device_code: str) -> dict:
+    """Returns one of:
+
+        {"status": "pending", "interval": <new interval if slow_down>}
+        {"status": "expired"}
+        {"status": "denied"}
+        {"status": "success", "access_token": "...", "scope": "..."}
+        {"status": "error", "error": "<message>"}
+    """
+    resp = _post_form(
+        ACCESS_TOKEN_URL,
+        {
+            "client_id": client_id,
+            "device_code": device_code,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        },
+    )
+    err = resp.get("error")
+    if err == "authorization_pending":
+        return {"status": "pending"}
+    if err == "slow_down":
+        # GitHub asked us to back off; pass the new interval through.
+        return {"status": "pending", "slow_down": True}
+    if err == "expired_token":
+        return {"status": "expired"}
+    if err == "access_denied":
+        return {"status": "denied"}
+    if err:
+        return {"status": "error", "error": resp.get("error_description") or err}
+    token = resp.get("access_token")
+    if not token:
+        return {"status": "error", "error": "no access_token in response"}
+    return {
+        "status": "success",
+        "access_token": token,
+        "scope": resp.get("scope", ""),
+        "token_type": resp.get("token_type", "bearer"),
+    }
+
+
+# --- Authenticated GitHub calls -----------------------------------------
+
+def fetch_user(token: str) -> dict:
+    data, _ = _get_json(USER_URL, token)
+    if isinstance(data, dict):
+        return data
+    return {}
+
+
+def fetch_repos(token: str, q: str = "", page: int = 1, per_page: int = 30) -> dict:
+    """List the user's repos. If `q` is present we filter client-side by
+    full_name — GitHub's /user/repos has no `q` param; the proper search
+    endpoint /search/repositories has a different shape we don't need.
+    """
+    params = {
+        "per_page": str(per_page),
+        "page": str(page),
+        "sort": "pushed",
+        "affiliation": "owner,collaborator,organization_member",
+    }
+    data, headers = _get_json(REPOS_URL, token, params=params)
+    if not isinstance(data, list):
+        return {"repos": [], "has_more": False}
+    q_lower = q.strip().lower()
+    repos = []
+    for r in data:
+        full_name = r.get("full_name", "")
+        if q_lower and q_lower not in full_name.lower():
+            continue
+        repos.append({
+            "full_name": full_name,
+            "name": r.get("name", ""),
+            "owner": (r.get("owner") or {}).get("login", ""),
+            "private": bool(r.get("private")),
+            "default_branch": r.get("default_branch", "main"),
+            "description": r.get("description") or "",
+            "clone_url": r.get("clone_url", ""),
+            "html_url": r.get("html_url", ""),
+            "pushed_at": r.get("pushed_at", ""),
+            "stargazers_count": int(r.get("stargazers_count", 0) or 0),
+        })
+    # Crude has_more — Link header would be more accurate but this is fine
+    # for the SPA's "Load more" button.
+    link = headers.get("Link", "") or headers.get("link", "")
+    has_more = 'rel="next"' in link
+    return {"repos": repos, "has_more": has_more, "page": page}

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.1.10",
+  "version": "5.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/app/web/src/pages/SettingsPage.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import {
-  ChevronDown, ChevronRight, GitBranch, Loader2, Plus,
+  ChevronDown, ChevronRight, ExternalLink, GitBranch,
+  Github, Loader2, Plus, Search, X,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { notifyProjectsChanged, useProject } from "@/lib/project";
@@ -317,12 +318,50 @@ type GithubAuthStatus = {
   credentials_path: string;
   fingerprint: string;
   instructions: string;
+  // OAuth metadata — empty when the active token came from the PAT path.
+  login: string;
+  avatar_url: string;
+  scopes: string;
+  connected_at: number;
+  // Device-flow setup state — drives the first-time-setup vs Connect button choice.
+  client_id_configured: boolean;
+  client_id_preview: string;
+  register_url: string;
+};
+
+type DeviceCode = {
+  flow_id: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+};
+
+type DevicePoll =
+  | { status: "pending"; interval?: number }
+  | { status: "success"; login: string }
+  | { status: "expired" }
+  | { status: "denied" }
+  | { status: "error"; error: string };
+
+type GhRepo = {
+  full_name: string;
+  name: string;
+  owner: string;
+  private: boolean;
+  default_branch: string;
+  description: string;
+  clone_url: string;
+  html_url: string;
+  pushed_at: string;
+  stargazers_count: number;
 };
 
 function GithubAuthCard() {
   const [status, setStatus] = useState<GithubAuthStatus | null>(null);
-  const [token, setToken] = useState("");
-  const [user, setUser] = useState("x-access-token");
+  const [device, setDevice] = useState<DeviceCode | null>(null);
+  const [showPat, setShowPat] = useState(false);
+  const [showClientIdSetup, setShowClientIdSetup] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -334,18 +373,12 @@ function GithubAuthCard() {
 
   useEffect(() => { load(); }, [load]);
 
-  const connect = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!token.trim()) return;
+  const startDeviceFlow = async () => {
     setSubmitting(true);
     setError(null);
     try {
-      const next = await api.post<GithubAuthStatus>("/api/github-auth/configure", {
-        token: token.trim(),
-        user: user.trim() || "x-access-token",
-      });
-      setStatus(next);
-      setToken("");
+      const code = await api.post<DeviceCode>("/api/github-auth/device/start", {});
+      setDevice(code);
     } catch (e) {
       setError(String((e as Error).message ?? e));
     } finally {
@@ -373,21 +406,35 @@ function GithubAuthCard() {
   if (status.authenticated) {
     return (
       <div className="space-y-3">
-        <div className="inline-flex items-center gap-2 text-sm">
-          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-200 text-[9px] uppercase tracking-wider">
-            connected
-          </span>
-          <span className="opacity-70">
-            PRISM can clone private GitHub repos for any project.
-          </span>
-        </div>
-        {status.fingerprint && (
-          <div className="text-[11px] opacity-60 font-mono">
-            using <span className="opacity-90">{status.fingerprint}</span>
+        <div className="flex items-center gap-3">
+          {status.avatar_url ? (
+            <img
+              src={status.avatar_url}
+              alt={status.login}
+              className="w-10 h-10 rounded-full border border-[color:var(--midground-base)]/20"
+            />
+          ) : (
+            <div className="w-10 h-10 rounded-full bg-[color:var(--midground-base)]/10 flex items-center justify-center">
+              <Github className="w-5 h-5 opacity-70" />
+            </div>
+          )}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-200 text-[9px] uppercase tracking-wider">
+                connected
+              </span>
+              <span className="text-sm font-semibold">
+                {status.login || status.fingerprint || "GitHub"}
+              </span>
+            </div>
+            <div className="text-[11px] opacity-60 mt-0.5">
+              {status.scopes
+                ? <>scopes: <span className="font-mono">{status.scopes}</span></>
+                : status.fingerprint
+                  ? <>using <span className="font-mono">{status.fingerprint}</span> (PAT)</>
+                  : "PRISM can clone private GitHub repos"}
+            </div>
           </div>
-        )}
-        <div className="text-[11px] opacity-50 font-mono">
-          credentials → {status.credentials_path}
         </div>
         {error && (
           <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
@@ -407,61 +454,500 @@ function GithubAuthCard() {
     );
   }
 
+  // Not connected — three sub-states drive the visual:
+  //   1. no client_id    → first-time setup card with deep link to register
+  //   2. client_id ok    → big "Connect with GitHub" button (device flow)
+  //   3. PAT fallback    → collapsed by default, expandable
   return (
-    <form onSubmit={connect} className="space-y-3">
+    <div className="space-y-3">
       <div className="inline-flex items-center gap-2 text-sm">
         <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-200 text-[9px] uppercase tracking-wider">
           not connected
         </span>
         <span className="opacity-70">
-          Paste a Personal Access Token to clone private repos:
+          Connect once — PRISM uses the token for every clone after that.
         </span>
       </div>
-      <div className="grid grid-cols-[1fr_180px] gap-3">
-        <label className="flex flex-col gap-1 min-w-0">
-          <span className="text-[10px] uppercase tracking-wider opacity-60">
-            Token
-          </span>
-          <input
-            type="password"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="ghp_… or github_pat_…"
-            autoComplete="off"
-            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] uppercase tracking-wider opacity-60">
-            User <span className="opacity-50 normal-case">(optional)</span>
-          </span>
-          <input
-            value={user}
-            onChange={(e) => setUser(e.target.value)}
-            placeholder="x-access-token"
-            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
-          />
-        </label>
+
+      {!status.client_id_configured || showClientIdSetup ? (
+        <ClientIdSetup
+          status={status}
+          onSaved={() => { setShowClientIdSetup(false); load(); }}
+          onCancel={status.client_id_configured ? () => setShowClientIdSetup(false) : undefined}
+        />
+      ) : (
+        <button
+          type="button"
+          onClick={startDeviceFlow}
+          disabled={submitting}
+          className="w-full inline-flex items-center justify-center gap-2 px-4 py-3 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-sm uppercase tracking-wider disabled:opacity-30 hover:opacity-90"
+        >
+          {submitting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Github className="w-4 h-4" />}
+          {submitting ? "Starting…" : "Connect with GitHub"}
+        </button>
+      )}
+
+      {status.client_id_configured && !showClientIdSetup && (
+        <div className="text-[11px] opacity-50 flex items-center gap-2">
+          <span>OAuth App ID: <span className="font-mono">{status.client_id_preview}</span></span>
+          <button
+            type="button"
+            onClick={() => setShowClientIdSetup(true)}
+            className="underline hover:no-underline opacity-70 hover:opacity-100"
+          >
+            change
+          </button>
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+          {error}
+        </div>
+      )}
+
+      <details
+        open={showPat}
+        onToggle={(e) => setShowPat((e.target as HTMLDetailsElement).open)}
+        className="pt-2 border-t border-[color:var(--midground-base)]/10"
+      >
+        <summary className="text-[11px] uppercase tracking-wider opacity-60 cursor-pointer hover:opacity-100 list-none">
+          Or paste a Personal Access Token instead →
+        </summary>
+        <PatFallback onConnected={(next) => { setStatus(next); }} />
+      </details>
+
+      {device && (
+        <DeviceFlowModal
+          device={device}
+          onClose={() => setDevice(null)}
+          onSuccess={() => { setDevice(null); load(); }}
+        />
+      )}
+    </div>
+  );
+}
+
+
+function ClientIdSetup({
+  status, onSaved, onCancel,
+}: {
+  status: GithubAuthStatus;
+  onSaved: () => void;
+  onCancel?: () => void;
+}) {
+  const [clientId, setClientId] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!clientId.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.post("/api/github-auth/client-id", { client_id: clientId.trim() });
+      onSaved();
+    } catch (e) {
+      setError(String((e as Error).message ?? e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={save}
+      className="rounded-md border border-[color:var(--midground-base)]/15 bg-[color:var(--midground-base)]/[0.03] p-4 space-y-3"
+    >
+      <div className="text-[10px] uppercase tracking-[0.18em] opacity-60">
+        First-time setup
       </div>
+      <ol className="text-xs leading-relaxed opacity-85 list-decimal pl-5 space-y-1.5 marker:opacity-50">
+        <li>
+          <a
+            href={status.register_url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-1 underline hover:no-underline"
+          >
+            Register a PRISM OAuth App on github.com
+            <ExternalLink className="w-3 h-3 opacity-70" />
+          </a>{" "}
+          (any callback URL is fine).
+        </li>
+        <li>
+          On the app's settings page, flip on <span className="font-mono">Enable Device Flow</span>.
+        </li>
+        <li>Copy the <span className="font-mono">Client ID</span> from the top of the app page and paste it below.</li>
+      </ol>
+      <input
+        value={clientId}
+        onChange={(e) => setClientId(e.target.value)}
+        placeholder="Ov23li…"
+        autoComplete="off"
+        spellCheck={false}
+        className="w-full px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+      />
       {error && (
         <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
           {error}
         </div>
       )}
       <div className="flex items-center justify-end gap-2">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={submitting}
+            className="text-[11px] uppercase tracking-wider opacity-70 hover:opacity-100"
+          >
+            Cancel
+          </button>
+        )}
         <button
           type="submit"
-          disabled={submitting || !token.trim()}
+          disabled={submitting || !clientId.trim()}
           className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-30"
         >
           {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
-          {submitting ? "Connecting…" : "Connect"}
+          {submitting ? "Saving…" : "Save Client ID"}
         </button>
       </div>
-      <p className="text-[11px] opacity-60 leading-snug">
-        {status.instructions}
+    </form>
+  );
+}
+
+
+function DeviceFlowModal({
+  device, onClose, onSuccess,
+}: {
+  device: DeviceCode;
+  onClose: () => void;
+  onSuccess: () => void;
+}) {
+  const [poll, setPoll] = useState<DevicePoll>({ status: "pending" });
+  const [copied, setCopied] = useState(false);
+  const [interval_, setInterval_] = useState(device.interval);
+
+  // Auto-open the GitHub device-confirmation page in a new tab so the
+  // user doesn't have to copy/paste a URL too — the code still has to
+  // be entered manually but the page is one click closer.
+  useEffect(() => {
+    try { window.open(device.verification_uri, "_blank", "noopener"); } catch { /* ignore */ }
+  }, [device.verification_uri]);
+
+  useEffect(() => {
+    if (poll.status !== "pending") return;
+    const t = setTimeout(async () => {
+      try {
+        const next = await api.post<DevicePoll>("/api/github-auth/device/poll", {
+          flow_id: device.flow_id,
+        });
+        setPoll(next);
+        if (next.status === "pending" && "interval" in next && next.interval) {
+          setInterval_(next.interval);
+        }
+        if (next.status === "success") onSuccess();
+      } catch (e) {
+        setPoll({ status: "error", error: String((e as Error).message ?? e) });
+      }
+    }, interval_ * 1000);
+    return () => clearTimeout(t);
+  }, [poll, interval_, device.flow_id, onSuccess]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(device.user_code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch { /* ignore */ }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-[460px] max-w-[90vw] rounded-lg border border-[color:var(--midground-base)]/20 bg-[color:var(--background-base)] p-6 space-y-4 relative shadow-2xl">
+        <button
+          type="button"
+          onClick={onClose}
+          className="absolute top-3 right-3 opacity-60 hover:opacity-100"
+          aria-label="Close"
+        >
+          <X className="w-4 h-4" />
+        </button>
+        <div className="flex items-center gap-2">
+          <Github className="w-5 h-5" />
+          <h2 className="font-serif text-lg tracking-tight">Connect to GitHub</h2>
+        </div>
+        <p className="text-sm opacity-80">
+          Enter this code on the GitHub page that just opened:
+        </p>
+        <div className="flex items-center gap-2 justify-center">
+          <code className="px-4 py-3 rounded-md bg-[color:var(--midground-base)]/10 border border-[color:var(--midground-base)]/20 text-xl font-mono tracking-[0.3em] select-all">
+            {device.user_code}
+          </code>
+          <button
+            type="button"
+            onClick={copy}
+            className="px-3 py-3 rounded-md border border-[color:var(--midground-base)]/30 text-[10px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10"
+          >
+            {copied ? "Copied" : "Copy"}
+          </button>
+        </div>
+        <a
+          href={device.verification_uri}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs underline hover:no-underline opacity-80 hover:opacity-100"
+        >
+          Re-open <span className="font-mono">{device.verification_uri}</span>
+          <ExternalLink className="w-3 h-3" />
+        </a>
+        <DeviceFlowFooter poll={poll} onClose={onClose} />
+      </div>
+    </div>
+  );
+}
+
+function DeviceFlowFooter({ poll, onClose }: { poll: DevicePoll; onClose: () => void }) {
+  if (poll.status === "pending") {
+    return (
+      <div className="flex items-center gap-2 text-xs opacity-70">
+        <Loader2 className="w-3 h-3 animate-spin" />
+        Waiting for confirmation… this panel will close automatically.
+      </div>
+    );
+  }
+  if (poll.status === "success") {
+    return (
+      <div className="text-xs text-emerald-200">
+        Connected as <span className="font-mono">{poll.login}</span>!
+      </div>
+    );
+  }
+  if (poll.status === "expired") {
+    return (
+      <div className="space-y-2">
+        <div className="text-xs text-amber-200">
+          Code expired — start a new connect attempt.
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-[11px] uppercase tracking-wider underline hover:no-underline"
+        >
+          Close
+        </button>
+      </div>
+    );
+  }
+  if (poll.status === "denied") {
+    return (
+      <div className="text-xs text-amber-200">
+        You declined the authorization. Close this dialog and try again if that was a mistake.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+        {poll.error}
+      </div>
+    </div>
+  );
+}
+
+
+function PatFallback({ onConnected }: { onConnected: (s: GithubAuthStatus) => void }) {
+  const [token, setToken] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token.trim()) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const next = await api.post<GithubAuthStatus>("/api/github-auth/configure", {
+        token: token.trim(),
+        user: "x-access-token",
+      });
+      onConnected(next);
+      setToken("");
+    } catch (e) {
+      setError(String((e as Error).message ?? e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={submit} className="mt-3 space-y-2">
+      <div className="flex items-center gap-2">
+        <input
+          type="password"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+          placeholder="ghp_… or github_pat_…"
+          autoComplete="off"
+          className="flex-1 px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+        />
+        <button
+          type="submit"
+          disabled={submitting || !token.trim()}
+          className="px-3 py-2 rounded-md border border-[color:var(--midground-base)]/30 text-[11px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10 disabled:opacity-30"
+        >
+          {submitting && <Loader2 className="w-3 h-3 animate-spin inline mr-1" />}
+          {submitting ? "Connecting…" : "Use token"}
+        </button>
+      </div>
+      {error && (
+        <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+          {error}
+        </div>
+      )}
+      <p className="text-[11px] opacity-50 leading-snug">
+        Create a fine-grained PAT at{" "}
+        <a
+          href="https://github.com/settings/personal-access-tokens/new"
+          target="_blank"
+          rel="noreferrer"
+          className="underline hover:no-underline"
+        >
+          github.com/settings/personal-access-tokens/new
+        </a>{" "}
+        with <span className="font-mono">Contents: read</span> on the repos PRISM should clone.
       </p>
     </form>
+  );
+}
+
+
+function RepoPickerModal({
+  onPick, onClose,
+}: {
+  onPick: (url: string, defaultBranch: string) => void;
+  onClose: () => void;
+}) {
+  const [q, setQ] = useState("");
+  const [page, setPage] = useState(1);
+  const [repos, setRepos] = useState<GhRepo[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async (resetPage: boolean) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const nextPage = resetPage ? 1 : page;
+      const r = await api.get<{ repos: GhRepo[]; has_more: boolean }>(
+        `/api/github-auth/repos?q=${encodeURIComponent(q)}&page=${nextPage}`,
+      );
+      setRepos((prev) => resetPage ? r.repos : [...prev, ...r.repos]);
+      setHasMore(r.has_more);
+      if (resetPage) setPage(1);
+    } catch (e) {
+      setError(String((e as Error).message ?? e));
+    } finally {
+      setLoading(false);
+    }
+  }, [q, page]);
+
+  useEffect(() => { load(true); /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [q]);
+
+  const loadMore = async () => {
+    setPage((p) => p + 1);
+    setLoading(true);
+    try {
+      const r = await api.get<{ repos: GhRepo[]; has_more: boolean }>(
+        `/api/github-auth/repos?q=${encodeURIComponent(q)}&page=${page + 1}`,
+      );
+      setRepos((prev) => [...prev, ...r.repos]);
+      setHasMore(r.has_more);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-[560px] max-w-[90vw] max-h-[80vh] rounded-lg border border-[color:var(--midground-base)]/20 bg-[color:var(--background-base)] p-5 flex flex-col gap-3 shadow-2xl">
+        <div className="flex items-center gap-2">
+          <Github className="w-5 h-5" />
+          <h2 className="font-serif text-lg tracking-tight flex-1">Pick a GitHub repo</h2>
+          <button type="button" onClick={onClose} aria-label="Close" className="opacity-60 hover:opacity-100">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+        <label className="flex items-center gap-2 px-3 py-2 rounded-md bg-[color:var(--midground-base)]/[0.04] border border-[color:var(--midground-base)]/15">
+          <Search className="w-4 h-4 opacity-50" />
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="filter by name…"
+            className="flex-1 bg-transparent text-sm focus:outline-none"
+            autoFocus
+          />
+        </label>
+        {error && (
+          <div className="rounded-md border border-rose-500/30 bg-rose-500/10 text-rose-200 px-3 py-2 text-xs">
+            {error}
+          </div>
+        )}
+        <ul className="flex-1 overflow-y-auto divide-y divide-[color:var(--midground-base)]/10 -mx-2">
+          {repos.map((r) => (
+            <li key={r.full_name}>
+              <button
+                type="button"
+                onClick={() => onPick(
+                  `https://github.com/${r.full_name}`,
+                  r.default_branch || "main",
+                )}
+                className="w-full text-left px-2 py-2 hover:bg-[color:var(--midground-base)]/[0.04]"
+              >
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="font-mono">{r.full_name}</span>
+                  {r.private && (
+                    <span className="text-[9px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-[color:var(--midground-base)]/15 opacity-80">
+                      private
+                    </span>
+                  )}
+                  <span className="ml-auto text-[11px] opacity-50 font-mono">
+                    {r.default_branch}
+                  </span>
+                </div>
+                {r.description && (
+                  <div className="text-[11px] opacity-60 mt-0.5 truncate">{r.description}</div>
+                )}
+              </button>
+            </li>
+          ))}
+          {repos.length === 0 && !loading && (
+            <li className="px-2 py-6 text-center text-sm opacity-60">
+              {q ? `No repos match "${q}".` : "No repos found."}
+            </li>
+          )}
+        </ul>
+        <div className="flex items-center gap-2">
+          {hasMore && (
+            <button
+              type="button"
+              onClick={loadMore}
+              disabled={loading}
+              className="px-3 py-1.5 rounded-md border border-[color:var(--midground-base)]/20 text-[11px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10 disabled:opacity-40"
+            >
+              {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : "Load more"}
+            </button>
+          )}
+          <span className="text-[11px] opacity-50 ml-auto">
+            {repos.length} repo{repos.length === 1 ? "" : "s"}
+            {loading && <Loader2 className="w-3 h-3 animate-spin inline ml-2" />}
+          </span>
+        </div>
+      </div>
+    </div>
   );
 }
 
@@ -1145,12 +1631,22 @@ function ProjectEditor({
   const [confirmText, setConfirmText] = useState("");
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [ghAuthed, setGhAuthed] = useState(false);
+  const [picking, setPicking] = useState(false);
   const isProtected = name === "default";
 
   useEffect(() => {
     setRemote(info?.remote_url ?? "");
     setRef(info?.tracked_ref ?? "origin/main");
   }, [info?.remote_url, info?.tracked_ref]);
+
+  // Lazy-load github auth status so the Browse button only renders when
+  // a repo list call would actually succeed. Cheap — single GET.
+  useEffect(() => {
+    api.get<GithubAuthStatus>("/api/github-auth/status")
+      .then((s) => setGhAuthed(s.authenticated))
+      .catch(() => setGhAuthed(false));
+  }, []);
 
   const save = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -1212,8 +1708,17 @@ function ProjectEditor({
     >
       <div className="grid grid-cols-[1fr_180px] gap-3">
         <label className="flex flex-col gap-1 min-w-0">
-          <span className="text-[10px] uppercase tracking-wider opacity-60">
+          <span className="text-[10px] uppercase tracking-wider opacity-60 flex items-center gap-2">
             Git URL <span className="opacity-50 normal-case">(optional)</span>
+            {ghAuthed && (
+              <button
+                type="button"
+                onClick={() => setPicking(true)}
+                className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-wider opacity-80 hover:opacity-100"
+              >
+                <Github className="w-3 h-3" /> Browse my repos
+              </button>
+            )}
           </span>
           <input
             value={remote}
@@ -1324,6 +1829,21 @@ function ProjectEditor({
             </div>
           )}
         </div>
+      )}
+      {picking && (
+        <RepoPickerModal
+          onClose={() => setPicking(false)}
+          onPick={(url, defaultBranch) => {
+            setRemote(url);
+            // Only auto-fill the tracked ref when the user hasn't
+            // customized it from the default — otherwise we'd clobber
+            // their choice on every pick.
+            if (!ref || ref === "origin/main") {
+              setRef(`origin/${defaultBranch}`);
+            }
+            setPicking(false);
+          }}
+        />
       )}
     </form>
   );


### PR DESCRIPTION
## Summary

Replaces the v5.1.10 paste-a-PAT path as the primary GitHub connect flow with the standard OAuth Device Flow. User clicks `Connect with GitHub` → sees a 6-char code → GitHub's confirmation page auto-opens → confirms → PRISM polls and stores the access_token at `/data/.git-credentials` the same way v5.1.10 did. Connected state shows avatar + login + scopes. Project source editor gained a `Browse my repos` button that opens a searchable repo picker.

## What changed

- **New** `app/services/github_oauth.py` — stdlib-only (`urllib`) helpers; no httpx dep added.
- **New endpoints** under `/api/github-auth`: `GET/POST /client-id`, `POST /client-id/clear`, `POST /device/start`, `POST /device/poll`, `GET /repos`. Existing `/status`, `/configure`, `/clear` preserved for back-compat.
- **Storage**: Client ID at `/data/.github-client-id` (chmod 600); `PRISM_GITHUB_CLIENT_ID` env var takes precedence. OAuth metadata (login, scopes, avatar) at `/data/.github-auth.json`. Token never leaves the credentials file.
- **SPA**: `SettingsPage.tsx` Connections rebuilt — first-time-setup card (deep-link to `github.com/settings/applications/new` with name/URL pre-filled), Connect button, DeviceFlowModal, connected card with avatar.
- **Project editor**: `Browse my repos` button (only when connected). RepoPickerModal — searchable list; pick a repo to fill URL + seed `tracked_ref` to `origin/<default_branch>`.
- PAT paste lives behind a collapsed `<details>` fallback.
- Version bumped to 5.1.11.

## Test plan

- [x] Verified locally on http://localhost:8888 (preview container)
- [ ] Connections → first-time-setup: register OAuth App, paste Client ID, save
- [ ] Click `Connect with GitHub` → code appears, browser opens, modal polls until confirm
- [ ] Connected card shows avatar + login + scopes
- [ ] `Browse my repos` → pick private repo → URL + tracked ref auto-fill → clone succeeds
- [ ] PAT fallback still works end-to-end
- [ ] `Disconnect` clears creds + metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)