### PR TITLE
v5.2.0: folder mode + host claude auth

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,21 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.1.11"
+PRISM_VERSION = "5.2.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.2.0: Local folder mode + host claude auth. Add a project by "
+    "pointing at a folder PRISM has bind-mounted from your host (default "
+    "`${HOME}/code` → `/code` in the container). No git URL, no clone, "
+    "no GitHub credentials in the container — your host already has "
+    "your code and your git auth. Settings → Projects has a `Local "
+    "folder` / `Git URL` toggle; folder is the new default for new "
+    "projects. The host's `~/.claude` is now bind-mounted into the "
+    "container, so the container's claude uses your existing logged-in "
+    "subscription with no `claude /login` inside the container. The "
+    "git-URL clone path (and v5.1.10–11's GitHub OAuth connect) still "
+    "work as before for anyone who prefers them. "
     "v5.1.11: GitHub connect is now a one-click button, not a paste-a-PAT "
     "form. The Connections panel walks you through registering a `PRISM` "
     "OAuth App once (deep-link to `github.com/settings/applications/new` "

--- a/services/prism-service/app/api/projects.py
+++ b/services/prism-service/app/api/projects.py
@@ -36,6 +36,13 @@ _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 
 class CreateBody(BaseModel):
     name: str
+    # v5.2.0 primary path: point PRISM at a bind-mounted folder on the
+    # host. This is the simple flow for developer audiences — clone the
+    # repo on your host with your existing git auth, mount it into the
+    # container, paste the path here.
+    source_path: Optional[str] = None
+    # v5.1 legacy: PRISM clones the repo server-side. Kept for backward
+    # compatibility but no longer the recommended path.
     remote_url: Optional[str] = None
     tracked_ref: str = "origin/main"
 
@@ -53,9 +60,31 @@ def create_project(body: CreateBody) -> dict:
     pdir = project_data_dir(name)  # seeds source/, graph/, state.json
     head_sha: Optional[str] = None
     bootstrap = "skipped"
-
+    mode = "empty"
+    source_path = (body.source_path or "").strip()
     remote_url = (body.remote_url or "").strip()
-    if remote_url:
+
+    if source_path and remote_url:
+        raise HTTPException(
+            400,
+            "pass either source_path (folder mode) or remote_url (clone "
+            "mode), not both",
+        )
+
+    if source_path:
+        # Folder mode — no clone. Just record the path and kick off
+        # bootstrap (ingest + analyzer-queue refresh) against the
+        # bind-mounted dir.
+        try:
+            resolved = ss.set_source_path(name, source_path)
+        except ss.SourceUnavailable as e:
+            raise HTTPException(400, str(e))
+        head_sha = resolved["head_sha"]
+        mode = "folder"
+        Thread(target=ss.bootstrap_after_clone, args=(name,), daemon=True).start()
+        bootstrap = "started"
+    elif remote_url:
+        # Clone mode — legacy v5.1 path.
         try:
             state = ss.ensure_cloned(name, remote_url, body.tracked_ref)
         except ss.SourceUnavailable as e:
@@ -64,21 +93,18 @@ def create_project(body: CreateBody) -> dict:
         s = ue._read_state(name)
         s["remote_url"] = remote_url
         s["tracked_ref"] = body.tracked_ref
+        s["mode"] = "clone"
         ue._write_state(name, s)
-        # Same bootstrap as /api/understand/configure: ingest source into
-        # Brain + Graph, then enqueue analyzer jobs. Runs in background so
-        # the API call returns fast; the auto-drainer picks up the queue.
-        Thread(
-            target=ss.bootstrap_after_clone,
-            args=(name,),
-            daemon=True,
-        ).start()
+        Thread(target=ss.bootstrap_after_clone, args=(name,), daemon=True).start()
         bootstrap = "started"
+        mode = "clone"
 
     return {
         "created": True,
         "name": name,
         "path": str(pdir),
+        "mode": mode,
+        "source_path": source_path or None,
         "remote_url": remote_url or None,
         "tracked_ref": body.tracked_ref if remote_url else None,
         "head_sha": head_sha,

--- a/services/prism-service/app/api/understand.py
+++ b/services/prism-service/app/api/understand.py
@@ -29,36 +29,62 @@ def status(project: str = Query("default")) -> dict:
 
 
 class ConfigureBody(BaseModel):
-    remote_url: str
+    # v5.2.0 primary path — point PRISM at a bind-mounted folder
+    source_path: Optional[str] = None
+    # v5.1 legacy — let PRISM clone the repo server-side
+    remote_url: Optional[str] = None
     tracked_ref: str = "origin/main"
 
 
 @router.post("/configure")
 def configure(body: ConfigureBody, project: str = Query("default")) -> dict:
-    if not body.remote_url.strip():
-        raise HTTPException(400, "remote_url is required")
+    source_path = (body.source_path or "").strip()
+    remote_url = (body.remote_url or "").strip()
+    if not source_path and not remote_url:
+        raise HTTPException(
+            400, "either source_path (folder mode) or remote_url (clone "
+            "mode) is required",
+        )
+    if source_path and remote_url:
+        raise HTTPException(
+            400, "pass either source_path or remote_url, not both",
+        )
+
+    if source_path:
+        # Folder mode — record the bind-mounted path, no clone.
+        try:
+            resolved = ss.set_source_path(project, source_path)
+        except ss.SourceUnavailable as e:
+            raise HTTPException(400, str(e))
+        Thread(
+            target=ss.bootstrap_after_clone,
+            args=(project,),
+            daemon=True,
+        ).start()
+        return {
+            "configured": True,
+            "mode": "folder",
+            "source_path": resolved["source_path"],
+            "head_sha": resolved["head_sha"],
+            "ingest": "started",
+            "bootstrap": "started",
+        }
+
+    # Clone mode — legacy v5.1 path.
     try:
-        state = ss.ensure_cloned(project, body.remote_url, body.tracked_ref)
+        state = ss.ensure_cloned(project, remote_url, body.tracked_ref)
     except ss.SourceUnavailable as e:
         raise HTTPException(400, str(e))
     s = ue._read_state(project)
-    s["remote_url"] = body.remote_url
+    s["remote_url"] = remote_url
     s["tracked_ref"] = body.tracked_ref
+    s["mode"] = "clone"
     ue._write_state(project, s)
-
-    # Bootstrap: ingest source into Brain + Graph AND enqueue analyzer
-    # jobs in one background thread, so the configure call returns fast.
-    # The auto-drainer (started in main.py lifespan) picks up the queue
-    # and runs claude -p for each analyzer.
-    Thread(
-        target=ss.bootstrap_after_clone,
-        args=(project,),
-        daemon=True,
-    ).start()
-
+    Thread(target=ss.bootstrap_after_clone, args=(project,), daemon=True).start()
     return {
         "configured": True,
-        "remote_url": body.remote_url,
+        "mode": "clone",
+        "remote_url": remote_url,
         "tracked_ref": body.tracked_ref,
         "head_sha": state.head_sha,
         "advanced": state.advanced,

--- a/services/prism-service/app/engines/understand_engine.py
+++ b/services/prism-service/app/engines/understand_engine.py
@@ -239,8 +239,15 @@ class UnderstandEngine:
         """Compose source pin state + queue snapshot for the
         understand_status MCP tool."""
         state = _read_state(self.project)
+        # v5.2.0 — projects can be in folder-mode OR clone-mode. Surface
+        # both so the SPA can show the right thing in the Settings card.
+        source_path = state.get("source_path")
+        mode = state.get("mode") or ("folder" if source_path else
+                                     ("clone" if state.get("remote_url") else "empty"))
         out: dict = {
             "project": self.project,
+            "mode": mode,
+            "source_path": source_path,
             "tracked_ref": state.get("tracked_ref", "origin/main"),
             "remote_url": state.get("remote_url"),
             "last_analyzed_sha": state.get("last_analyzed_sha"),

--- a/services/prism-service/app/services/source_service.py
+++ b/services/prism-service/app/services/source_service.py
@@ -102,12 +102,89 @@ def _run_git(args: list[str], cwd: Path, timeout: int = 60) -> tuple[int, str, s
 
 
 def source_dir_for(project: str) -> Path:
-    """Return the source/ subdir for a project, ensured to exist."""
+    """Return the directory PRISM should analyze for this project.
+
+    v5.2.0 — projects can be either:
+      * Folder-mode (preferred): understand_state.json has a `source_path`
+        field set to a directory (typically /code/<repo> bind-mounted from
+        the host). We return that path as-is; no clone happens server-side.
+      * Clone-mode (legacy): no source_path set. We return the per-project
+        data/projects/<name>/source dir which ensure_cloned() fills via
+        `git clone`.
+
+    Falls back to the data-dir path if state can't be read so the function
+    is safe to call before configuration.
+    """
+    from app.engines import understand_engine as ue
+    try:
+        state = ue._read_state(project)
+        sp = state.get("source_path") or ""
+        if sp:
+            p = Path(sp)
+            if p.is_dir():
+                return p
+    except Exception:
+        pass
     return project_data_dir(project) / "source"
 
 
 def is_cloned(project: str) -> bool:
-    return (source_dir_for(project) / ".git").exists()
+    """Renamed semantically — answers 'does PRISM know where this project's
+    source lives, and is it readable?' Returns True for both folder-mode
+    (source_path set and points at a real dir) and clone-mode (source/
+    has a .git checkout)."""
+    from app.engines import understand_engine as ue
+    try:
+        sp = (ue._read_state(project).get("source_path") or "").strip()
+        if sp and Path(sp).is_dir():
+            return True
+    except Exception:
+        pass
+    return (project_data_dir(project) / "source" / ".git").exists()
+
+
+def set_source_path(project: str, source_path: str) -> dict:
+    """Configure a project to read its source from a bind-mounted folder
+    instead of a git clone. Validates the path is reachable; records it
+    in understand_state.json. Idempotent.
+
+    Returns the resolved state for the SPA's response.
+    """
+    from app.engines import understand_engine as ue
+    sp = (source_path or "").strip()
+    if not sp:
+        raise SourceUnavailable("source_path is required")
+    p = Path(sp).resolve()
+    if not p.is_dir():
+        raise SourceUnavailable(
+            f"source_path {sp!r} does not exist or is not a directory inside "
+            "the container — check your docker-compose bind-mount"
+        )
+    state = ue._read_state(project)
+    state["source_path"] = str(p)
+    state["mode"] = "folder"
+    # Clear remote_url so the SPA knows this project isn't tracking a
+    # remote anymore. Leaves tracked_ref alone since it might be useful
+    # for drift-detection against the local git checkout's branch.
+    state.pop("remote_url", None)
+    ue._write_state(project, state)
+    return {
+        "project": project,
+        "source_path": str(p),
+        "mode": "folder",
+        "head_sha": _current_sha_if_git(p),
+    }
+
+
+def _current_sha_if_git(path: Path) -> str:
+    """If `path` is a git repo, return its current HEAD SHA. Otherwise ''."""
+    if not (path / ".git").exists():
+        return ""
+    try:
+        rc, out, _err = _run_git(["rev-parse", "HEAD"], path, timeout=10)
+        return out.strip() if rc == 0 else ""
+    except Exception:
+        return ""
 
 
 def ensure_cloned(
@@ -180,14 +257,51 @@ def _rev_parse(src_dir: Path, ref: str) -> Optional[str]:
 
 
 def current_sha(project: str, ref: str = "HEAD") -> str:
-    """Return the SHA at `ref` in the project's source clone."""
+    """Return the SHA at `ref` in the project's source dir.
+
+    Works for both clone-mode (data/projects/<name>/source is a git repo)
+    and folder-mode (bind-mounted /code/<repo> that happens to be a git
+    repo). If the folder isn't a git repo at all, returns a synthetic
+    SHA derived from a directory-content hash so drift detection still
+    has a stable identity to compare against.
+    """
     src = source_dir_for(project)
     if not is_cloned(project):
-        raise SourceUnavailable(f"project {project!r} is not cloned yet")
-    sha = _rev_parse(src, ref)
-    if sha is None:
-        raise SourceUnavailable(f"ref {ref!r} not found in {project}")
-    return sha
+        raise SourceUnavailable(f"project {project!r} has no source configured")
+    if (src / ".git").exists():
+        sha = _rev_parse(src, ref)
+        if sha is None:
+            raise SourceUnavailable(f"ref {ref!r} not found in {project}")
+        return sha
+    # Non-git folder: synthesize a stable SHA from a quick directory
+    # fingerprint. Enough to detect "changed since last analyzed" for
+    # drift purposes; not cryptographically meaningful.
+    return _folder_fingerprint(src)
+
+
+def _folder_fingerprint(path: Path) -> str:
+    """Stable-ish hash over file paths + mtimes under `path`. Skipped dirs
+    match the same skip set used by ingest_source_to_brain so the
+    fingerprint reflects what PRISM actually cares about."""
+    import hashlib
+    h = hashlib.sha256()
+    try:
+        for p in sorted(path.rglob("*")):
+            if not p.is_file():
+                continue
+            if any(part in _INGEST_SKIP_DIRS for part in p.parts):
+                continue
+            try:
+                rel = str(p.relative_to(path)).replace("\\", "/")
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                h.update(str(int(p.stat().st_mtime)).encode("utf-8"))
+                h.update(b"\x00")
+            except (OSError, ValueError):
+                continue
+    except OSError:
+        pass
+    return h.hexdigest()
 
 
 def has_advanced(project: str, since_sha: str, tracked_ref: str = "origin/main") -> bool:

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.1.11",
+  "version": "5.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/app/web/src/pages/SettingsPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useParams } from "react-router-dom";
 import {
-  ChevronDown, ChevronRight, ExternalLink, GitBranch,
+  ChevronDown, ChevronRight, ExternalLink, FolderTree, GitBranch,
   Github, Loader2, Plus, Search, X,
 } from "lucide-react";
 import { api } from "@/lib/api";
@@ -52,6 +52,8 @@ type QueueCounts = {
 
 type ProjectInfo = {
   name: string;
+  mode: "folder" | "clone" | "empty";
+  source_path: string | null;
   remote_url: string | null;
   tracked_ref: string | null;
   current_sha: string | null;
@@ -63,6 +65,8 @@ const ZERO_QUEUE: QueueCounts = { pending: 0, in_progress: 0, completed: 0, fail
 
 async function fetchInfo(name: string): Promise<ProjectInfo> {
   const s = await api.get<{
+    mode?: "folder" | "clone" | "empty";
+    source_path?: string | null;
     tracked_ref: string;
     remote_url: string | null;
     current_sha: string | null;
@@ -71,6 +75,8 @@ async function fetchInfo(name: string): Promise<ProjectInfo> {
   }>(`/api/understand?project=${encodeURIComponent(name)}`);
   return {
     name,
+    mode: s.mode ?? (s.source_path ? "folder" : (s.remote_url ? "clone" : "empty")),
+    source_path: s.source_path ?? null,
     remote_url: s.remote_url ?? null,
     tracked_ref: s.tracked_ref ?? null,
     current_sha: s.current_sha ?? null,
@@ -79,9 +85,13 @@ async function fetchInfo(name: string): Promise<ProjectInfo> {
   };
 }
 
+function hasSource(info: ProjectInfo | undefined): boolean {
+  return Boolean(info?.source_path || info?.remote_url);
+}
+
 function isDrifted(info: ProjectInfo | undefined): boolean {
   if (!info?.current_sha) return false;
-  if (!info.last_analyzed_sha) return Boolean(info.remote_url);
+  if (!info.last_analyzed_sha) return hasSource(info);
   return info.current_sha !== info.last_analyzed_sha;
 }
 
@@ -1552,13 +1562,22 @@ function ProjectCard({
             )}
           </div>
           <div className="text-[11px] opacity-60 mt-1 flex flex-wrap gap-x-4 gap-y-1">
-            <span className="inline-flex items-center gap-1">
-              <GitBranch className="w-3 h-3" />
-              {info?.tracked_ref ?? "—"}
-            </span>
-            <span className="truncate max-w-[420px]">
-              {info?.remote_url ?? <em className="opacity-60">no source</em>}
-            </span>
+            {info?.mode === "folder" && info.source_path ? (
+              <span className="inline-flex items-center gap-1 truncate max-w-[480px]">
+                <FolderTree className="w-3 h-3" />
+                <span className="font-mono">{info.source_path}</span>
+              </span>
+            ) : info?.mode === "clone" && info.remote_url ? (
+              <>
+                <span className="inline-flex items-center gap-1">
+                  <GitBranch className="w-3 h-3" />
+                  {info.tracked_ref ?? "origin/main"}
+                </span>
+                <span className="truncate max-w-[420px]">{info.remote_url}</span>
+              </>
+            ) : (
+              <em className="opacity-60">no source</em>
+            )}
             <span>
               sha: <span className="font-mono">
                 {info?.current_sha ? info.current_sha.slice(0, 10) : "—"}
@@ -1623,6 +1642,19 @@ function ProjectEditor({
   onSaved: () => void;
   onDeleted: () => Promise<void> | void;
 }) {
+  // v5.2.0 — primary source mode is now "folder" (bind-mounted path).
+  // "url" is the legacy clone-mode preserved for backward compat. New
+  // projects default to folder; existing projects default to whatever
+  // they already are.
+  const initialMode: "folder" | "url" =
+    info?.mode === "clone" ? "url" :
+    info?.mode === "folder" ? "folder" :
+    // empty / new project — default to folder
+    "folder";
+  const [mode, setMode] = useState<"folder" | "url">(initialMode);
+  const [folderPath, setFolderPath] = useState(
+    info?.source_path ?? `/code/${name}`,
+  );
   const [remote, setRemote] = useState(info?.remote_url ?? "");
   const [ref, setRef] = useState(info?.tracked_ref ?? "origin/main");
   const [submitting, setSubmitting] = useState(false);
@@ -1636,9 +1668,15 @@ function ProjectEditor({
   const isProtected = name === "default";
 
   useEffect(() => {
+    setMode(
+      info?.mode === "clone" ? "url" :
+      info?.mode === "folder" ? "folder" :
+      "folder"
+    );
+    setFolderPath(info?.source_path ?? `/code/${name}`);
     setRemote(info?.remote_url ?? "");
     setRef(info?.tracked_ref ?? "origin/main");
-  }, [info?.remote_url, info?.tracked_ref]);
+  }, [info?.mode, info?.source_path, info?.remote_url, info?.tracked_ref, name]);
 
   // Lazy-load github auth status so the Browse button only renders when
   // a repo list call would actually succeed. Cheap — single GET.
@@ -1650,17 +1688,21 @@ function ProjectEditor({
 
   const save = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!remote.trim()) {
-      setError("git url is required (leave a project sourceless by closing this editor without saving)");
+    if (mode === "folder" && !folderPath.trim()) {
+      setError("Source path is required. Type the container-side path to the folder you bind-mounted into /code (see your docker-compose).");
+      return;
+    }
+    if (mode === "url" && !remote.trim()) {
+      setError("git URL is required.");
       return;
     }
     setSubmitting(true);
     setError(null);
     try {
-      await api.post(`/api/understand/configure?project=${encodeURIComponent(name)}`, {
-        remote_url: remote.trim(),
-        tracked_ref: ref.trim() || "origin/main",
-      });
+      const body = mode === "folder"
+        ? { source_path: folderPath.trim() }
+        : { remote_url: remote.trim(), tracked_ref: ref.trim() || "origin/main" };
+      await api.post(`/api/understand/configure?project=${encodeURIComponent(name)}`, body);
       onSaved();
     } catch (e) {
       setError(String((e as Error).message ?? e));
@@ -1699,46 +1741,105 @@ function ProjectEditor({
   };
 
   const drifted = isDrifted(info);
-  const hasSource = Boolean(info?.remote_url);
+  const sourceConfigured = hasSource(info);
 
   return (
     <form
       onSubmit={save}
       className="mt-3 ml-7 rounded-md border border-[color:var(--midground-base)]/15 bg-[color:var(--midground-base)]/[0.03] p-4 space-y-3"
     >
-      <div className="grid grid-cols-[1fr_180px] gap-3">
-        <label className="flex flex-col gap-1 min-w-0">
-          <span className="text-[10px] uppercase tracking-wider opacity-60 flex items-center gap-2">
-            Git URL <span className="opacity-50 normal-case">(optional)</span>
-            {ghAuthed && (
-              <button
-                type="button"
-                onClick={() => setPicking(true)}
-                className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-wider opacity-80 hover:opacity-100"
-              >
-                <Github className="w-3 h-3" /> Browse my repos
-              </button>
-            )}
-          </span>
-          <input
-            value={remote}
-            onChange={(e) => setRemote(e.target.value)}
-            placeholder="https://github.com/owner/repo"
-            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
-          />
-        </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-[10px] uppercase tracking-wider opacity-60">
-            Tracked ref
-          </span>
-          <input
-            value={ref}
-            onChange={(e) => setRef(e.target.value)}
-            className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
-          />
-        </label>
+      {/* Source mode toggle — folder is the v5.2.0 primary path. */}
+      <div className="flex items-center gap-1 text-[10px] uppercase tracking-wider opacity-80">
+        <span className="opacity-60 mr-2">Source</span>
+        <button
+          type="button"
+          onClick={() => setMode("folder")}
+          className={
+            "px-3 py-1 rounded-md border " +
+            (mode === "folder"
+              ? "bg-[color:var(--midground-base)]/15 border-[color:var(--midground-base)]/40"
+              : "border-[color:var(--midground-base)]/15 opacity-70 hover:opacity-100")
+          }
+        >
+          <FolderTree className="w-3 h-3 inline mr-1 -mt-0.5" />
+          Local folder
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("url")}
+          className={
+            "px-3 py-1 rounded-md border " +
+            (mode === "url"
+              ? "bg-[color:var(--midground-base)]/15 border-[color:var(--midground-base)]/40"
+              : "border-[color:var(--midground-base)]/15 opacity-70 hover:opacity-100")
+          }
+        >
+          <GitBranch className="w-3 h-3 inline mr-1 -mt-0.5" />
+          Git URL
+        </button>
+        <span className="opacity-50 normal-case ml-auto">
+          {mode === "folder"
+            ? "PRISM reads files where they already live on your host"
+            : "PRISM clones the repo server-side"}
+        </span>
       </div>
-      {info?.remote_url && info.remote_url !== remote.trim() && (
+
+      {mode === "folder" ? (
+        <div className="space-y-2">
+          <label className="flex flex-col gap-1 min-w-0">
+            <span className="text-[10px] uppercase tracking-wider opacity-60">
+              Container path
+            </span>
+            <input
+              value={folderPath}
+              onChange={(e) => setFolderPath(e.target.value)}
+              placeholder="/code/your-repo"
+              className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+            />
+          </label>
+          <p className="text-[11px] opacity-60 leading-snug">
+            This path lives <em>inside the container</em>. Bind-mount your
+            code dir into <span className="font-mono">/code</span> in
+            docker-compose (default is{" "}
+            <span className="font-mono">~/code</span> on the host), then
+            point at a subfolder here. No git URL, no auth, no clone.
+          </p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-[1fr_180px] gap-3">
+          <label className="flex flex-col gap-1 min-w-0">
+            <span className="text-[10px] uppercase tracking-wider opacity-60 flex items-center gap-2">
+              Git URL
+              {ghAuthed && (
+                <button
+                  type="button"
+                  onClick={() => setPicking(true)}
+                  className="ml-auto inline-flex items-center gap-1 text-[10px] uppercase tracking-wider opacity-80 hover:opacity-100"
+                >
+                  <Github className="w-3 h-3" /> Browse my repos
+                </button>
+              )}
+            </span>
+            <input
+              value={remote}
+              onChange={(e) => setRemote(e.target.value)}
+              placeholder="https://github.com/owner/repo"
+              className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="text-[10px] uppercase tracking-wider opacity-60">
+              Tracked ref
+            </span>
+            <input
+              value={ref}
+              onChange={(e) => setRef(e.target.value)}
+              className="px-3 py-2 rounded-md bg-[color:var(--background-base)]/60 border border-[color:var(--midground-base)]/20 text-sm font-mono"
+            />
+          </label>
+        </div>
+      )}
+      {mode === "url" && info?.remote_url && info.remote_url !== remote.trim() && (
         <div className="text-[11px] opacity-60">
           Changing the URL is refused server-side once a clone exists — to
           re-point, delete the project's source/ dir first.
@@ -1758,7 +1859,7 @@ function ProjectEditor({
           Make active
         </button>
         <div className="flex items-center gap-2">
-          {hasSource && (
+          {sourceConfigured && (
             <button
               type="button"
               onClick={sync}
@@ -1778,7 +1879,7 @@ function ProjectEditor({
             className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-40"
           >
             {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
-            {submitting ? "Saving…" : info?.remote_url ? "Update source" : "Set source"}
+            {submitting ? "Saving…" : sourceConfigured ? "Update source" : "Set source"}
           </button>
         </div>
       </div>

--- a/services/prism-service/docker-compose.v51.yml
+++ b/services/prism-service/docker-compose.v51.yml
@@ -1,14 +1,17 @@
-# Parallel preview of v5.1.7 (delete-projects + lock fix + claude CLI
-# in container + run-log observability) without disturbing the operator's
-# primary instance on 7777/7778.
+# Parallel preview of v5.2.0 (folder mode + bind-mount host claude auth)
+# without disturbing the operator's primary instance on 7777/7778.
 #
 # Run:
 #   docker compose -p prism-v51 \
 #     -f services/prism-service/docker-compose.v51.yml up -d --build
 #
-# One-time auth (v5.1.7 — claude CLI is bundled in the image):
-#   docker exec -it prism-service-v51 claude login
-#   # Tokens land in ./data-v51/.claude-config, survive container swaps.
+# v5.2.0 — no `claude login` needed in the container. The host's
+# existing ~/.claude is bind-mounted in, so the container's claude
+# uses the same OAuth tokens the host already has.
+#
+# Add a project: SPA Settings → Projects → "+ new" → type a folder
+# path like /code/<repo-name> (the /code dir is bind-mounted from
+# your host's PRISM_CODE_DIR, defaulting to ${HOME}/code).
 #
 # Then:
 #   UI  -> http://localhost:8888
@@ -28,20 +31,15 @@ services:
       - "8888:7778"   # UI
       - "8887:7777"   # MCP
     volumes:
-      # Isolated data dir so the v5.1.7 preview never writes into the
-      # primary instance's brain.db / graph.db / understand_state /
-      # .claude-config (so `claude login` here doesn't touch your prod
-      # auth, and a `claude login` on prod doesn't bleed in here).
       - ./data-v51:/data
+      # v5.2.0 — host claude auth shared into the container.
+      - ${PRISM_CLAUDE_HOME:-${HOME:-${USERPROFILE}}/.claude}:/root/.claude
+      # v5.2.0 — host code dir mounted so projects can point at /code/<repo>
+      # without server-side cloning.
+      - ${PRISM_CODE_DIR:-${HOME:-${USERPROFILE}}/code}:/code:ro
     environment:
       - PRISM_DATA_DIR=/data
-      # v5.1.7 — claude CLI uses this dir for OAuth tokens. Lives inside
-      # the data volume so `docker exec ... claude login` only has to
-      # run once per install.
-      - CLAUDE_CONFIG_DIR=/data/.claude-config
-      # Surfaces the friendly container name in /api/claude-auth/status
-      # so the SPA can print a clean `docker exec -it prism-service-v51
-      # claude /login` instead of the random short ID.
+      - CLAUDE_CONFIG_DIR=/root/.claude
       - PRISM_CONTAINER_NAME=prism-service-v51
       - NICEGUI_STORAGE_PATH=/data/.nicegui
       - PRISM_EMBEDDER=${PRISM_EMBEDDER:-minilm}

--- a/services/prism-service/docker-compose.yml
+++ b/services/prism-service/docker-compose.yml
@@ -6,22 +6,24 @@ services:
       - "7777:7777"
     volumes:
       - ./data:/data
+      # v5.2.0 — bind-mount the host's existing Claude Code install.
+      # The container's `claude` reads the same OAuth credentials your
+      # host's `claude` already has from `claude login`. No setup inside
+      # the container, no key juggling. RW so token refresh writes back
+      # (8h access tokens rotate via the refresh token in the same file).
+      #
+      # Override the host path if your claude config lives elsewhere:
+      #   PRISM_CLAUDE_HOME=/path/to/.claude docker compose up
+      - ${PRISM_CLAUDE_HOME:-${HOME:-${USERPROFILE}}/.claude}:/root/.claude
+      # v5.2.0 — bind-mount the parent dir that holds your code. In the
+      # SPA's Settings → Projects, point at /code/<repo-name> and PRISM
+      # analyzes it where it lives. No clone, no git auth needed in the
+      # container (your host already has it).
+      - ${PRISM_CODE_DIR:-${HOME:-${USERPROFILE}}/code}:/code:ro
     environment:
       - PRISM_DATA_DIR=/data
-      # Claude CLI auth — borrowed from Auto-Claude's CLAUDE_CONFIG_DIR
-      # pattern (apps/desktop/src/main/claude-profile-manager.ts:541).
-      # Point Claude at a directory INSIDE the /data volume so its OAuth
-      # tokens (access + refresh) persist across container swaps and
-      # Watchtower upgrades. ONE-TIME setup:
-      #
-      #     docker exec -it prism-service claude login
-      #
-      # Then never again — the CLI auto-refreshes access tokens (8h
-      # expiry) against console.anthropic.com using the long-lived
-      # refresh token, both stored in /data/.claude-config. No host
-      # bind-mount, no host `claude` install required, INV-1 preserved
-      # (this is your subscription, not an API key).
-      - CLAUDE_CONFIG_DIR=${CLAUDE_CONFIG_DIR:-/data/.claude-config}
+      # v5.2.0 — claude reads creds from the bind-mounted host config dir.
+      - CLAUDE_CONFIG_DIR=/root/.claude
       # Surfaces the friendly container name in /api/claude-auth/status
       # so the SPA can print `docker exec -it <name> claude /login`
       # instead of the random short ID. Override per install.

--- a/services/prism-service/tests/unit/test_folder_mode.py
+++ b/services/prism-service/tests/unit/test_folder_mode.py
@@ -1,0 +1,176 @@
+"""Folder-mode projects — v5.2.0.
+
+Validates that a project can be configured via `source_path` (bind-mounted
+folder) instead of `remote_url` (server-side clone). Isolated via
+tmp_path + monkeypatched PROJECTS_DIR so nothing writes to /data.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app import config
+from app.api import projects as projects_api
+from app.api import understand as understand_api
+from app.engines import understand_engine as ue
+from app.services import source_service as ss
+
+
+@pytest.fixture
+def isolated_projects_root(tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(projects_api, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(projects_api, "DEFAULT_PROJECT", "default")
+    ss._LOCKS.clear()
+    return tmp_path / "projects"
+
+
+@pytest.fixture
+def code_folder(tmp_path: Path) -> Path:
+    """A bind-mount-style folder with a tiny git repo inside."""
+    code = tmp_path / "code" / "demo"
+    code.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", "--initial-branch=main"],
+                   cwd=str(code), check=True)
+    subprocess.run(["git", "config", "user.email", "x@x"], cwd=str(code), check=True)
+    subprocess.run(["git", "config", "user.name", "x"], cwd=str(code), check=True)
+    (code / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=str(code), check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"],
+                   cwd=str(code), check=True)
+    return code
+
+
+def test_set_source_path_records_state(isolated_projects_root, code_folder):
+    config.project_data_dir("folder-proj")  # seed state.json
+    out = ss.set_source_path("folder-proj", str(code_folder))
+
+    assert out["mode"] == "folder"
+    assert Path(out["source_path"]).resolve() == code_folder.resolve()
+    assert out["head_sha"]  # git repo, so head_sha is populated
+
+    state = ue._read_state("folder-proj")
+    assert state["source_path"] == str(code_folder.resolve())
+    assert state["mode"] == "folder"
+
+
+def test_set_source_path_rejects_missing_dir(isolated_projects_root, tmp_path):
+    config.project_data_dir("missing-proj")
+    with pytest.raises(ss.SourceUnavailable):
+        ss.set_source_path("missing-proj", str(tmp_path / "does-not-exist"))
+
+
+def test_source_dir_for_returns_bind_mount(isolated_projects_root, code_folder):
+    config.project_data_dir("p")
+    ss.set_source_path("p", str(code_folder))
+    assert ss.source_dir_for("p").resolve() == code_folder.resolve()
+
+
+def test_source_dir_for_falls_back_to_clone_path_when_no_source_path(
+    isolated_projects_root,
+):
+    config.project_data_dir("clone-proj")
+    expected = isolated_projects_root / "clone-proj" / "source"
+    assert ss.source_dir_for("clone-proj").resolve() == expected.resolve()
+
+
+def test_is_cloned_true_for_folder_mode(isolated_projects_root, code_folder):
+    config.project_data_dir("p")
+    ss.set_source_path("p", str(code_folder))
+    assert ss.is_cloned("p") is True
+
+
+def test_current_sha_returns_git_head_in_folder_mode(
+    isolated_projects_root, code_folder,
+):
+    config.project_data_dir("p")
+    ss.set_source_path("p", str(code_folder))
+    sha = ss.current_sha("p")
+    # git rev-parse HEAD output is 40 hex chars
+    assert len(sha) == 40
+    assert all(c in "0123456789abcdef" for c in sha)
+
+
+def test_current_sha_synthesizes_fingerprint_for_non_git_folder(
+    isolated_projects_root, tmp_path,
+):
+    plain_dir = tmp_path / "plain"
+    plain_dir.mkdir()
+    (plain_dir / "a.py").write_text("# a", encoding="utf-8")
+    (plain_dir / "b.py").write_text("# b", encoding="utf-8")
+
+    config.project_data_dir("p")
+    ss.set_source_path("p", str(plain_dir))
+    sha = ss.current_sha("p")
+    assert len(sha) == 64  # sha256 hex
+    # Same fingerprint when called twice with no changes.
+    assert ss.current_sha("p") == sha
+
+
+def test_post_projects_with_source_path_skips_clone(
+    isolated_projects_root, code_folder, monkeypatch,
+):
+    """The /api/projects POST with source_path must NOT call ensure_cloned."""
+    called = []
+    monkeypatch.setattr(
+        ss, "ensure_cloned",
+        lambda *a, **kw: called.append(("ensure_cloned", a, kw)) or None,
+    )
+    monkeypatch.setattr(
+        ss, "bootstrap_after_clone",
+        lambda *a, **kw: None,
+    )
+
+    body = projects_api.CreateBody(name="folder-via-api", source_path=str(code_folder))
+    out = projects_api.create_project(body)
+
+    assert out["mode"] == "folder"
+    assert out["source_path"] == str(code_folder)
+    assert out["bootstrap"] == "started"
+    assert called == []  # never tried to clone
+
+
+def test_post_projects_rejects_both_source_path_and_remote_url(
+    isolated_projects_root, code_folder,
+):
+    from fastapi import HTTPException
+    body = projects_api.CreateBody(
+        name="conflicted",
+        source_path=str(code_folder),
+        remote_url="https://github.com/x/y",
+    )
+    with pytest.raises(HTTPException) as ei:
+        projects_api.create_project(body)
+    assert ei.value.status_code == 400
+    assert "either" in str(ei.value.detail).lower()
+
+
+def test_understand_configure_folder_mode(
+    isolated_projects_root, code_folder, monkeypatch,
+):
+    """POST /api/understand/configure with source_path takes the folder path."""
+    monkeypatch.setattr(ss, "bootstrap_after_clone", lambda *a, **kw: None)
+    config.project_data_dir("cfg-proj")
+
+    body = understand_api.ConfigureBody(source_path=str(code_folder))
+    out = understand_api.configure(body, project="cfg-proj")
+
+    assert out["configured"] is True
+    assert out["mode"] == "folder"
+    assert Path(out["source_path"]).resolve() == code_folder.resolve()
+
+
+def test_status_surfaces_mode_and_source_path(
+    isolated_projects_root, code_folder,
+):
+    config.project_data_dir("status-proj")
+    ss.set_source_path("status-proj", str(code_folder))
+
+    status = ue.UnderstandEngine("status-proj").status()
+    assert status["mode"] == "folder"
+    assert Path(status["source_path"]).resolve() == code_folder.resolve()
+    assert status["remote_url"] is None
+    assert status["current_sha"]


### PR DESCRIPTION
## Summary

Customer setup collapses to one paste. No `claude /login`, no GitHub credentials, no server-side clone.

### What ships

**Local folder mode** — primary way to add a project in v5.2.0.

- Customer bind-mounts their code dir into `/code` via docker-compose (default `${HOME}/code` → `/code`). Compose template ships with the mount baked in.
- In Settings, the project editor has a **Local folder / Git URL** toggle. Folder is the new default. Customer types a container-side path like `/code/my-repo` and PRISM analyzes the bind-mount where it lives.
- `source_service`: new `set_source_path()`, folder-aware `source_dir_for()` / `is_cloned()` / `current_sha()`. Non-git folders get a synthetic SHA from a directory fingerprint so drift detection still works.
- Status endpoint surfaces `mode` and `source_path` so the SPA renders the right chrome per project.

**Host claude auth via bind-mount** — no more `claude /login` inside the container.

- `docker-compose.yml` now mounts `${HOME}/.claude` → `/root/.claude` (RW so 8h access-token refresh writes back), with `CLAUDE_CONFIG_DIR` pointed at it. The container's claude uses the host's existing OAuth tokens.
- Override via `PRISM_CLAUDE_HOME` if the operator's claude config lives elsewhere; `PRISM_CODE_DIR` for the code mount path.

The v5.1 clone path (and v5.1.10–11's GitHub OAuth connect) still work unchanged. The toggle defaults to folder for new projects, preserves the existing mode for legacy projects.

### Test plan

- [x] 11 new unit tests cover the folder-mode contract end-to-end: validation, source_dir_for override, folder-vs-clone discrimination, git rev-parse, mtime fingerprint fallback, both API endpoints, status surface fields.
- [x] Full suite **363/363** passing.
- [x] SPA TSC clean.
- [x] End-to-end smoke on v5.1 preview (8888): created a folder-mode project against a real bind-mounted git repo on the host, confirmed `mode=folder`, `head_sha` resolved via git rev-parse, bootstrap fired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)