### PR TITLE
v5.2.2: Connections honest about required vs optional

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,17 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.2.1"
+PRISM_VERSION = "5.2.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.2.2: Settings -> Connections is now honest about what's required "
+    "vs optional. Claude OAuth carries a `required` pill (analyzers + Q&A "
+    "need it). GitHub carries an `optional` pill plus inline copy saying "
+    "you can skip it entirely if you're using folder mode (the v5.2.0 "
+    "default) - your host already has git auth and PRISM reads via the "
+    "bind-mount. Connect only if you want PRISM to clone private repos "
+    "server-side or use the `Browse my repos` picker. "
     "v5.2.1: Fix /understand empty-state. Used to say 'Use Add project in "
     "the top bar' but there is no such button — replaced with a clear "
     "two-mode explainer (Local folder + Git URL) and a `Configure '<name>' "

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.2.1",
+  "version": "5.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/app/web/src/pages/SettingsPage.tsx
@@ -18,7 +18,7 @@ const SECTION_META: Record<SectionId, { title: string; description: string }> = 
   },
   connections: {
     title: "Connections",
-    description: "Claude OAuth subscription and GitHub access for private-repo clones.",
+    description: "Claude OAuth (required for analyzers and Q&A). GitHub is optional — only needed if PRISM clones repos server-side; folder-mode projects use your host's git auth via the bind-mount.",
   },
   jobs: {
     title: "Jobs",
@@ -196,11 +196,35 @@ export default function SettingsPage() {
       {section === "connections" && (
         <div className="space-y-6">
           <Card>
-            <SectionLabel>Claude</SectionLabel>
+            <div className="flex items-center gap-3 mb-3">
+              <SectionLabel>Claude</SectionLabel>
+              <span className="text-[9px] uppercase tracking-wider px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-200">
+                required
+              </span>
+              <span className="text-[11px] opacity-60">
+                analyzers and ask-the-knowledge queries use your OAuth subscription
+              </span>
+            </div>
             <ClaudeAuthCard />
           </Card>
           <Card>
-            <SectionLabel>GitHub</SectionLabel>
+            <div className="flex items-center gap-3 mb-3">
+              <SectionLabel>GitHub</SectionLabel>
+              <span className="text-[9px] uppercase tracking-wider px-2 py-0.5 rounded-full bg-[color:var(--midground-base)]/15 text-[color:var(--midground-base)]">
+                optional
+              </span>
+              <span className="text-[11px] opacity-60">
+                only needed if PRISM clones repos server-side
+              </span>
+            </div>
+            <p className="text-[11px] opacity-60 leading-snug mb-3">
+              Skip this if you're using <span className="font-medium">folder
+              mode</span> (the v5.2.0 default) — your host already has git
+              auth and PRISM reads files via the bind-mount, no cloning
+              needed. Connect only if you want PRISM to <span className="font-medium">
+              clone private repos for you</span> or use the <span className="font-medium">Browse
+              my repos</span> picker in the project editor.
+            </p>
             <GithubAuthCard />
           </Card>
         </div>


### PR DESCRIPTION
Fixes the confusing UX where GitHub connect looked equally required as Claude OAuth. In v5.2.0 folder mode (the new default) GitHub is irrelevant — host has git auth. Added required/optional pills + inline copy. UI-only.