### PR TITLE
v5.2.4: layer + domain graph palette — real hue variation

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,18 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.2.3"
+PRISM_VERSION = "5.2.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.2.4: Layer + domain graph palette refresh. Both PrismLayerNode "
+    "and PrismDomainNode used to keep all swatches inside the cool "
+    "blue-grey family, so a 10-layer architecture graph read as one "
+    "blob. Replaced with 8 hue-distinct colors (steel, teal, sage, "
+    "amber, coral, lavender, rose, warm grey) at muted saturation that "
+    "still sits on the Slate Blue dark theme. Domains use the same "
+    "hues lifted in lightness so parent cards visually outrank their "
+    "child layers. "
     "v5.2.3: GitHub connect off the Connections page entirely. The "
     "Connections section (now `Claude auth` in the sidebar) holds only "
     "Claude OAuth, which IS required. GitHub connect moved into the "

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.2.3",
+  "version": "5.2.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/app/web/src/components/understand/PrismDomainNode.tsx
+++ b/services/prism-service/app/web/src/components/understand/PrismDomainNode.tsx
@@ -18,17 +18,19 @@ export interface PrismDomainNodeData extends Record<string, unknown> {
 
 export type PrismDomainFlowNode = Node<PrismDomainNodeData, "prism-domain">;
 
-// Slate Blue palette — paired companion set to PrismLayerNode.PALETTE
-// so the two views read as the same theme even when shown side by
-// side. Slightly lifted L for the domain (parent) tier so domain
-// cards visually outrank the layer cards underneath them.
+// Domain palette — companion to PrismLayerNode.PALETTE. Same multi-hue
+// family as v5.2.4's layer refresh, but each domain swatch is slightly
+// lifted in lightness so domain (parent) cards visually outrank the
+// layer (child) cards underneath them.
 const DOMAIN_PALETTE = [
-  { border: "rgba(100,135,180,0.55)", bg: "rgba(100,135,180,0.10)", dot: "#6487b4" },
-  { border: "rgba(125,165,195,0.55)", bg: "rgba(125,165,195,0.10)", dot: "#7da5c3" },
-  { border: "rgba(85,115,150,0.55)",  bg: "rgba(85,115,150,0.10)",  dot: "#557396" },
-  { border: "rgba(115,155,170,0.55)", bg: "rgba(115,155,170,0.10)", dot: "#739baa" },
-  { border: "rgba(150,170,195,0.55)", bg: "rgba(150,170,195,0.10)", dot: "#96aac3" },
-  { border: "rgba(95,140,170,0.55)",  bg: "rgba(95,140,170,0.10)",  dot: "#5f8caa" },
+  { border: "rgba(100,150,180,0.55)", bg: "rgba(100,150,180,0.10)", dot: "#6496b4" },  // steel blue (lifted)
+  { border: "rgba(115,190,200,0.55)", bg: "rgba(115,190,200,0.10)", dot: "#73bec8" },  // teal (lifted)
+  { border: "rgba(140,190,150,0.55)", bg: "rgba(140,190,150,0.10)", dot: "#8cbe96" },  // sage (lifted)
+  { border: "rgba(220,190,110,0.55)", bg: "rgba(220,190,110,0.10)", dot: "#dcbe6e" },  // amber (lifted)
+  { border: "rgba(235,155,130,0.55)", bg: "rgba(235,155,130,0.10)", dot: "#eb9b82" },  // coral (lifted)
+  { border: "rgba(190,160,215,0.55)", bg: "rgba(190,160,215,0.10)", dot: "#bea0d7" },  // lavender (lifted)
+  { border: "rgba(225,150,180,0.55)", bg: "rgba(225,150,180,0.10)", dot: "#e196b4" },  // rose (lifted)
+  { border: "rgba(180,170,155,0.55)", bg: "rgba(180,170,155,0.10)", dot: "#b4aa9b" },  // warm grey (lifted)
 ];
 export const prismDomainColor = (i: number) => DOMAIN_PALETTE[i % DOMAIN_PALETTE.length];
 

--- a/services/prism-service/app/web/src/components/understand/PrismLayerNode.tsx
+++ b/services/prism-service/app/web/src/components/understand/PrismLayerNode.tsx
@@ -25,18 +25,21 @@ export interface PrismLayerNodeData extends Record<string, unknown> {
 
 export type PrismLayerFlowNode = Node<PrismLayerNodeData, "prism-layer">;
 
-// Slate Blue palette — all swatches sit in the cool blue-grey hue
-// family so the layer cards harmonize with the new background tokens.
-// Variation comes from L+S rather than hue so 7 layers stay
-// distinguishable without breaking the "one theme" read.
+// Layer palette — v5.2.4 refresh. Previous version sat all 7 swatches
+// inside the cool blue-grey family (Slate Blue theme harmony) but that
+// made every layer read identically in practice — a 10-layer architecture
+// graph looked like one blob. New palette gives each layer a real hue
+// while keeping saturation tasteful for the dark theme (each ~L65/C25 in
+// OKLCH terms — distinct but never crayon-bright).
 const PALETTE = [
   { border: "rgba(74,124,155,0.55)",  bg: "rgba(74,124,155,0.10)",  dot: "#4a7c9b" },  // steel blue
-  { border: "rgba(110,150,190,0.55)", bg: "rgba(110,150,190,0.10)", dot: "#6e96be" },  // sky blue
-  { border: "rgba(140,165,200,0.55)", bg: "rgba(140,165,200,0.10)", dot: "#8ca5c8" },  // periwinkle
-  { border: "rgba(95,170,180,0.55)",  bg: "rgba(95,170,180,0.10)",  dot: "#5faab4" },  // teal blue
-  { border: "rgba(130,140,165,0.55)", bg: "rgba(130,140,165,0.10)", dot: "#828ca5" },  // grey blue
-  { border: "rgba(75,110,140,0.55)",  bg: "rgba(75,110,140,0.10)",  dot: "#4b6e8c" },  // navy blue
-  { border: "rgba(160,180,200,0.55)", bg: "rgba(160,180,200,0.10)", dot: "#a0b4c8" },  // silver blue
+  { border: "rgba(95,170,180,0.55)",  bg: "rgba(95,170,180,0.10)",  dot: "#5faab4" },  // teal
+  { border: "rgba(120,170,130,0.55)", bg: "rgba(120,170,130,0.10)", dot: "#78aa82" },  // sage green
+  { border: "rgba(200,170,90,0.55)",  bg: "rgba(200,170,90,0.10)",  dot: "#c8aa5a" },  // amber
+  { border: "rgba(220,135,110,0.55)", bg: "rgba(220,135,110,0.10)", dot: "#dc876e" },  // coral
+  { border: "rgba(170,140,200,0.55)", bg: "rgba(170,140,200,0.10)", dot: "#aa8cc8" },  // lavender
+  { border: "rgba(210,130,165,0.55)", bg: "rgba(210,130,165,0.10)", dot: "#d282a5" },  // rose
+  { border: "rgba(160,150,135,0.55)", bg: "rgba(160,150,135,0.10)", dot: "#a09687" },  // warm grey
 ];
 export const prismLayerColor = (i: number) => PALETTE[i % PALETTE.length];
 


### PR DESCRIPTION
Architecture graph was 'too blue' — every layer rendered in the same blue-grey family so a 10-layer graph read as one blob. Replaced both layer and domain palettes with 8 hue-distinct colors (steel, teal, sage, amber, coral, lavender, rose, warm grey) at muted saturation that still works on the slate-dark theme. UI-only.