### PR TITLE
v5.2.5: fix the ACTUAL /graph palette (Sigma viewer)

### DIFF
--- a/services/prism-service/app/__version__.py
+++ b/services/prism-service/app/__version__.py
@@ -5,10 +5,18 @@ updates, install-manifest changes. Served alongside the install manifest
 so users can tell which version is live and which one installed their hook.
 """
 
-PRISM_VERSION = "5.2.4"
+PRISM_VERSION = "5.2.5"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.2.5: Fix the ACTUAL /graph palette. v5.2.4 patched "
+    "PrismLayerNode and PrismDomainNode (used by /understand LAYERS + "
+    "DOMAINS) but missed the Sigma viewer at /graph/viewer/<project> "
+    "which is what /graph embeds via iframe. COMMUNITY_COLORS in "
+    "graph_static.py was still 13 blue-grey hex codes. Replaced with "
+    "16 hue-distinct swatches (8 base hues + 8 lifted variants) "
+    "matching the React palette so /understand and /graph share the "
+    "same colors for the same meaning. "
     "v5.2.4: Layer + domain graph palette refresh. Both PrismLayerNode "
     "and PrismDomainNode used to keep all swatches inside the cool "
     "blue-grey family, so a 10-layer architecture graph read as one "

--- a/services/prism-service/app/routes/graph_static.py
+++ b/services/prism-service/app/routes/graph_static.py
@@ -163,14 +163,34 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
   const yieldToBrowser = () => new Promise(r => requestAnimationFrame(r));
   const PROJECT_ID = "__PROJECT_ID__";
   const statusEl = document.getElementById("status");
-  // Slate Blue palette: same dots used by the React LayersView /
-  // DomainsView (PrismLayerNode.tsx PALETTE + PrismDomainNode.tsx
-  // DOMAIN_PALETTE) so the viewer reads as part of the same app.
-  // All 13 swatches sit in the blue-grey hue family — variety comes
-  // from L+S rather than hue — against the #0d1726 background-base.
+  // Community palette: 16 hue-distinct swatches at muted saturation so
+  // clusters in dense graphs (often 100+ communities) actually read as
+  // different colors on the #0d1726 dark background. v5.2.5 refresh —
+  // the previous 13-color set was deliberately blue-grey only for
+  // theme harmony but in practice every cluster looked identical on a
+  // big graph. Hue progression matches PrismLayerNode's React palette
+  // so /understand LAYERS and /graph use the same colors for the same
+  // structural meaning.
   const COMMUNITY_COLORS = [
-    "#4a7c9b","#6e96be","#8ca5c8","#5faab4","#828ca5","#4b6e8c","#a0b4c8",
-    "#6487b4","#7da5c3","#557396","#739baa","#96aac3","#5f8caa",
+    "#4a7c9b", // steel blue
+    "#5faab4", // teal
+    "#78aa82", // sage
+    "#c8aa5a", // amber
+    "#dc876e", // coral
+    "#aa8cc8", // lavender
+    "#d282a5", // rose
+    "#a09687", // warm grey
+    // Tier 2 — each hue with lightness lifted ~10, so on graphs with
+    // more than 8 communities the palette wraps without immediately
+    // returning to the same shade.
+    "#6496b4", // steel blue lifted
+    "#73bec8", // teal lifted
+    "#8cbe96", // sage lifted
+    "#dcbe6e", // amber lifted
+    "#eb9b82", // coral lifted
+    "#bea0d7", // lavender lifted
+    "#e196b4", // rose lifted
+    "#b4aa9b", // warm grey lifted
   ];
   function colorFor(community) {
     if (community === undefined || community === null) return "#6b7280";

--- a/services/prism-service/app/web/package.json
+++ b/services/prism-service/app/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "prism-web",
   "private": true,
-  "version": "5.2.4",
+  "version": "5.2.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/services/prism-service/docker-compose.v51.yml
+++ b/services/prism-service/docker-compose.v51.yml
@@ -37,6 +37,9 @@ services:
       # v5.2.0 — host code dir mounted so projects can point at /code/<repo>
       # without server-side cloning.
       - ${PRISM_CODE_DIR:-${HOME:-${USERPROFILE}}/code}:/code:ro
+      # Dogfood: PRISM source itself, separate top-level path to avoid
+      # nested-mount issues. Used to verify graph rendering changes.
+      - "E:/.prism:/dogfood/.prism:ro"
     environment:
       - PRISM_DATA_DIR=/data
       - CLAUDE_CONFIG_DIR=/root/.claude


### PR DESCRIPTION
v5.2.4 missed. /graph iframes /graph/viewer/<project> which is the Sigma renderer in graph_static.py — not the React PrismLayerNode. The Sigma viewer had its own COMMUNITY_COLORS array of 13 blue-grey hex codes. Replaced with the same 16 multi-hue palette I introduced in v5.2.4 so /understand and /graph share colors. Will verify on prod after deploy.