### PR TITLE
fix(v5.3.20): embedder tqdm race + trash sweeper log spam

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -8,10 +8,30 @@ bumping the patch, the user can't tell they got the new code — fix
 that habit, not the version number.
 """
 
-PRISM_VERSION = "5.3.17"
+PRISM_VERSION = "5.3.20"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v5.3.20: Startup hardening. Two regressions that user hit locally "
+    "fixed before ship: (1) Brain embedder load is now serialized with "
+    "a module-level threading.Lock so concurrent Brain.__init__ from "
+    "the drift timer + MCP tools + lifespan can't both race past the "
+    "`_MODEL is None` check, both fetch from HuggingFace, and race tqdm's "
+    "class state (`'tqdm' object has no attribute '_lock'` → one worker "
+    "silently dropped to BM25+GraphRAG only). Also sets "
+    "HF_HUB_DISABLE_PROGRESS_BARS=1 and TQDM_DISABLE=1 at brain_engine "
+    "import — server processes never show those bars to anyone and they "
+    "were the proximate cause of the race. (2) Trash sweeper "
+    "`[trash] <name>: still locked, will retry` no longer logs every 30s "
+    "for the lifetime of the process. Per-entry attempt counter logs the "
+    "warning once on first failure, stays quiet through subsequent "
+    "sweeps, and re-logs loudly once at ~1h (PRISM_TRASH_SWEEP_INTERVAL × "
+    "120) so the user knows to close the tool still holding the dir. "
+    "Successful cleanup after a prior lock logs `cleaned after retry` so "
+    "the recovery is visible. New tests/unit/test_trash_sweeper.py and "
+    "test_embedder_concurrent_load.py pin both behaviors. "
+    "v5.3.19: (skipped, local build) "
+    "v5.3.18: (skipped, local build) "
     "v5.3.17: Tauri shell auto-update wired. New "
     ".github/workflows/release-tauri.yml builds signed bundles for "
     "macOS (arm64 + x64), Windows, and Linux on every `v*` tag push, "

--- a/services/prism-service/prism_service/engines/brain_engine.py
+++ b/services/prism-service/prism_service/engines/brain_engine.py
@@ -15,11 +15,22 @@ from __future__ import annotations
 
 import ctypes
 import json
+import os
 import re
 import sqlite3
 import subprocess
 import sys
+import threading
 import warnings
+
+# Embedder downloads pull HuggingFace files behind a tqdm progress bar.
+# Under concurrent Brain init (drift timer + MCP tools + lifespan) tqdm's
+# class-level state races and one thread fails the load with
+# `'tqdm' object has no attribute '_lock'`. Server processes never show
+# the bars to anyone — silence them before model2vec/sentence-transformers
+# pulls tqdm in.
+os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
+os.environ.setdefault("TQDM_DISABLE", "1")
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -139,6 +150,7 @@ def _similar_task_ids(
 # Optional dependency detection
 # ---------------------------------------------------------------------------
 _MODEL = None
+_MODEL_LOCK = threading.Lock()
 _SQLITE_VEC_LOADED = False
 
 # Cross-encoder reranker (lazy-loaded on first use when PRISM_RERANK != off).
@@ -441,21 +453,24 @@ def _try_enable_vector(db: sqlite3.Connection) -> bool:
         preset = "potion"
     backend, model_id = _EMBEDDER_PRESETS[preset]
 
-    if _MODEL is not None:
-        return True  # already loaded (same process reuse)
-
-    try:
-        if backend == "model2vec":
-            _MODEL = _load_model2vec(model_id)
-        elif backend == "sentence-transformers":
-            _MODEL = _load_sentence_transformer(model_id)
-        print(f"Brain: embedder = {preset} ({backend}: {model_id})",
-              file=sys.stderr)
-        return True
-    except Exception as e:
-        print(f"Brain: embedder load failed ({preset}: {e!r}); BM25+GraphRAG only",
-              file=sys.stderr)
-        return False
+    # Serialize the load so two threads can't both decide _MODEL is None
+    # and both fetch from HuggingFace at once — that's how tqdm's class
+    # state races and one of them logs "embedder load failed".
+    with _MODEL_LOCK:
+        if _MODEL is not None:
+            return True  # already loaded (same process reuse)
+        try:
+            if backend == "model2vec":
+                _MODEL = _load_model2vec(model_id)
+            elif backend == "sentence-transformers":
+                _MODEL = _load_sentence_transformer(model_id)
+            print(f"Brain: embedder = {preset} ({backend}: {model_id})",
+                  file=sys.stderr)
+            return True
+        except Exception as e:
+            print(f"Brain: embedder load failed ({preset}: {e!r}); BM25+GraphRAG only",
+                  file=sys.stderr)
+            return False
 
 
 # ---------------------------------------------------------------------------

--- a/services/prism-service/prism_service/services/trash.py
+++ b/services/prism-service/prism_service/services/trash.py
@@ -54,33 +54,57 @@ def is_deleted(project_dir: Path) -> bool:
     return (project_dir / MARKER_NAME).is_file()
 
 
+# Track sweep attempts per entry so we log the first "still locked" warning
+# loud, then stay quiet until either the entry is cleaned or we hit
+# _LOUD_RETRY_AT (at which point we log once more — the user has probably
+# left a tool open and should know). Cleared when the entry is gone.
+_LOCK_ATTEMPTS: dict[str, int] = {}
+_LOUD_RETRY_AT = 120  # ~1h at the default 30s interval
+
+
 def sweep_once() -> int:
     """Best-effort rmtree pass over every `.deleted`-marked project.
-    PermissionError is logged but skipped — the next sweep retries.
-    Returns the number of dirs actually removed."""
+    PermissionError is logged once per entry — subsequent passes stay
+    quiet so the log doesn't spam every 30s. Returns the count cleaned."""
     if not PROJECTS_DIR.is_dir():
         return 0
     cleaned = 0
+    live_names: set[str] = set()
     for entry in PROJECTS_DIR.iterdir():
         if not entry.is_dir():
             continue
         if not is_deleted(entry):
             continue
+        live_names.add(entry.name)
         try:
             shutil.rmtree(entry)
             cleaned += 1
+            if _LOCK_ATTEMPTS.pop(entry.name, 0):
+                print(
+                    f"[trash] {entry.name}: cleaned after retry",
+                    file=sys.stderr, flush=True,
+                )
         except PermissionError as e:
-            print(
-                f"[trash] {entry.name}: still locked, will retry ({e})",
-                file=sys.stderr, flush=True,
-            )
+            n = _LOCK_ATTEMPTS.get(entry.name, 0) + 1
+            _LOCK_ATTEMPTS[entry.name] = n
+            if n == 1 or n == _LOUD_RETRY_AT:
+                suffix = "" if n == 1 else f" (still after {n} sweeps — close any tool holding this dir)"
+                print(
+                    f"[trash] {entry.name}: still locked, will retry ({e}){suffix}",
+                    file=sys.stderr, flush=True,
+                )
         except FileNotFoundError:
             cleaned += 1
+            _LOCK_ATTEMPTS.pop(entry.name, None)
         except OSError as e:
             print(
                 f"[trash] unexpected error on {entry.name}: {e}",
                 file=sys.stderr, flush=True,
             )
+    # Drop tracking for entries no longer present (cleaned by another path,
+    # or the marker was removed externally).
+    for stale in [k for k in _LOCK_ATTEMPTS if k not in live_names]:
+        _LOCK_ATTEMPTS.pop(stale, None)
     return cleaned
 
 

--- a/services/prism-service/tests/unit/test_embedder_concurrent_load.py
+++ b/services/prism-service/tests/unit/test_embedder_concurrent_load.py
@@ -1,0 +1,80 @@
+"""Embedder load is serialized across threads.
+
+Without the lock added in v5.3.18 two Brain.__init__ calls on different
+threads could both observe `_MODEL is None`, both call _load_model2vec,
+and both kick a HuggingFace download — racing tqdm's class state and
+failing one of the loads with `'tqdm' object has no attribute '_lock'`.
+
+This test fires N concurrent _try_enable_vector calls against a fake
+loader that records its call count; the loader must be invoked exactly
+once.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+
+import pytest
+
+from prism_service.engines import brain_engine as be
+
+
+class _FakeModel:
+    def encode(self, _):
+        return [[0.1] * 8]
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    monkeypatch.setattr(be, "_MODEL", None)
+    monkeypatch.setattr(be, "_SQLITE_VEC_LOADED", False)
+
+
+def test_loader_called_once_under_thread_race(monkeypatch):
+    call_count = {"n": 0}
+
+    def _slow_loader(_model_id):
+        # Sleep so threads pile up at the lock; without the lock both
+        # would race past the `_MODEL is None` check and increment.
+        call_count["n"] += 1
+        time.sleep(0.05)
+        return _FakeModel()
+
+    monkeypatch.setattr(be, "_load_model2vec", _slow_loader)
+
+    # Pretend sqlite_vec succeeded so we reach the model load.
+    class _DummyVec:
+        @staticmethod
+        def load(_db):
+            pass
+
+    monkeypatch.setitem(__import__("sys").modules, "sqlite_vec", _DummyVec)
+
+    def _worker():
+        db = sqlite3.connect(":memory:")
+        try:
+            db.enable_load_extension(True)
+        except Exception:
+            pass
+        be._try_enable_vector(db)
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert call_count["n"] == 1, (
+        f"expected exactly one model load under thread race, got {call_count['n']}"
+    )
+    assert be._MODEL is not None
+
+
+def test_tqdm_progress_bars_disabled_at_module_import():
+    import os
+    # Set at module import (top of brain_engine.py) so HuggingFace + tqdm
+    # see them before any worker fetches a model.
+    assert os.environ.get("HF_HUB_DISABLE_PROGRESS_BARS") == "1"
+    assert os.environ.get("TQDM_DISABLE") == "1"

--- a/services/prism-service/tests/unit/test_trash_sweeper.py
+++ b/services/prism-service/tests/unit/test_trash_sweeper.py
@@ -1,0 +1,96 @@
+"""Trash sweeper: once-only "still locked" logging.
+
+The old sweep_once() logged on every pass — every 30s for the lifetime
+of the process if the file stayed locked (Windows + open SQLite handle).
+This test pins the new behavior: log once on first failure, stay quiet,
+log once again on success.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from prism_service import config
+from prism_service.services import trash
+
+
+@pytest.fixture
+def isolated_projects_root(tmp_path, monkeypatch):
+    proj_root = tmp_path / "projects"
+    proj_root.mkdir()
+    monkeypatch.setattr(config, "PROJECTS_DIR", proj_root)
+    monkeypatch.setattr(trash, "PROJECTS_DIR", proj_root)
+    trash._LOCK_ATTEMPTS.clear()
+    return proj_root
+
+
+def _seed_marked(root: Path, name: str) -> Path:
+    pdir = root / name
+    pdir.mkdir()
+    (pdir / "data.txt").write_text("x", encoding="utf-8")
+    trash.mark_deleted(pdir)
+    return pdir
+
+
+def test_locked_entry_logs_once_across_sweeps(isolated_projects_root, monkeypatch, capsys):
+    _seed_marked(isolated_projects_root, "locked-one")
+
+    def _raise(path):
+        raise PermissionError(f"[WinError 5] Access is denied: {path!r}")
+
+    monkeypatch.setattr(shutil, "rmtree", _raise)
+
+    trash.sweep_once()
+    trash.sweep_once()
+    trash.sweep_once()
+
+    err = capsys.readouterr().err
+    # First sweep logs the warning; subsequent sweeps must stay quiet.
+    assert err.count("still locked") == 1, err
+
+
+def test_clean_after_lock_logs_recovery(isolated_projects_root, monkeypatch, capsys):
+    pdir = _seed_marked(isolated_projects_root, "recovers")
+
+    # First call: simulate the lock. Second call: real rmtree.
+    real_rmtree = shutil.rmtree
+    calls = {"n": 0}
+
+    def _flaky(path):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise PermissionError("locked")
+        return real_rmtree(path)
+
+    monkeypatch.setattr(shutil, "rmtree", _flaky)
+
+    trash.sweep_once()
+    assert pdir.exists()
+    cleaned = trash.sweep_once()
+
+    assert cleaned == 1
+    assert not pdir.exists()
+    err = capsys.readouterr().err
+    assert "still locked" in err
+    assert "cleaned after retry" in err
+
+
+def test_lock_attempts_clears_when_entry_disappears(isolated_projects_root, monkeypatch):
+    """If the .deleted marker is removed externally, the sweeper stops
+    seeing the entry and must drop it from _LOCK_ATTEMPTS so a future
+    re-mark starts with a fresh log."""
+    pdir = _seed_marked(isolated_projects_root, "vanishes")
+    monkeypatch.setattr(
+        shutil, "rmtree",
+        lambda p: (_ for _ in ()).throw(PermissionError("x")),
+    )
+    trash.sweep_once()
+    assert "vanishes" in trash._LOCK_ATTEMPTS
+
+    # Marker gone → entry no longer sweep-eligible.
+    (pdir / trash.MARKER_NAME).unlink()
+    trash.sweep_once()
+    assert "vanishes" not in trash._LOCK_ATTEMPTS


### PR DESCRIPTION
## Summary

Two regressions caught when starting PRISM v5.3.19 locally — fixed before they ship.

### 1. Brain embedder race
Concurrent `Brain.__init__` from drift timer + MCP tools + lifespan all hit `_try_enable_vector` → `_load_model2vec`. The `_MODEL is None` check was unguarded, so two threads could both fetch from HuggingFace at once. Parallel fetches raced tqdm's class state:

```
Brain: embedder load failed (potion: AttributeError("'tqdm' object has no attribute '_lock'")); BM25+GraphRAG only
...
Brain: embedder = potion (model2vec: minishlab/potion-base-32M)
```

One worker silently dropped to BM25+GraphRAG only — embedding search became non-deterministic per request.

**Fix:** module-level `_MODEL_LOCK = threading.Lock()` wraps the check + load + assign. `brain_engine.py` import also sets `HF_HUB_DISABLE_PROGRESS_BARS=1` + `TQDM_DISABLE=1` — server processes never show those bars to anyone and they were the proximate cause of the race surface.

### 2. Trash sweeper log spam
`[trash] <name>: still locked, will retry ([WinError 5]…)` was logged every 30s for the lifetime of the process whenever a Windows file lock outlived the sweep cadence (the user hit this on a `.git/objects/pack/*.idx` inside a soft-deleted project).

**Fix:** per-entry attempt counter logs the warning once on first failure, stays quiet through subsequent sweeps, and re-logs once at ~1h (`_LOUD_RETRY_AT × interval`) with a hint to close whatever tool is still holding the dir. Successful cleanup after a prior lock logs `cleaned after retry` so recovery is visible.

## Tests

- `tests/unit/test_embedder_concurrent_load.py` — 8 threads race `_try_enable_vector` against a fake loader; loader called exactly once.
- `tests/unit/test_trash_sweeper.py` — 3 sweeps over a locked entry produce exactly one warning; recovery path logs `cleaned after retry`.

## Test plan

- [x] New unit tests pass (`pytest tests/unit/test_trash_sweeper.py tests/unit/test_embedder_concurrent_load.py` → 5 passed)
- [x] Patched service starts cleanly on isolated ports 8887/8888
- [x] 6 concurrent `brain_search` hits all return 200
- [x] Log contains exactly one `Brain: embedder = potion (...)` line, zero tqdm tracebacks
- [x] `/api/service-info` reports `version: 5.3.20`

🤖 Generated with [Claude Code](https://claude.com/claude-code)