### PR TITLE
v5.3.24: bump past parallel-branch version collision

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -8,16 +8,16 @@ bumping the patch, the user can't tell they got the new code — fix
 that habit, not the version number.
 """
 
-PRISM_VERSION = "5.3.21"
+PRISM_VERSION = "5.3.24"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
-    "v5.3.21: Regression coverage for analyzer_runner._strip_preamble_to_"
-    "heading + _classify. The preamble-strip fix landed earlier without "
-    "tests; 16 unit tests now pin behavior across the markdown path "
-    "(h1-at-start, h1-after-prose, indented-h1, empty, no-heading-fails) "
-    "and the dict path (schema/steps/layers/domains keys, error envelope, "
-    "exit-nonzero -> partial). No logic change. "
+    "v5.3.24: Version-number cleanup. Regression coverage for "
+    "analyzer_runner._strip_preamble_to_heading + _classify (16 unit "
+    "tests, originally tagged v5.3.21 in #67) was merged after a "
+    "parallel branch had already shipped a different v5.3.21 + v5.3.22 "
+    "+ v5.3.23. Bumping past the collision to keep the footer "
+    "trustworthy. No logic change beyond the tests already on main. "
     "v5.3.20: Startup hardening. Two regressions that user hit locally "
     "fixed before ship: (1) Brain embedder load is now serialized with "
     "a module-level threading.Lock so concurrent Brain.__init__ from "


### PR DESCRIPTION
Two sessions collided on patch numbers. PR #67's v5.3.21 bump conflicts with the v5.3.21 GHCR image from another branch. Bumping to v5.3.24 and rewriting the version notes to match reality. Pure metadata.