### PR TITLE
v6.0.0: native-first cutover + /understand contrast pass

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -1,17 +1,38 @@
 """Single source of truth for PRISM's version.
 
-Bump on EVERY commit that changes user-visible behavior. The MAJOR and
-MINOR slots gate releases (5.3 = pip + Tauri v6.0.0-dev); the PATCH
-slot is incremented on every small iteration so the SPA footer always
-identifies exactly which build is live. If you ship a change without
-bumping the patch, the user can't tell they got the new code — fix
-that habit, not the version number.
+v6.0.0 marks the cutover: native (pip-installed Python service +
+Tauri desktop binaries) is now THE primary distribution. Docker
+remains supported for server / CI deploys but is no longer the
+default install. The 5.3.x patch series was the in-progress
+'pip + Tauri v6.0.0-dev' work — that work is now feature-complete
+and stable enough to drop the -dev suffix.
+
+Going forward: bump PATCH on every commit that changes user-visible
+behavior so the SPA footer always identifies exactly which build is
+live. Bump MINOR for backward-compatible feature work, MAJOR for
+distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "5.3.24"
+PRISM_VERSION = "6.0.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.0.0: NATIVE FIRST. The v5.3.x 'pip + Tauri v6.0.0-dev' series "
+    "is now stable; this release marks the distribution-shape cutover. "
+    "Primary install paths: `pipx install prism-service` for terminal "
+    "users on Mac/Linux/Windows, signed Tauri desktop binaries (.dmg "
+    "/ .msi / .AppImage) for click-to-run users. Docker image still "
+    "ships from GHCR for server / CI deploys but is no longer the "
+    "default the docs point at. Host-native auth (~/.claude direct, "
+    "host gh CLI + ssh keys for git, host browser for OAuth) means "
+    "the docker friction we chased through v5.1 → v5.2 (bind-mount "
+    "perms, OAuth localhost redirects, Watchtower update lag) "
+    "evaporates on native installs. Also includes the v5.3.25 "
+    "/understand contrast pass: UnderstandPage + OnboardingView + "
+    "LayersView + DomainsView were dropping AAA semantic text tokens "
+    "to opacity-60 sleeves, dropping effective contrast below WCAG "
+    "AA — replaced with --text-secondary tokens on body copy. "
+    "v5.3.25: /understand contrast pass — "
     "v5.3.24: Version-number cleanup. Regression coverage for "
     "analyzer_runner._strip_preamble_to_heading + _classify (16 unit "
     "tests, originally tagged v5.3.21 in #67) was merged after a "

--- a/services/prism-service/prism_service/web/src/components/understand/DomainsView.tsx
+++ b/services/prism-service/prism_service/web/src/components/understand/DomainsView.tsx
@@ -123,7 +123,7 @@ function DomainsOverviewPanel({
     <aside className="w-[320px] shrink-0 space-y-5">
       <div>
         <h2 className="font-serif text-xl tracking-tight">Domain glossary</h2>
-        <p className="text-[13px] opacity-70 leading-relaxed mt-1">
+        <p className="text-[13px] text-[color:var(--text-secondary)] leading-relaxed mt-1">
           {domains.length} domain{domains.length === 1 ? "" : "s"} ·{" "}
           {totalEntities} total entit{totalEntities === 1 ? "y" : "ies"}.
           Click a domain to drill into its entities.

--- a/services/prism-service/prism_service/web/src/components/understand/LayersView.tsx
+++ b/services/prism-service/prism_service/web/src/components/understand/LayersView.tsx
@@ -182,7 +182,7 @@ function LayerDetailRow({ layer, colorIdx }: { layer: Layer; colorIdx: number })
         </div>
       </div>
       {layer.description && (
-        <p className="text-[12px] opacity-70 mt-1 leading-relaxed">
+        <p className="text-[12px] text-[color:var(--text-secondary)] mt-1 leading-relaxed">
           {layer.description}
         </p>
       )}
@@ -196,7 +196,7 @@ function LayerDetailRow({ layer, colorIdx }: { layer: Layer; colorIdx: number })
         </div>
       )}
       {layer.files && layer.files.length > 0 && (
-        <ul className="mt-3 text-[11px] font-mono opacity-70 space-y-0.5 max-h-32 overflow-auto">
+        <ul className="mt-3 text-[11px] font-mono text-[color:var(--text-secondary)] space-y-0.5 max-h-32 overflow-auto">
           {layer.files.slice(0, 10).map((f) => (
             <li key={f} className="flex items-center gap-1.5 truncate">
               <FileCode className="w-3 h-3 opacity-50 shrink-0" />

--- a/services/prism-service/prism_service/web/src/components/understand/OnboardingView.tsx
+++ b/services/prism-service/prism_service/web/src/components/understand/OnboardingView.tsx
@@ -28,7 +28,7 @@ function parseMarkdown(text: string): ReactNode[] {
   const flushPara = () => {
     if (para.length === 0) return;
     blocks.push(
-      <p key={`p${blocks.length}`} className="text-sm leading-relaxed opacity-85">
+      <p key={`p${blocks.length}`} className="text-sm leading-relaxed text-[color:var(--text-secondary)]">
         {renderInline(para.join(" "))}
       </p>,
     );
@@ -37,7 +37,7 @@ function parseMarkdown(text: string): ReactNode[] {
   const flushList = () => {
     if (listItems.length === 0) return;
     blocks.push(
-      <ul key={`ul${blocks.length}`} className="text-sm leading-relaxed opacity-85 list-disc pl-5 space-y-1">
+      <ul key={`ul${blocks.length}`} className="text-sm leading-relaxed text-[color:var(--text-secondary)] list-disc pl-5 space-y-1">
         {listItems.map((it, k) => (
           <li key={k}>{renderInline(it)}</li>
         ))}

--- a/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
@@ -128,7 +128,7 @@ export default function UnderstandPage() {
       <div className="flex items-baseline justify-between gap-4">
         <div>
           <h1 className="font-serif text-3xl tracking-tight">Understand</h1>
-          <p className="text-sm opacity-60 mt-1">
+          <p className="text-sm text-[color:var(--text-secondary)] mt-1">
             Generate tour, architecture, domain glossary, and onboarding doc
             from this project's source. Point a project at a local folder
             or a git remote in <span className="font-medium">Settings → Projects</span>.
@@ -180,11 +180,11 @@ export default function UnderstandPage() {
       {!status?.current_sha && (
         <Card>
           <SectionLabel>No source configured for "{project}"</SectionLabel>
-          <p className="text-sm opacity-70 mt-2">
+          <p className="text-sm text-[color:var(--text-secondary)] mt-2">
             Pick a source for this project in <span className="font-medium">Settings → Projects</span>{" "}
             so PRISM can scan the code. Two shapes:
           </p>
-          <ul className="text-sm opacity-70 mt-2 space-y-1 list-disc pl-5">
+          <ul className="text-sm text-[color:var(--text-secondary)] mt-2 space-y-1 list-disc pl-5">
             <li className="leading-relaxed">
               <FolderTree className="w-3.5 h-3.5 inline mr-1 -mt-0.5" />
               <span className="font-medium">Local folder</span> — point at any


### PR DESCRIPTION
Marks the v5.3.x -> v6.0.0 cutover. Pip-installed service + Tauri desktop binaries are now the primary distribution; docker stays supported for server deploys. Bundled with the /understand contrast fix the user flagged: opacity-60/70 sleeves on body copy dropped below WCAG AA; replaced with the AAA --text-secondary token. Verified visually on the native dev instance on 7780.