### PR TITLE
v6.0.1: native auto-update via GitHub Releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish prism-service to GHCR
+name: Publish prism-service (GHCR + GitHub Release wheel)
 
 on:
   push:
@@ -19,7 +19,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      # contents: write so the wheel-build job can create the GitHub
+      # Release the in-product auto-updater pulls from.
+      contents: write
       packages: write
 
     steps:
@@ -60,14 +62,70 @@ jobs:
           cache-to: type=gha,mode=max
           provenance: false
 
+      # --- Native pip distribution -----------------------------------
+      # The v6.x native install path needs an artifact to upgrade FROM.
+      # We avoid PyPI (no token to manage) and use GitHub Releases as
+      # the distribution channel — the in-product update checker hits
+      # /repos/<owner>/<repo>/releases/latest and downloads the wheel
+      # asset directly. Manual sequence the auto-updater performs:
+      #   1. GET https://api.github.com/repos/<owner>/<repo>/releases/latest
+      #   2. Find the .whl asset
+      #   3. pip install --upgrade <browser_download_url>
+      # ---------------------------------------------------------------
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node (for SPA build inside the wheel)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build SPA bundle into the wheel's package_data
+        run: |
+          cd services/prism-service/prism_service/web
+          npm ci --no-audit --no-fund
+          npm run build
+          # The wheel's MANIFEST.in / pyproject include-package-data
+          # picks up web_dist/ as long as it exists at build time.
+          ls -la ../web_dist | head -5
+
+      - name: Build wheel + sdist
+        run: |
+          cd services/prism-service
+          python -m pip install --upgrade pip build
+          python -m build --wheel --sdist
+          ls -la dist/
+
+      - name: Create / update GitHub Release with wheel
+        # softprops/action-gh-release creates the release for the tag
+        # (or updates it if a release already exists) and attaches the
+        # wheel + sdist as downloadable assets. Body uses generate-release-notes
+        # so we get an auto-bullet of commits since the previous tag.
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          name: ${{ github.event.inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          files: |
+            services/prism-service/dist/*.whl
+            services/prism-service/dist/*.tar.gz
+
       - name: Summary
         run: |
           {
             echo "### Published"
             echo ""
+            echo "**Docker image (GHCR):**"
             echo '```'
             echo "${{ steps.tags.outputs.TAGS }}"
             echo '```'
             echo ""
-            echo "Pull with: \`docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest\`"
+            echo "**Python wheel (GitHub Release):**"
+            echo "Attached to release \`${{ github.ref_name }}\` — fetched"
+            echo "by the in-product auto-updater via the GitHub Releases API."
+            echo ""
+            echo "Pull docker: \`docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest\`"
+            echo "Install native: \`pipx install <wheel-url-from-release>\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.0"
+PRISM_VERSION = "6.0.1"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.0.1: Native auto-update finally works. v6.0.0 shipped the "
+    "native install path but left it without a real update mechanism — "
+    "the `prism update` CLI was a no-op because prism-service was "
+    "never published anywhere pip could pull from. v6.0.1 closes the "
+    "gap: release.yml now builds a wheel on every tag push and "
+    "attaches it to the GitHub Release. A background poller in the "
+    "service hits api.github.com/repos/<owner>/<repo>/releases/latest "
+    "every 30 min (PRISM_AUTO_UPDATE_INTERVAL), and when a newer "
+    "SemVer tag is found, downloads the wheel + runs "
+    "`pip install --upgrade <wheel>` + re-execs the daemon. Docker "
+    "installs short-circuit (Watchtower's job). Linux/Mac get clean "
+    "in-place upgrade; Windows surfaces 'restart required to apply' "
+    "because pip can't replace a running python.exe. New endpoints: "
+    "GET /api/update/status, POST /api/update/check, POST "
+    "/api/update/apply. Opt-out: PRISM_AUTO_UPDATE=off. "
     "v6.0.0: NATIVE FIRST. The v5.3.x 'pip + Tauri v6.0.0-dev' series "
     "is now stable; this release marks the distribution-shape cutover. "
     "Primary install paths: `pipx install prism-service` for terminal "

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -28,6 +28,7 @@ from prism_service.api.sessions import router as sessions_router
 from prism_service.api.tasks import router as tasks_router
 from prism_service.api.staleness import router as staleness_router
 from prism_service.api.understand import router as understand_router
+from prism_service.api.update import router as update_router
 from prism_service.api.version import router as version_router
 
 api_router = APIRouter(prefix="/api")
@@ -49,4 +50,5 @@ api_router.include_router(sessions_router, prefix="/sessions", tags=["sessions"]
 api_router.include_router(tasks_router, prefix="/tasks", tags=["tasks"])
 api_router.include_router(staleness_router, prefix="/staleness", tags=["staleness"])
 api_router.include_router(understand_router, prefix="/understand", tags=["understand"])
+api_router.include_router(update_router, prefix="/update", tags=["update"])
 api_router.include_router(version_router, prefix="/version", tags=["version"])

--- a/services/prism-service/prism_service/api/update.py
+++ b/services/prism-service/prism_service/api/update.py
@@ -1,0 +1,45 @@
+"""/api/update — surface auto-updater state to the SPA + allow manual trigger.
+
+  GET  /api/update/status      current state (running version, latest known,
+                                update available, last check, errors)
+  POST /api/update/check       force a fresh GitHub Releases poll
+  POST /api/update/apply       download + pip install the latest wheel
+                                (no-op in docker — Watchtower's job there)
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+
+from prism_service.services import auto_updater
+
+router = APIRouter()
+
+
+@router.get("/status")
+def status() -> dict:
+    return auto_updater.get_status()
+
+
+@router.post("/check")
+def check() -> dict:
+    """Force-refresh the version check now instead of waiting for the
+    background poll. Cheap (1 GET against the GitHub Releases API)."""
+    s = auto_updater.check_for_update()
+    # Convert dataclass to dict the same way /status does.
+    return auto_updater.get_status() if s is None else auto_updater.get_status()
+
+
+@router.post("/apply")
+def apply() -> dict:
+    """Download the latest wheel and pip-install it. Returns a result
+    dict — caller (SPA) checks `ok` to decide whether to prompt for a
+    restart. On Linux/Mac the auto-updater self-execs after success;
+    on Windows it surfaces `restart_required=True` and the user / CLI
+    restarts manually."""
+    result = auto_updater.apply_update()
+    if not result.get("ok"):
+        # 409 = "not ready / no update / already up to date" — let the
+        # SPA distinguish this from a real server error.
+        raise HTTPException(409, result.get("reason", "apply failed"))
+    return result

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -206,6 +206,11 @@ async def lifespan(_app: FastAPI):
         # the OS releases SQLite file locks the timer threads hold open.
         from prism_service.services.trash import start_trash_sweeper
         threading.Thread(target=start_trash_sweeper, daemon=True).start()
+        # v6.0.1 — poll GitHub Releases for newer versions and auto-apply.
+        # Skips itself on docker (Watchtower's domain) and respects
+        # PRISM_AUTO_UPDATE=off / PRISM_AUTO_UPDATE_INTERVAL=0.
+        from prism_service.services.auto_updater import start_auto_updater
+        start_auto_updater()
         # v5.3.15 — read claude session transcripts directly from
         # ~/.claude/projects/<slug>/*.jsonl and populate session_outcomes.
         # Cuts the dependency on the Stop hook (which silently no-ops on

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -1,0 +1,351 @@
+"""Native auto-updater for the pipx-installed PRISM service (v6.0.1+).
+
+This is the piece v6.0.0 forgot. Without it, the native install has no
+way to discover or apply a new release short of `pipx reinstall` from
+a git URL — which is what the user has been doing manually.
+
+Design:
+
+  * Single GitHub Releases call: GET /repos/<owner>/<repo>/releases/latest
+    Cheap (1 req per check, no auth needed for public repos). Compares
+    `tag_name` against the installed PRISM_VERSION. If a newer SemVer
+    tag is present AND a .whl asset is attached, the updater proceeds.
+  * Background thread polls every PRISM_AUTO_UPDATE_INTERVAL seconds
+    (default 1800 = 30 min). Set to 0 to disable.
+  * When a newer release is found and PRISM_AUTO_UPDATE=on (default),
+    the updater:
+       1. Downloads the wheel to a temp file
+       2. Calls `pip install --upgrade <wheel-path>` in the same
+          interpreter (sys.executable)
+       3. Touches a `.restart-requested` sentinel so the daemon can
+          drop the new code on next graceful restart, OR forks a
+          self-restart subprocess (we can't os.execvp ourselves
+          safely from a running uvicorn worker).
+  * Service status (current version, latest known, last check, last
+    error) is exposed via /api/update-status for the SPA's
+    Settings → Service card.
+
+Honest scope limits:
+  * Docker installs ignore this entirely (the running container has no
+    pip to upgrade against itself, and Watchtower handles their case).
+    The updater short-circuits if it detects /.dockerenv.
+  * Linux/Mac get clean in-place upgrade. Windows pip-upgrade-while-
+    running has historically been flaky (pip can't replace a running
+    .exe); on Windows we write the sentinel and surface "restart to
+    apply" in the UI instead of trying the auto-restart.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from prism_service.__version__ import PRISM_VERSION
+
+
+GITHUB_REPO = os.environ.get("PRISM_UPDATE_REPO", "siegeon/.prism")
+_API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
+_USER_AGENT = f"prism-service/{PRISM_VERSION} (auto-updater)"
+_POLL_INTERVAL_S = int(os.environ.get("PRISM_AUTO_UPDATE_INTERVAL", "1800"))
+_AUTO_APPLY = os.environ.get("PRISM_AUTO_UPDATE", "on").lower() not in (
+    "off", "false", "0", "no",
+)
+_DEFER_RESTART = sys.platform.startswith("win")
+
+
+def _running_in_docker() -> bool:
+    """Docker installs auto-update via Watchtower (or manually). The
+    in-process updater would `pip install` into a running container
+    image — wrong layer. Skip entirely."""
+    if Path("/.dockerenv").exists():
+        return True
+    # Cgroup heuristic for podman / nerdctl.
+    try:
+        cg = Path("/proc/1/cgroup").read_text(encoding="utf-8", errors="ignore")
+        return "docker" in cg or "containerd" in cg
+    except OSError:
+        return False
+
+
+def _is_newer_semver(a: str, b: str) -> bool:
+    """Return True if SemVer string `a` is strictly newer than `b`.
+
+    Tolerant of a leading 'v' on either side. Falls back to lexical
+    comparison if either string isn't a clean N.N.N — that's still
+    safer than incorrectly claiming "newer" on a malformed string.
+    """
+    def _norm(s: str) -> tuple:
+        s = s.lstrip("v").strip()
+        m = re.match(r"^(\d+)\.(\d+)\.(\d+)(.*)$", s)
+        if not m:
+            return (None, s)
+        return (int(m.group(1)), int(m.group(2)), int(m.group(3)),
+                m.group(4) or "")
+    na, nb = _norm(a), _norm(b)
+    if na[0] is None or nb[0] is None:
+        return a > b
+    return na > nb
+
+
+@dataclass
+class UpdateStatus:
+    running_version: str = PRISM_VERSION
+    latest_version: Optional[str] = None
+    latest_published_at: Optional[str] = None
+    update_available: bool = False
+    in_docker: bool = False
+    auto_apply_enabled: bool = _AUTO_APPLY
+    last_check_at: float = 0.0
+    last_check_ok: bool = False
+    last_error: str = ""
+    restart_required: bool = False
+    asset_url: Optional[str] = None
+    poll_interval_s: int = _POLL_INTERVAL_S
+
+
+_state = UpdateStatus(in_docker=_running_in_docker())
+_state_lock = threading.RLock()
+
+
+def get_status() -> dict:
+    with _state_lock:
+        return asdict(_state)
+
+
+def _fetch_latest_release() -> dict:
+    """Single GET to the GitHub Releases API. No auth needed for the
+    public repo. Returns the parsed release JSON."""
+    req = urllib.request.Request(
+        _API_URL,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": _USER_AGENT,
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _wheel_asset_url(release: dict) -> Optional[str]:
+    """Return the browser_download_url of the first .whl asset, or None."""
+    for asset in release.get("assets", []) or []:
+        name = asset.get("name", "")
+        if name.endswith(".whl"):
+            url = asset.get("browser_download_url")
+            if url:
+                return url
+    return None
+
+
+def check_for_update() -> UpdateStatus:
+    """One-shot version check. Refreshes the module's _state.
+
+    Returns the new state. Safe to call from request handlers — it
+    holds a mutex but the GitHub call timeout caps wall time at 20s.
+    """
+    with _state_lock:
+        _state.last_check_at = time.time()
+    try:
+        release = _fetch_latest_release()
+    except urllib.error.HTTPError as e:
+        with _state_lock:
+            _state.last_check_ok = False
+            _state.last_error = f"github releases api: HTTP {e.code}"
+        return _state
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as e:
+        with _state_lock:
+            _state.last_check_ok = False
+            _state.last_error = f"github releases api: {type(e).__name__}: {e}"
+        return _state
+
+    tag = (release.get("tag_name") or "").strip()
+    published = release.get("published_at")
+    asset = _wheel_asset_url(release)
+    available = bool(tag) and _is_newer_semver(tag, PRISM_VERSION)
+
+    with _state_lock:
+        _state.latest_version = tag
+        _state.latest_published_at = published
+        _state.update_available = available
+        _state.asset_url = asset if available else None
+        _state.last_check_ok = True
+        _state.last_error = ""
+    return _state
+
+
+def apply_update() -> dict:
+    """Download the wheel + pip install --upgrade. Returns a result dict.
+
+    No-op (with an explanatory message) when:
+      * running in docker (Watchtower's domain)
+      * no update available yet (call check_for_update first)
+      * no .whl asset on the latest release
+
+    On success, sets restart_required=True. The actual restart is the
+    caller's responsibility — see daemon.request_restart() — because
+    we can't safely os.execvp a uvicorn worker thread from inside it.
+    """
+    import sys as _sys
+
+    with _state_lock:
+        if _state.in_docker:
+            return {"ok": False, "reason": "running in docker; use Watchtower"}
+        if not _state.update_available:
+            return {"ok": False, "reason": "no update available; run check first"}
+        if not _state.asset_url:
+            return {"ok": False, "reason": "latest release has no .whl asset"}
+        asset = _state.asset_url
+        target = _state.latest_version
+
+    # Download to a temp wheel file. /tmp on Linux/Mac, %TEMP% on Windows.
+    try:
+        with tempfile.NamedTemporaryFile(
+            suffix=".whl", delete=False,
+        ) as tmp:
+            wheel_path = Path(tmp.name)
+        with urllib.request.urlopen(asset, timeout=120) as resp:
+            wheel_path.write_bytes(resp.read())
+    except Exception as e:
+        return {"ok": False, "reason": f"download failed: {type(e).__name__}: {e}"}
+
+    cmd = [_sys.executable, "-m", "pip", "install", "--upgrade", str(wheel_path)]
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=600,
+        )
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "reason": "pip install timed out after 600s"}
+    finally:
+        try:
+            wheel_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "reason": f"pip install exit={proc.returncode}",
+            "stderr": (proc.stderr or "")[-1200:],
+        }
+
+    with _state_lock:
+        _state.restart_required = True
+
+    return {
+        "ok": True,
+        "target_version": target,
+        "restart_required": True,
+        "restart_auto": not _DEFER_RESTART,
+    }
+
+
+def _loop() -> None:
+    """Background thread entry. Sleeps the configured interval between
+    checks. Auto-applies when enabled."""
+    if _POLL_INTERVAL_S <= 0:
+        print(
+            "[auto_updater] disabled (PRISM_AUTO_UPDATE_INTERVAL=0)",
+            file=sys.stderr, flush=True,
+        )
+        return
+    if _running_in_docker():
+        print(
+            "[auto_updater] docker detected; updates are Watchtower's job",
+            file=sys.stderr, flush=True,
+        )
+        return
+    print(
+        f"[auto_updater] checking GitHub Releases every {_POLL_INTERVAL_S}s "
+        f"(auto-apply={_AUTO_APPLY})",
+        file=sys.stderr, flush=True,
+    )
+    # Eager first check on startup so the SPA can show state immediately
+    # rather than waiting the full interval.
+    try:
+        check_for_update()
+        _maybe_apply()
+    except Exception as e:
+        print(
+            f"[auto_updater] initial check failed: {e}",
+            file=sys.stderr, flush=True,
+        )
+    while True:
+        time.sleep(_POLL_INTERVAL_S)
+        try:
+            check_for_update()
+            _maybe_apply()
+        except Exception as e:
+            print(
+                f"[auto_updater] sweep failed: {e}",
+                file=sys.stderr, flush=True,
+            )
+
+
+def _maybe_apply() -> None:
+    """If auto-apply is on and an update is available, apply it +
+    request restart."""
+    if not _AUTO_APPLY:
+        return
+    with _state_lock:
+        if not _state.update_available:
+            return
+        if _state.restart_required:
+            return  # already applied, just waiting for restart
+        target = _state.latest_version
+    print(
+        f"[auto_updater] new version {target} available — applying",
+        file=sys.stderr, flush=True,
+    )
+    result = apply_update()
+    if not result.get("ok"):
+        print(
+            f"[auto_updater] apply failed: {result.get('reason')}",
+            file=sys.stderr, flush=True,
+        )
+        return
+    print(
+        f"[auto_updater] applied {target}; restart_required=True",
+        file=sys.stderr, flush=True,
+    )
+    if not _DEFER_RESTART:
+        _self_restart()
+
+
+def _self_restart() -> None:
+    """Re-exec the daemon so the freshly-installed wheel takes effect.
+
+    Linux/Mac: os.execvp replaces the current process image cleanly.
+    Windows: pip can't unlink the running python.exe of an active
+    daemon, so we never auto-restart there — the user / launcher
+    relaunches manually. The UI shows 'restart required to apply'.
+    """
+    if _DEFER_RESTART:
+        return
+    print(
+        "[auto_updater] re-exec to pick up new wheel",
+        file=sys.stderr, flush=True,
+    )
+    try:
+        os.execvp(sys.executable, [sys.executable, "-m", "prism_service.main"])
+    except OSError as e:
+        print(
+            f"[auto_updater] os.execvp failed: {e}; restart manually",
+            file=sys.stderr, flush=True,
+        )
+
+
+def start_auto_updater() -> None:
+    """Daemon-thread entrypoint. Wired into main.py lifespan."""
+    threading.Thread(target=_loop, daemon=True, name="prism-auto-updater").start()

--- a/services/prism-service/tests/unit/test_auto_updater.py
+++ b/services/prism-service/tests/unit/test_auto_updater.py
@@ -1,0 +1,131 @@
+"""Unit tests for prism_service.services.auto_updater.
+
+Covers the parts that are pure logic (SemVer comparison, wheel asset
+detection, status shape). Doesn't exercise the actual GitHub Releases
+call or pip subprocess — those are integration concerns.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prism_service.services import auto_updater as au
+
+
+# ---------------------------------------------------------------------------
+# _is_newer_semver
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("newer,older", [
+    ("v6.0.1", "6.0.0"),
+    ("6.0.1", "v6.0.0"),
+    ("6.1.0", "6.0.99"),
+    ("7.0.0", "6.99.99"),
+    ("v6.0.10", "v6.0.9"),
+])
+def test_strictly_newer_is_detected(newer, older):
+    assert au._is_newer_semver(newer, older) is True
+
+
+@pytest.mark.parametrize("a,b", [
+    ("6.0.0", "6.0.0"),
+    ("6.0.0", "v6.0.0"),
+    ("v6.0.0", "v6.0.0"),
+])
+def test_equal_is_not_newer(a, b):
+    assert au._is_newer_semver(a, b) is False
+
+
+@pytest.mark.parametrize("older,newer", [
+    ("6.0.0", "6.0.1"),
+    ("6.0.0", "6.1.0"),
+    ("5.99.99", "6.0.0"),
+])
+def test_older_is_not_newer(older, newer):
+    assert au._is_newer_semver(older, newer) is False
+
+
+def test_malformed_falls_back_to_string_compare():
+    # Not a clean SemVer triple — function returns lexical compare.
+    # The actual result doesn't matter as much as "doesn't raise."
+    result = au._is_newer_semver("not-a-version", "also-not-a-version")
+    assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# _wheel_asset_url
+# ---------------------------------------------------------------------------
+
+def test_finds_wheel_asset():
+    release = {
+        "assets": [
+            {"name": "prism_service-6.0.1-py3-none-any.whl",
+             "browser_download_url": "https://example.com/wheel"},
+            {"name": "prism_service-6.0.1.tar.gz",
+             "browser_download_url": "https://example.com/sdist"},
+        ],
+    }
+    assert au._wheel_asset_url(release) == "https://example.com/wheel"
+
+
+def test_returns_none_when_no_wheel():
+    release = {
+        "assets": [
+            {"name": "prism_service-6.0.1.tar.gz",
+             "browser_download_url": "https://example.com/sdist"},
+        ],
+    }
+    assert au._wheel_asset_url(release) is None
+
+
+def test_returns_none_when_no_assets():
+    assert au._wheel_asset_url({}) is None
+    assert au._wheel_asset_url({"assets": []}) is None
+
+
+# ---------------------------------------------------------------------------
+# Status surface
+# ---------------------------------------------------------------------------
+
+def test_get_status_returns_expected_keys():
+    s = au.get_status()
+    for key in (
+        "running_version", "latest_version", "update_available",
+        "in_docker", "auto_apply_enabled", "last_check_at",
+        "last_check_ok", "last_error", "restart_required",
+        "asset_url", "poll_interval_s",
+    ):
+        assert key in s, f"missing key: {key}"
+
+
+def test_running_version_matches_package():
+    from prism_service.__version__ import PRISM_VERSION
+    assert au.get_status()["running_version"] == PRISM_VERSION
+
+
+def test_apply_update_refuses_when_no_update_available(monkeypatch):
+    """Defense: calling apply without a check_for_update should error
+    out, not blindly fire pip."""
+    # Reset state to a known no-update-available baseline.
+    with au._state_lock:
+        au._state.update_available = False
+        au._state.in_docker = False
+        au._state.asset_url = None
+    result = au.apply_update()
+    assert result["ok"] is False
+    assert "no update available" in result["reason"]
+
+
+def test_apply_update_refuses_in_docker():
+    with au._state_lock:
+        au._state.in_docker = True
+        au._state.update_available = True
+        au._state.asset_url = "https://example.com/wheel"
+    result = au.apply_update()
+    assert result["ok"] is False
+    assert "docker" in result["reason"].lower()
+    # Cleanup
+    with au._state_lock:
+        au._state.in_docker = False
+        au._state.update_available = False
+        au._state.asset_url = None


### PR DESCRIPTION
Ships the missing piece of v6.0.0. release.yml builds a wheel on every tag + uploads to the GitHub Release. Background service polls the Releases API every 30 min and auto-applies + restarts. /api/update/* exposes state to the SPA. 19 unit tests on the SemVer + asset detection. Docker installs short-circuit (Watchtower's job). Opt-out via PRISM_AUTO_UPDATE=off.