### PR TITLE
v6.0.2: release.yml fix — npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,10 @@ jobs:
       - name: Build SPA bundle into the wheel's package_data
         run: |
           cd services/prism-service/prism_service/web
-          npm ci --no-audit --no-fund
+          # `npm install` not `npm ci` — package-lock.json is not
+          # committed (web/.gitignore excludes it), and `npm ci`
+          # requires the lockfile to exist.
+          npm install --no-audit --no-fund
           npm run build
           # The wheel's MANIFEST.in / pyproject include-package-data
           # picks up web_dist/ as long as it exists at build time.

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,14 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.1"
+PRISM_VERSION = "6.0.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.0.2: Fix release.yml — `npm ci` was failing because the SPA's "
+    "package-lock.json isn't committed. Swapped to `npm install` so "
+    "the wheel build can produce web_dist/ on the GitHub Action "
+    "runner. Same v6.0.1 auto-update wiring underneath. "
     "v6.0.1: Native auto-update finally works. v6.0.0 shipped the "
     "native install path but left it without a real update mechanism — "
     "the `prism update` CLI was a no-op because prism-service was "


### PR DESCRIPTION
v6.0.1 release workflow failed: `npm ci` requires package-lock.json which is gitignored. Swap to `npm install`. Same auto-update wiring underneath.