### PR TITLE
feat(v6.0.4): DEV pill in Sidebar footer + PRISM_DEV_MODE gate

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,17 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.3"
+PRISM_VERSION = "6.0.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.0.4: Dev-mode marker. The Sidebar footer now renders an amber "
+    "'DEV' pill next to the version string when the service is started "
+    "with PRISM_DEV_MODE=1, so source-run instances (editable pip "
+    "install + 8887/8888) are visually distinguishable from a "
+    "pipx/Watchtower-managed prod daemon. /api/version gains a "
+    "`dev_mode: bool` field driving the pill; defaults false. No "
+    "behavior change for prod installs. "
     "v6.0.3: Settings -> Service grows an 'Updates' panel surfacing the "
     "v6.0.1 auto-updater state. Shows running version, latest available, "
     "last check, status pill (up-to-date / update-available / docker / "

--- a/services/prism-service/prism_service/api/version.py
+++ b/services/prism-service/prism_service/api/version.py
@@ -1,10 +1,16 @@
 """Version API — single source of truth for the SPA's footer + Settings."""
 
+import os
+
 from fastapi import APIRouter
 
 from prism_service.__version__ import PRISM_VERSION, PRISM_VERSION_NOTES
 
 router = APIRouter()
+
+
+def _dev_mode() -> bool:
+    return os.environ.get("PRISM_DEV_MODE", "").strip().lower() in ("1", "true", "yes", "on")
 
 
 @router.get("")
@@ -15,4 +21,5 @@ def version() -> dict:
     return {
         "version": PRISM_VERSION,
         "notes": PRISM_VERSION_NOTES,
+        "dev_mode": _dev_mode(),
     }

--- a/services/prism-service/prism_service/web/src/components/Sidebar.tsx
+++ b/services/prism-service/prism_service/web/src/components/Sidebar.tsx
@@ -220,10 +220,18 @@ export default function Sidebar() {
           </NavLink>
         )}
         <div
-          className="px-5 py-3 text-[10px] uppercase tracking-wider text-[color:var(--text-label)] border-t border-[color:var(--border-default)]"
+          className="px-5 py-3 text-[10px] uppercase tracking-wider text-[color:var(--text-label)] border-t border-[color:var(--border-default)] flex items-center gap-2"
           title={version?.notes ?? ""}
         >
-          Slate Blue · v{version?.version ?? "…"}
+          <span>Slate Blue · v{version?.version ?? "…"}</span>
+          {version?.dev_mode && (
+            <span
+              className="inline-flex items-center px-1.5 py-0.5 rounded-sm text-[9px] font-bold tracking-widest bg-amber-500/20 text-amber-300 border border-amber-500/40"
+              title="Source-run instance (PRISM_DEV_MODE=1)"
+            >
+              DEV
+            </span>
+          )}
         </div>
       </div>
     </aside>

--- a/services/prism-service/prism_service/web/src/lib/version.ts
+++ b/services/prism-service/prism_service/web/src/lib/version.ts
@@ -16,7 +16,7 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
 
-export type ServiceVersion = { version: string; notes: string };
+export type ServiceVersion = { version: string; notes: string; dev_mode?: boolean };
 
 let cached: ServiceVersion | null = null;
 let inflight: Promise<ServiceVersion> | null = null;


### PR DESCRIPTION
## Summary
- Adds an amber **DEV** pill to the Sidebar footer next to the version string, visible only when `PRISM_DEV_MODE=1`
- `/api/version` gains a `dev_mode: bool` field (env-gated; defaults `false`)
- `__version__` bumped to 6.0.4 with notes

## Why
Source-run dev instances (editable pip install on alt ports like 8887/8888) were visually indistinguishable from a pipx/Watchtower-managed prod daemon — the footer just showed `v6.0.3` either way. Now operators can tell at a glance which instance their window is pointed at.

## Behavior
- Prod installs (no `PRISM_DEV_MODE` set) — zero change. Pill not rendered.
- Dev launch with `PRISM_DEV_MODE=1` — footer reads `Slate Blue · v6.0.4` + amber `DEV` pill.

## Test plan
- [x] `/api/version` returns `"dev_mode":true` with env var set, `false` (or absent) without
- [x] SPA built and serves on a live dev instance — pill visible in footer
- [ ] Confirm pill not rendered on a prod instance (env var unset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)