### PR TITLE
fix(v6.0.5): auto-updater wheel filename — PEP 427 basename

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.4"
+PRISM_VERSION = "6.0.5"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.0.5: Auto-updater wheel filename fix. v6.0.1's apply_update() "
+    "downloaded the release wheel via "
+    "tempfile.NamedTemporaryFile(suffix='.whl'), producing names like "
+    "'tmpe06f9m57.whl'. pip>=24 validates wheel filenames against "
+    "PEP 427 ({name}-{version}-{pyver}-{abi}-{plat}.whl) and rejects "
+    "anything else — so every auto-update attempt since v6.0.1 has "
+    "died with 'Invalid wheel filename (wrong number of parts: must "
+    "have 5)'. Now extracts the real basename from the asset URL "
+    "(e.g. 'prism_service-6.0.5-py3-none-any.whl') via "
+    "posixpath.basename(urlparse(asset).path) and downloads into a "
+    "mkdtemp dir so pip sees a PEP-427-compliant name; cleanup via "
+    "shutil.rmtree in the finally block. Separate but related: "
+    "pipx>=1.7 venvs are uv-backed and don't ship pip — users on those "
+    "need `uv pip install --python <venv> pip` once before sys.executable "
+    "-m pip can resolve, but that's a pipx-side issue, not ours. "
     "v6.0.4: Dev-mode marker. The Sidebar footer now renders an amber "
     "'DEV' pill next to the version string when the service is started "
     "with PRISM_DEV_MODE=1, so source-run instances (editable pip "

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -39,13 +39,16 @@ from __future__ import annotations
 
 import json
 import os
+import posixpath
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -209,15 +212,26 @@ def apply_update() -> dict:
         asset = _state.asset_url
         target = _state.latest_version
 
-    # Download to a temp wheel file. /tmp on Linux/Mac, %TEMP% on Windows.
+    # Download to a temp dir using the asset's real basename. pip>=24
+    # validates wheel filenames against PEP 427's
+    # {name}-{version}-{pyver}-{abi}-{plat}.whl shape and rejects
+    # anything else — so tempfile.NamedTemporaryFile(suffix=".whl")
+    # produces names like "tmpe06f9m57.whl" that pip refuses with
+    # "Invalid wheel filename (wrong number of parts)". Pull the
+    # PEP-427-shaped basename out of the GitHub asset URL instead.
+    asset_basename = posixpath.basename(urllib.parse.urlparse(asset).path)
+    if not asset_basename.endswith(".whl"):
+        # Last-ditch fallback: synthesize a compliant name from the tag.
+        # GitHub always gives us a real basename in practice, so this
+        # branch is for safety only.
+        asset_basename = f"prism_service-{target}-py3-none-any.whl"
+    tmpdir = Path(tempfile.mkdtemp(prefix="prism-update-"))
+    wheel_path = tmpdir / asset_basename
     try:
-        with tempfile.NamedTemporaryFile(
-            suffix=".whl", delete=False,
-        ) as tmp:
-            wheel_path = Path(tmp.name)
         with urllib.request.urlopen(asset, timeout=120) as resp:
             wheel_path.write_bytes(resp.read())
     except Exception as e:
+        shutil.rmtree(tmpdir, ignore_errors=True)
         return {"ok": False, "reason": f"download failed: {type(e).__name__}: {e}"}
 
     cmd = [_sys.executable, "-m", "pip", "install", "--upgrade", str(wheel_path)]
@@ -228,10 +242,7 @@ def apply_update() -> dict:
     except subprocess.TimeoutExpired:
         return {"ok": False, "reason": "pip install timed out after 600s"}
     finally:
-        try:
-            wheel_path.unlink(missing_ok=True)
-        except OSError:
-            pass
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
     if proc.returncode != 0:
         return {


### PR DESCRIPTION
## Summary

v6.0.1's `apply_update()` downloaded the release wheel via `tempfile.NamedTemporaryFile(suffix=".whl")`, producing names like `tmpe06f9m57.whl`. pip>=24 enforces PEP 427 (`{name}-{version}-{pyver}-{abi}-{plat}.whl`) and rejects anything else — so every auto-update attempt since v6.0.1 has died with `Invalid wheel filename (wrong number of parts: must have 5)`.

- Pull the real basename out of the GitHub asset URL via `posixpath.basename(urlparse(asset).path)` (yields e.g. `prism_service-6.0.5-py3-none-any.whl`).
- Download into a `mkdtemp` dir under that name so pip sees a PEP-427-compliant path.
- Cleanup via `shutil.rmtree(tmpdir, ignore_errors=True)` in the `finally` block.
- Patch-bump to v6.0.5 with a changelog entry.

### Not fixed here

`pipx>=1.7` venvs are uv-backed and don't ship `pip`, so `sys.executable -m pip install` fails with `No module named pip` until the user runs `uv pip install --python <venv> pip` once. Out of scope for this PR — pipx-side issue.

`/api/projects`, `/api/update/status`, `/openapi.json` reportedly 404 on a freshly-started daemon. Separate bug, also out of scope here.

## Test plan

- [x] Both files AST-parse cleanly.
- [x] `posixpath.basename(urlparse('.../prism_service-6.0.5-py3-none-any.whl').path)` → `prism_service-6.0.5-py3-none-any.whl` (5 PEP-427 parts).
- [ ] Cut v6.0.5 tag → CI builds the wheel → auto-updater on a v6.0.4 pipx install (with `pip` re-added to the venv) now succeeds end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)