### PR TITLE
fix(v6.0.18): /api/graph/rebuild no longer silently no-ops

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,11 +13,30 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.17"
+PRISM_VERSION = "6.0.18"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
-    "v6.0.17: /understand also drops its per-page h1 (v6.0.15 only "
+    "v6.0.18: /graph Rebuild button actually rebuilds now. The "
+    "/api/graph/rebuild endpoint was calling graph_svc.rebuild() "
+    "without passing brain_db_path, so the staging-dir auto-backfill "
+    "(gated on `if brain_db_path and staging is empty`) silently "
+    "skipped. rebuild() then early-returned with "
+    "{message: 'no staged source files yet'}, but the API discarded "
+    "the result dict and returned {ok: true} — so every project that "
+    "had source files in Brain but had never manually staged for "
+    "graphify (i.e. virtually all of them) saw the Rebuild button "
+    "appear to succeed while graph.json never got produced and "
+    "communities stayed at 0. graph.db entities did exist but all "
+    "came from the tree-sitter fallback in brain_engine (graphify_id "
+    "NULL on every row), which sync_status had been flagging as stale "
+    "with no user-facing way to escape. Fix: pass brain_db_path so "
+    "backfill runs, and surface result['error'] as a real 500 instead "
+    "of masking it. The result dict (with nodes/edges/communities/"
+    "backfilled counts) now flows back to the SPA too, so the next "
+    "/api/graph/summary refresh sees graph_json_exists flip true and "
+    "the Sigma viewer can finally paint. v6.0.17: /understand also "
+    "drops its per-page h1 (v6.0.15 only "
     "covered Memory + Consolidation). Description paragraph stays "
     "next to the Refresh button; PageHeader's top-bar 'UNDERSTAND' "
     "is the single title. Swept the rest of the SPA — SettingsPage "

--- a/services/prism-service/prism_service/api/graph.py
+++ b/services/prism-service/prism_service/api/graph.py
@@ -48,11 +48,22 @@ def summary(project: str = Query("default")) -> dict:
 
 @router.post("/rebuild")
 def rebuild(project: str = Query("default")) -> dict:
+    # Pass brain_db_path so rebuild() can auto-backfill the graphify
+    # staging dir from the docs table when it's empty. Without this, any
+    # project whose source files were ingested via Brain but never
+    # manually staged (i.e. virtually all of them) saw the Rebuild button
+    # silently no-op: rebuild() returned {"message": "no staged source
+    # files yet"}, the API discarded it, and graph.json was never produced.
     try:
-        get_project(project).graph_svc.rebuild()
+        ctx = get_project(project)
+        result = ctx.graph_svc.rebuild(
+            brain_db_path=str(ctx._data_dir / "brain.db"),
+        )
     except Exception as exc:
         raise HTTPException(500, f"rebuild failed: {exc}")
-    return {"ok": True}
+    if isinstance(result, dict) and result.get("error"):
+        raise HTTPException(500, f"rebuild failed: {result['error']}")
+    return {"ok": True, **(result if isinstance(result, dict) else {})}
 
 
 class EdgesBetweenBody(BaseModel):


### PR DESCRIPTION
## Summary

The **Rebuild** button on `/graph` was a silent no-op for every project that hadn't manually staged source files for graphify — i.e. virtually all of them on a fresh native install.

**Root cause:** `/api/graph/rebuild` called `graph_svc.rebuild()` *without* `brain_db_path`, so the staging-dir auto-backfill (gated on `if brain_db_path and staging is empty`) was always skipped. `rebuild()` then early-returned `{message: "no staged source files yet"}`, but the API threw that away and returned `{ok: true}`. The SPA happily refreshed and showed `graph_json_exists: false` + `communities: 0` forever.

The same projects had `graph.db` entities populated by the tree-sitter fallback in `brain_engine` (every row had `graphify_id NULL`), which `sync_status` was already flagging stale — but the user-facing button couldn't escape that state.

## Fix

- Pass `brain_db_path` to `rebuild()` so it can auto-backfill staging from the Brain docs table.
- Stop masking `result["error"]` as success — raise HTTP 500 with the real graphify error.
- Spread `result` (nodes/edges/communities/backfilled counts) into the response.

## Known follow-up (separate)

On this dev instance Brain's docs table is dominated by `.venvs/` and `.dev-data/` paths rather than real source under `services/`. After this fix Rebuild correctly invokes graphify, but graphify still emits no `graph.json` because every staged path starts with a dot and gets pruned by `graphify/detect.py:373`. That's a Brain-ingestion-scope bug — filed separately, not in this PR.

## Test plan

- [ ] On a project where Brain has real source paths: click Rebuild → `graph.json` materializes, `communities` > 0, Sigma viewer paints.
- [ ] On a project where staging would still be empty after backfill: Rebuild returns HTTP 500 with graphify's actual stderr instead of a fake `{ok: true}`.
- [ ] `/api/graph/summary` after a successful rebuild reports `graph_json_exists: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)