### PR TITLE
fix(v6.0.34): auto_updater falls back through ensurepip+uv

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,11 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.33"
+PRISM_VERSION = "6.0.34"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
-    "v6.0.33: New /ship skill at .claude/skills/ship/SKILL.md codifies "
+    "v6.0.34: auto_updater apply_update() gains two fallback install paths "
+    "so the release daemon can self-update on pipx-uv-backed venvs (which "
+    "ship without pip). New order: 'python -m pip install' (legacy); on "
+    "'No module named pip', 'python -m ensurepip --upgrade' then retry; "
+    "final fallback 'uv pip install --python <sys.executable> <wheel>' "
+    "(works on every pipx-uv install since uv is always on PATH there). "
+    "Picks the first non-zero-exit path; surfaces 'install exit=N (tried "
+    "pip, ensurepip+pip, uv pip)' if all three fail. v6.0.33 hit this "
+    "exact gap — the WSL release daemon refused auto-apply with 'pip "
+    "install exit=1' and required a manual wheel install. v6.0.34 will "
+    "be the first release that ALL existing daemons can pull in cleanly. "    "v6.0.33: New /ship skill at .claude/skills/ship/SKILL.md codifies "
     "the delivery flow: pre-flight checks (version bumped, no merge "
     "markers, not on protected branch) -> local gates (tsc + npm build "
     "+ pytest + dev /api/version + /verify) -> checkin (specific files, "
@@ -790,6 +800,7 @@ PRISM_VERSION_NOTES = (
     "drainer + drift UI. v5.1: Understand-Anything. v5.0: "
     "Hermes-native React/Vite SPA."
 )
+
 
 
 

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -234,20 +234,50 @@ def apply_update() -> dict:
         shutil.rmtree(tmpdir, ignore_errors=True)
         return {"ok": False, "reason": f"download failed: {type(e).__name__}: {e}"}
 
-    cmd = [_sys.executable, "-m", "pip", "install", "--upgrade", str(wheel_path)]
-    try:
-        proc = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=600,
-        )
-    except subprocess.TimeoutExpired:
-        return {"ok": False, "reason": "pip install timed out after 600s"}
-    finally:
+    # Three install paths, in order:
+    #   1. python -m pip install  (the legacy path, works when pip is in the venv)
+    #   2. python -m ensurepip --upgrade ; python -m pip install
+    #      (recovers from venvs that shipped without pip)
+    #   3. uv pip install --python <sys.executable> <wheel>
+    #      (works on pipx-uv-backed venvs that intentionally exclude pip)
+    # Picks the first that exits 0. Surfaces a useful error if all fail.
+
+    def _try(cmd):
+        try:
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+        except subprocess.TimeoutExpired:
+            return None
+
+    pip_cmd = [_sys.executable, "-m", "pip", "install", "--upgrade", str(wheel_path)]
+    proc = _try(pip_cmd)
+    if proc is None:
         shutil.rmtree(tmpdir, ignore_errors=True)
+        return {"ok": False, "reason": "pip install timed out after 600s"}
+
+    # If pip is missing, try ensurepip + retry.
+    if proc.returncode != 0 and "No module named pip" in (proc.stderr or ""):
+        bootstrap = _try([_sys.executable, "-m", "ensurepip", "--upgrade"])
+        if bootstrap is not None and bootstrap.returncode == 0:
+            proc = _try(pip_cmd) or proc
+
+    # Final fallback: uv pip install --python <sys.executable> <wheel>.
+    # Picks up uv from PATH (pipx-uv-backed installs always have uv available).
+    if proc.returncode != 0:
+        uv_path = shutil.which("uv")
+        if uv_path:
+            uv_cmd = [uv_path, "pip", "install", "--python", _sys.executable,
+                      str(wheel_path)]
+            uv_proc = _try(uv_cmd)
+            if uv_proc is not None:
+                proc = uv_proc
+
+    shutil.rmtree(tmpdir, ignore_errors=True)
 
     if proc.returncode != 0:
         return {
             "ok": False,
-            "reason": f"pip install exit={proc.returncode}",
+            "reason": f"install exit={proc.returncode} "
+                      f"(tried pip, ensurepip+pip, uv pip)",
             "stderr": (proc.stderr or "")[-1200:],
         }
 


### PR DESCRIPTION
Closes the v6.0.33 ship gap. apply_update() now tries pip → ensurepip+pip → uv pip; picks the first non-zero-exit. Every existing release daemon will be able to auto-pull v6.0.34 cleanly.