### PR TITLE
feat(v6.1.0): bundle prism-service runtime as Tauri sidecar (closes #84 with PR #85)

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -67,6 +67,61 @@ jobs:
           npm install --no-audit --no-fund
           npm run build
 
+      # --- Bundle prism-service as a Tauri sidecar (v6.1.0+, issue #84) ----
+      # The Tauri installer used to ship just the shell; users had to
+      # pipx-install the backend by hand or hit ERR_CONNECTION_REFUSED.
+      # PyInstaller freezes prism_service into a single platform-native
+      # exe that ships alongside prism-shell.exe via bundle.externalBin.
+      # --------------------------------------------------------------------
+      - name: Setup Python (for sidecar build)
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install prism-service + pyinstaller into a sidecar venv
+        shell: bash
+        run: |
+          cd services/prism-service
+          python -m pip install --upgrade pip
+          python -m pip install pyinstaller
+          python -m pip install -e .
+
+      - name: Resolve Rust target triple for sidecar naming
+        id: triple
+        shell: bash
+        run: |
+          # tauri-action passes --target X via matrix.args on macOS; on
+          # linux/windows the matrix uses the host's default triple.
+          ARGS="${{ matrix.args }}"
+          if echo "$ARGS" | grep -q -- '--target'; then
+            TRIPLE=$(echo "$ARGS" | sed -E 's/.*--target +([^ ]+).*/\1/')
+          else
+            TRIPLE=$(rustc -vV | sed -n 's|host: ||p')
+          fi
+          echo "triple=$TRIPLE" >> "$GITHUB_OUTPUT"
+          echo "Sidecar target triple: $TRIPLE"
+
+      - name: Build prism-service sidecar (pyinstaller)
+        shell: bash
+        run: |
+          cd services/prism-service
+          pyinstaller installer/pyinstaller.spec --noconfirm --clean
+          ls -la dist/
+
+      - name: Stage sidecar into Tauri externalBin slot
+        shell: bash
+        run: |
+          cd services/prism-service
+          mkdir -p desktop/tauri-shell/src-tauri/binaries
+          TRIPLE="${{ steps.triple.outputs.triple }}"
+          if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
+            cp dist/prism-service.exe "desktop/tauri-shell/src-tauri/binaries/prism-service-${TRIPLE}.exe"
+          else
+            cp dist/prism-service "desktop/tauri-shell/src-tauri/binaries/prism-service-${TRIPLE}"
+            chmod +x "desktop/tauri-shell/src-tauri/binaries/prism-service-${TRIPLE}"
+          fi
+          ls -la desktop/tauri-shell/src-tauri/binaries/
+
       - name: Install Tauri shell deps
         run: |
           cd services/prism-service/desktop/tauri-shell

--- a/services/prism-service/.gitignore
+++ b/services/prism-service/.gitignore
@@ -8,6 +8,14 @@ data/
 data-v51/
 .prism/
 
+# PyInstaller sidecar build outputs (services/prism-service/installer/)
+build/
+dist/
+*.spec.bak
+
+# Staged Tauri sidecar binaries (built in CI, copied per target triple)
+desktop/tauri-shell/src-tauri/binaries/
+
 # IDE
 .vscode/
 .idea/

--- a/services/prism-service/desktop/tauri-shell/src-tauri/tauri.conf.json
+++ b/services/prism-service/desktop/tauri-shell/src-tauri/tauri.conf.json
@@ -32,6 +32,7 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "externalBin": ["binaries/prism-service"],
     "createUpdaterArtifacts": true
   },
   "plugins": {

--- a/services/prism-service/installer/pyinstaller.spec
+++ b/services/prism-service/installer/pyinstaller.spec
@@ -1,0 +1,133 @@
+# PyInstaller spec for the bundled prism-service Tauri sidecar.
+#
+# Build with (from services/prism-service/):
+#   pyinstaller installer/pyinstaller.spec --noconfirm --clean
+#
+# Output: dist/prism-service.exe (Windows) — a single-file frozen
+# bundle that the Tauri installer ships next to prism-shell.exe via
+# bundle.externalBin in tauri.conf.json.
+#
+# Prereqs satisfied by CI before invoking this spec:
+#   - npm run build inside prism_service/web/  (populates web_dist/)
+#   - pip install -e .[dev] inside services/prism-service
+#   - pip install pyinstaller
+#
+# `prism_service/web_dist/` is bundled as data (the SPA the frozen
+# uvicorn serves at /). Hidden imports cover the dynamic / lazy
+# imports PyInstaller's static analysis misses.
+# -*- mode: python ; coding: utf-8 -*-
+
+import os
+import sys
+from pathlib import Path
+
+# When PyInstaller invokes a spec, __file__ is not defined — anchor on
+# the spec's own dir via SPECPATH (PyInstaller injects this).
+HERE = Path(SPECPATH).resolve()
+SERVICE_ROOT = HERE.parent
+PKG_ROOT = SERVICE_ROOT / "prism_service"
+WEB_DIST = PKG_ROOT / "web_dist"
+
+if not WEB_DIST.exists():
+    raise SystemExit(
+        f"web_dist missing at {WEB_DIST} — run `npm run build` in "
+        f"prism_service/web/ before invoking pyinstaller"
+    )
+
+# Static assets the running service reads from disk relative to the
+# package root. PyInstaller copies these into sys._MEIPASS at runtime;
+# main.py's `Path(__file__).parent / 'web_dist'` resolves correctly
+# because PyInstaller rewrites __file__ for frozen modules.
+datas = [
+    (str(WEB_DIST), "prism_service/web_dist"),
+    (str(PKG_ROOT / "inference" / "prompts"), "prism_service/inference/prompts"),
+]
+
+# Hidden imports — modules referenced only via deferred / dynamic
+# import sites that PyInstaller's static analysis can't follow.
+# Errs on the side of completeness: 5MB of extra bytecode is cheaper
+# than a ModuleNotFoundError at runtime on a customer machine.
+hiddenimports = [
+    # Service modules pulled in lazily from main.py timer threads
+    "prism_service.engines.brain_engine",
+    "prism_service.engines.conductor_engine",
+    "prism_service.engines.understand_engine",
+    "prism_service.engines.query_decomposer",
+    "prism_service.engines.mulch",
+    "prism_service.mcp.server",
+    "prism_service.mcp.tools",
+    "prism_service.mcp.understand_tools",
+    "prism_service.routes.sse",
+    "prism_service.routes.graph_static",
+    "prism_service.services.scoring_service",
+    "prism_service.services.reflection_runner",
+    "prism_service.services.claude_transcripts",
+    "prism_service.services.auto_updater",
+    "prism_service.project_context",
+    # Third-party deferred / plugin-style imports
+    "uvicorn.logging",
+    "uvicorn.loops.auto",
+    "uvicorn.protocols.http.auto",
+    "uvicorn.protocols.websockets.auto",
+    "uvicorn.lifespan.on",
+    "sqlite_vec",
+    "model2vec",
+    "tokenizers",
+    "sentence_transformers",
+    "graphifyy",
+    "tree_sitter",
+    "tree_sitter_languages",
+    # MCP transport surface — pulled by name in server.py
+    "mcp.server.lowlevel",
+    "mcp.server.streamable_http",
+]
+
+
+a = Analysis(
+    [str(HERE / "service_entry.py")],
+    pathex=[str(SERVICE_ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # Heavy optional deps we don't need at runtime
+        "tkinter",
+        "matplotlib",
+        "PyQt5",
+        "PyQt6",
+        "PySide2",
+        "PySide6",
+        "IPython",
+        "jupyter",
+        "notebook",
+    ],
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+# --onefile equivalent: collect binaries + data into the single exe.
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="prism-service",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/services/prism-service/installer/service_entry.py
+++ b/services/prism-service/installer/service_entry.py
@@ -1,0 +1,56 @@
+"""PyInstaller entrypoint for the bundled prism-service sidecar.
+
+Frozen as `prism-service.exe` and dropped next to `prism-shell.exe` by
+the Tauri installer. The Tauri shell spawns this exe instead of looking
+for a host-installed Python — the user never has to run
+`pipx install prism-service`.
+
+Why a dedicated entry instead of reusing `prism_service.cli.prism_cli`:
+the CLI's foreground `start` re-execs `sys.executable -m prism_service.main`,
+which doesn't work inside a PyInstaller --onefile bundle (sys.executable
+points at the frozen exe; there's no `-m` semantics on the embedded
+interpreter). Tauri only ever needs one launch mode — synchronous
+foreground uvicorn — so we sidestep the CLI entirely.
+
+PyInstaller resolves `prism_service.main`'s deferred imports (FastAPI
+routes, engines, etc.) via the hidden-imports list in pyinstaller.spec.
+The SPA bundle at prism_service/web_dist/ is added as bundled data and
+loaded from sys._MEIPASS at runtime via the existing
+`Path(__file__).parent / "web_dist"` lookup in main.py.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def main() -> int:
+    # Default ports match the Tauri shell's WebView URL (7778) and the
+    # MCP transport (7777). Honor any env overrides the shell wants to
+    # pass through.
+    os.environ.setdefault("PRISM_UI_PORT", "7778")
+    os.environ.setdefault("PRISM_MCP_PORT", "7777")
+
+    # Force UTF-8 stdio so version notes / em-dashes in logs don't blow
+    # up under Windows cp1252.
+    if hasattr(sys.stdout, "reconfigure"):
+        try:
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+            sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+        except (AttributeError, OSError):
+            pass
+
+    # Deferred import — keeps PyInstaller's static analysis happy and
+    # surfaces a clear error message if the frozen bundle is missing a
+    # heavy dep (torch / fastapi / etc).
+    import uvicorn
+    from prism_service.config import UI_PORT
+    from prism_service.main import app
+
+    uvicorn.run(app, host="127.0.0.1", port=UI_PORT)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,28 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.0.41"
+PRISM_VERSION = "6.1.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.1.0: Windows installer is finally self-sufficient (closes #84). "
+    "The 6.0.x Tauri installer dropped prism-shell.exe on disk but no "
+    "backend, so a fresh-machine install rendered ERR_CONNECTION_REFUSED "
+    "until the user ran `pipx install prism-service` by hand. v6.1.0 "
+    "ships prism-service as a PyInstaller-frozen single-file exe bundled "
+    "alongside prism-shell.exe via Tauri's bundle.externalBin. New "
+    "services/prism-service/installer/ carries pyinstaller.spec and a "
+    "lightweight service_entry.py that boots uvicorn directly (sidesteps "
+    "the CLI's sys.executable -m re-exec which doesn't work under "
+    "PyInstaller). release-tauri.yml gains four steps before the Tauri "
+    "bundle: setup Python, pip install + pyinstaller, resolve the rust "
+    "target triple, run pyinstaller, copy dist/prism-service(.exe) into "
+    "src-tauri/binaries/prism-service-<triple>(.exe) so tauri-action "
+    "picks it up. tauri.conf.json bundle.externalBin entry teaches the "
+    "installer to ship it. Pairs with PR #85's ordered launcher "
+    "discovery — resolve_launcher() in lib.rs finds the bundled "
+    "prism-service.exe next to prism-shell.exe and spawns it; no host "
+    "Python required. "
     "v6.0.41: Give job rows the same title+description shape as worker rows. "
     "Each analyzer now has a friendly title (\"Onboarding writer\" instead of "
     "raw `onboarding_writer`) and a one-line purpose blurb pulled from the "


### PR DESCRIPTION
## Summary

Closes #84 (with #85). The 6.0.x Windows installer dropped `prism-shell.exe` on disk but no backend, so a fresh-machine install rendered `ERR_CONNECTION_REFUSED` until the user ran `pipx install prism-service` by hand. v6.1.0 ships the backend as a **PyInstaller-frozen single-file exe** bundled alongside `prism-shell.exe` via Tauri `bundle.externalBin`.

Pairs with #85 (splash UI + ordered launcher discovery). Once both merge into v6.1.0 a fresh-VM user downloads `PRISM_X.Y.Z_x64-setup.exe`, runs it, launches the app, and gets a working UI — no Docker, no Python, no separate installs.

## Changes

- **`services/prism-service/installer/pyinstaller.spec`** (new) — `--onefile` spec freezing `prism_service` into `prism-service.exe` with embedded CPython, all third-party deps, `web_dist/` as bundled data, and explicit hidden imports for the deferred / dynamic modules PyInstaller static analysis misses (engines, MCP server, transport, sqlite-vec, model2vec, sentence-transformers, tree-sitter, graphifyy, uvicorn auto-loaders).
- **`services/prism-service/installer/service_entry.py`** (new) — lightweight uvicorn entrypoint that sidesteps the CLI's `sys.executable -m prism_service.main` re-exec (doesn't work under a frozen `--onefile` bundle). Defaults `PRISM_UI_PORT=7778` / `PRISM_MCP_PORT=7777` (overridable by env from the Tauri shell), forces UTF-8 stdio, calls `uvicorn.run(app, host="127.0.0.1", port=UI_PORT)`.
- **`.github/workflows/release-tauri.yml`** — four new steps before `tauri-action`: (1) `actions/setup-python@v5` py3.12, (2) `pip install pyinstaller` + `pip install -e .`, (3) resolve the rust target triple (from `matrix.args --target X` on macOS, `rustc -vV` on linux/windows), (4) `pyinstaller installer/pyinstaller.spec`, (5) copy `dist/prism-service(.exe)` to `src-tauri/binaries/prism-service-<triple>(.exe)` so `tauri-action` picks it up.
- **`services/prism-service/desktop/tauri-shell/src-tauri/tauri.conf.json`** — single line: `bundle.externalBin: ["binaries/prism-service"]`. (No other file under tauri-shell/ is touched — that's #85's territory.)
- **`services/prism-service/prism_service/__version__.py`** — bump 6.0.41 to 6.1.0 with the v6.1.0 release note. No "Phase 1 / Phase 2" framing; v6.1.0 ships the actual fix.
- **`services/prism-service/.gitignore`** — ignore PyInstaller `build/` + `dist/` outputs and the staged `src-tauri/binaries/` dir.

## Local verification

PyInstaller built `dist/prism-service.exe` (240 MB) on Windows from the spec. The frozen exe was launched on isolated port `17780` (no collision with dev `:8888` or release `:7778`); `GET /api/version` returned `{"version":"6.1.0", ...}` within **8 seconds** of cold start. Bundle is functional end-to-end on the sidecar side.

What couldn't be verified locally: the full Tauri MSI build (5-10 min cross-platform Rust compile per the brief) and the clean-VM Windows installer smoke. Those are gated on the CI Tauri bundle pipeline that fires on the next `v*` tag.

## PRISM conductor

Task `ab1fe289-9626-4fba-835b-0119b1e068ad`, workflow_step=`green_gate`, gate_state=`passed`.

Overrides at red_gate (no installer integration test harness yet in the repo) and green_gate (full clean-VM Windows install smoke gated on CI bundle build per the ticket brief), both with explicit validation reasons recorded.

## Test plan

- [ ] CI: `release-tauri.yml` runs to green on the v6.1.0 tag — pyinstaller produces `prism-service.exe` on the Windows runner, sidecar gets staged into `src-tauri/binaries/prism-service-x86_64-pc-windows-msvc.exe`, `tauri-action` picks it up and lands it in the `.msi`.
- [ ] After #85 merges: on a fresh Windows machine with no Docker / no Python / no prior PRISM install, run `PRISM_6.1.0_x64-setup.exe`, launch the app, see the splash transition to the main UI without manual `pipx install`.
- [ ] On a fresh macOS machine: same workflow with the `.dmg` (sidecar built for both `aarch64-apple-darwin` and `x86_64-apple-darwin` by the matrix).
- [ ] On a fresh Linux: `.AppImage` / `.deb` with `prism-service-x86_64-unknown-linux-gnu` sidecar.