### PR TITLE
fix(v6.1.3): /conductor swimlanes filter out status=done

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.1.2"
+PRISM_VERSION = "6.1.3"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.1.3: /conductor swimlanes no longer accumulate shipped work. "
+    "ConductorService.managed_tasks() + step_buckets() now filter out "
+    "status=done — on the prism dev instance, 14 of 15 visible lane "
+    "tiles were historical green_gate=passed tasks (every previous "
+    "ship), drowning the one actively-managed task. Done means done; "
+    "workflow_step stays on the row for audit but the conductor view "
+    "treats it as not-currently-managed. One-line change in "
+    "prism_service/services/conductor_service.py.\n\n"
     "v6.1.2: MemoryPage groups by value + surfaces unused metadata. The "
     "47-tile wall is now bucketed top-down: 'Proven' (recalled in real "
     "sessions, emerald-ringed tiles), 'High value' (author marked "

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1353,6 +1353,12 @@ class ConductorService:
         A task is "managed" when workflow_step is non-empty OR gate_state
         is not 'none'. Tasks worked raw (status flips only) are not
         included — they don't appear on the /conductor page.
+
+        v6.1.3: filter out status=done. Conductor swimlanes had been
+        accumulating every task that ever reached green_gate, polluting
+        the active view (14 of 15 visible tiles were done shipped work).
+        Done means done — it stays in the audit trail (workflow_step is
+        not cleared) but doesn't show as currently-managed work.
         """
         if self._task_svc is None:
             return []
@@ -1364,7 +1370,10 @@ class ConductorService:
         for t in tasks:
             step = getattr(t, "workflow_step", "") or ""
             gate = getattr(t, "gate_state", "none") or "none"
+            status = getattr(t, "status", "") or ""
             if step == "" and gate == "none":
+                continue
+            if status == "done":
                 continue
             out.append({
                 "id": t.id,
@@ -1388,7 +1397,9 @@ class ConductorService:
         """Count of conductor-managed tasks per workflow_step.
 
         Used by the /conductor stepper to show "12 tasks at implement_tasks,
-        3 at red_gate" at a glance.
+        3 at red_gate" at a glance. v6.1.3: status=done excluded — same
+        rationale as managed_tasks (counters were inflated by historical
+        shipped work).
         """
         if self._task_svc is None:
             return {}
@@ -1400,6 +1411,7 @@ class ConductorService:
         counter: Counter[str] = Counter()
         for t in tasks:
             step = getattr(t, "workflow_step", "") or ""
-            if step:
+            status = getattr(t, "status", "") or ""
+            if step and status != "done":
                 counter[step] += 1
         return dict(counter)


### PR DESCRIPTION
## Summary

`ConductorService.managed_tasks()` + `step_buckets()` were returning every task that ever passed through the conductor regardless of status. On the dev instance, **14 of 15** visible swimlane tiles were historical `green_gate=passed` shipped work — drowning the single actively-managed task.

Fix: one-line filter in each function — skip `status == "done"`. `workflow_step` stays on the row for audit, but the conductor view treats done as not-currently-managed.

## Test plan
- [x] Dev daemon at 8888 verified the bug (14/15 done tiles on /conductor before fix)
- [ ] After v6.1.3 deploy on Ubuntu release 7778: `/api/conductor/state` returns only active tasks
- [ ] /conductor page renders only the currently-managed task instead of the wall of shipped ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)