### PR TITLE
fix(v6.1.4): CORS for Tauri shell splash + sync lifespan thread count (closes #88)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,24 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.1.3"
+PRISM_VERSION = "6.1.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.1.4: fix Tauri shell splash hang on cold-launch. The standalone "
+    "GUI was sitting at \"Starting backend…\" until its 30s timeout "
+    "because the backend served /api/version with no "
+    "Access-Control-Allow-Origin header — the webview origin "
+    "(tauri://localhost on Mac/Linux, http(s)://tauri.localhost on "
+    "Windows WebView2) is cross-origin, so the browser dropped the "
+    "response body and the splash never resolved. Added CORSMiddleware "
+    "in prism_service/main.py scoped to the Tauri origins (single "
+    "allow_origin_regex covers all three forms), allow_methods=['*'] so "
+    "the OPTIONS preflight stops returning 405. Same fix unblocks the "
+    "cross-origin /sse/sessions stream the SPA consumes once the splash "
+    "is past. Pinned by tests/unit/test_main_cors_headers.py — 6 cases "
+    "across {GET, OPTIONS preflight} × {tauri://localhost, "
+    "http://tauri.localhost, https://tauri.localhost}. Closes #88.\n\n"
     "v6.1.3: /conductor swimlanes no longer accumulate shipped work. "
     "ConductorService.managed_tasks() + step_buckets() now filter out "
     "status=done — on the prism dev instance, 14 of 15 visible lane "

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -20,6 +20,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 import uvicorn
@@ -240,6 +241,19 @@ async def lifespan(_app: FastAPI):
 
 
 app = FastAPI(title="PRISM Service", lifespan=lifespan)
+
+# The standalone Tauri shell loads its splash from a tauri:// origin and
+# polls /api/version cross-origin. Without these headers the webview sends
+# the request (server logs it, returns 200) but the browser silently drops
+# the response body — splash hangs at "Starting backend…" for 30s and
+# falls through to a misleading "install via pipx" error (issue #88).
+# Loopback-only socket so no allow_credentials needed.
+app.add_middleware(
+    CORSMiddleware,
+    allow_origin_regex=r"^(tauri://localhost|https?://tauri\.localhost)$",
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # JSON API for the SPA + non-API routes (SSE, graph viewer).
 from prism_service.api import api_router

--- a/services/prism-service/tests/unit/test_lifespan_lock_recovery.py
+++ b/services/prism-service/tests/unit/test_lifespan_lock_recovery.py
@@ -43,11 +43,18 @@ def test_lifespan_starts_threads_when_no_lock(isolated_lock):
             patch("prism_service.main._install_stackdump_handler"):
         _run_lifespan()
 
-    # 8 daemon threads (v6.0.x): mcp + governance + drift + quality +
-    # understand_drainer + trash_sweeper + transcript_importer + one
-    # spawned indirectly via start_auto_updater / start_reflection_worker.
+    # 9 daemon threads as of v6.1.1:
+    #   7 explicit in main.py — mcp + governance + drift + quality +
+    #     understand_drainer + trash_sweeper + transcript_importer
+    #   1 from start_auto_updater() (always starts)
+    #   1 from start_memory_summary_worker() (defaults ON, v6.1.1+)
+    # reflection_worker is OFF by default (PRISM_REFLECTION_WORKER=on
+    # to opt in) so it does NOT add to the count here.
+    # patch("prism_service.main.threading.Thread") mutates the global
+    # threading module, so threads started inside the indirectly-imported
+    # services are also intercepted.
     started = [c for c in mock_t.return_value.start.mock_calls]
-    assert len(started) == 8
+    assert len(started) == 9
 
 
 def test_lifespan_reclaims_stale_lock_and_starts_threads(isolated_lock, capsys):
@@ -60,8 +67,8 @@ def test_lifespan_reclaims_stale_lock_and_starts_threads(isolated_lock, capsys):
         _run_lifespan()
 
     started = [c for c in mock_t.return_value.start.mock_calls]
-    # Same 8 threads — see test_lifespan_starts_threads_when_no_lock.
-    assert len(started) == 8  # threads started despite the stale lock
+    # Same 9 threads — see test_lifespan_starts_threads_when_no_lock.
+    assert len(started) == 9  # threads started despite the stale lock
 
     err = capsys.readouterr().err
     assert "stale lock detected" in err

--- a/services/prism-service/tests/unit/test_main_cors_headers.py
+++ b/services/prism-service/tests/unit/test_main_cors_headers.py
@@ -1,0 +1,81 @@
+"""CORS smoke test for the Tauri shell splash path (closes issue #88).
+
+The standalone Tauri shell loads its splash from a tauri:// origin and
+fetches http://127.0.0.1:7778/api/version cross-origin. Without
+CORSMiddleware the response carries no Access-Control-Allow-Origin
+header — the browser silently drops the response body and the splash
+hangs at "Starting backend…" until its 30s timeout fires.
+
+These tests pin the server contract so that class of break can't slip
+into a release again. They:
+
+  1. assert /api/version returns an `access-control-allow-origin`
+     header that matches the Origin: tauri://localhost the request
+     was made with;
+  2. assert the OPTIONS preflight returns 200 (not 405) for the same
+     Origin — which is the second wall the splash hit after the GET;
+  3. cover the Windows WebView2 origin `http(s)://tauri.localhost` too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+httpx = pytest.importorskip("httpx")
+testclient_mod = pytest.importorskip("fastapi.testclient")
+TestClient = testclient_mod.TestClient
+
+from prism_service.main import app
+
+
+@pytest.fixture(scope="module")
+def client() -> TestClient:
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+    ],
+)
+def test_api_version_returns_cors_allow_origin_for_tauri(client, origin):
+    r = client.get("/api/version", headers={"Origin": origin})
+    assert r.status_code == 200
+    assert r.headers.get("access-control-allow-origin") == origin, (
+        f"expected access-control-allow-origin: {origin}, "
+        f"got: {dict(r.headers)!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "origin",
+    [
+        "tauri://localhost",
+        "http://tauri.localhost",
+        "https://tauri.localhost",
+    ],
+)
+def test_api_version_options_preflight_succeeds_for_tauri(client, origin):
+    r = client.options(
+        "/api/version",
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert r.status_code == 200, (
+        f"OPTIONS preflight should return 200, got {r.status_code}; "
+        f"a 405 here is the symptom of missing CORSMiddleware"
+    )
+    assert r.headers.get("access-control-allow-origin") == origin


### PR DESCRIPTION
## Summary

- Add `CORSMiddleware` to `prism_service/main.py` scoped to the Tauri webview origins so `/api/version` returns `Access-Control-Allow-Origin` on the cross-origin splash poll — fixes the v6.1.0 GUI hang at "Starting backend…" (issue #88).
- Pin the contract: 6 new test cases × {GET, OPTIONS preflight} × {tauri://localhost, http://tauri.localhost, https://tauri.localhost}.
- Sync `test_lifespan_lock_recovery` thread count 8 → 9 — v6.1.1 added `start_memory_summary_worker` (defaults ON) as a 9th background thread and the counter was never updated. Investigated as a real signal, not as "pre-existing."

## Verification

Ran the issue body's verification steps against a real uvicorn from this branch on temp ports 9887/9888 (dev :8888 untouched):

| # | Step | Result |
|---|---|---|
| 1 | `GET /api/version` `Origin: tauri://localhost` | 200, ACAO: `tauri://localhost`, vary: Origin |
| 2 | `GET /api/version` `Origin: http://tauri.localhost` (WebView2) | 200, ACAO: `http://tauri.localhost` |
| 3 | `GET /api/version` `Origin: https://tauri.localhost` | 200, ACAO: `https://tauri.localhost` |
| 4 | `OPTIONS /api/version` preflight | 200 (was 405), allow-methods: DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT |
| 5 | Control — no Origin header | 200, no ACAO leaked |
| 6 | Hostile origin `evil.example` | 200, no ACAO (CORS-blocked) |

Unit suite: **440/440 pass** on this branch (was 438+2-fail on main; the 2 failures were the lifespan thread-count drift fixed here).

## Test plan

- [x] RED proven before patch (`access-control-allow-origin` missing on cross-origin GET)
- [x] GREEN after patch (6 new cases + 440 total)
- [x] Real curl against running uvicorn — issue body's verification steps all pass
- [ ] CI green
- [ ] Dev daemon at :8888 bounced post-merge, `/api/version` reports v6.1.4
- [ ] Cross-origin curl against the running dev daemon shows the same ACAO behavior

Closes #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)