### PR TITLE
feat(v6.1.5): PageRank centrality on entities (Ultimate Graph slice 3)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,30 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.1.4"
+PRISM_VERSION = "6.1.5"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.1.5: Ultimate Graph slice 3 — PageRank centrality persisted on "
+    "entities at graph_rebuild. New _compute_pagerank() in "
+    "prism_service/services/graph_service.py runs a pure-Python power "
+    "iteration over (nodes, links) with damping=0.85, n_iter=30, "
+    "redistributing dangling-node mass uniformly so total stays 1.0 — "
+    "no new dep, networkx would be overkill for entity tables bounded "
+    "by repo size (typically <10k nodes). Schema migration adds "
+    "`centrality REAL DEFAULT 0` to entities + descending partial "
+    "index for cheap top-N reads. _import_graph_json now UPDATEs the "
+    "score on every rebuild, alongside the existing community pass. "
+    "New GraphService.top_central_entities() + GET /api/graph/central "
+    "expose the ranked list. /graph page gains a 'Top hubs by "
+    "PageRank' card under the Sigma viewer. First piece of the "
+    "Ultimate Graph epic (siegeon/.prism#50) — slices 1,2,4,5,6 "
+    "(annotation schema, graph_annotate/graph_jobs MCP tools, "
+    "/api/understand contract, /understand page, background enrichment "
+    "loop) follow on subsequent patches. Tests at "
+    "tests/unit/test_graph_pagerank.py — 5 cases covering ordering, "
+    "empty graphs, all-dangling, schema migration idempotency, and "
+    "top_central_entities desc ordering.\n\n"
     "v6.1.4: fix Tauri shell splash hang on cold-launch. The standalone "
     "GUI was sitting at \"Starting backend…\" until its 30s timeout "
     "because the backend served /api/version with no "

--- a/services/prism-service/prism_service/api/graph.py
+++ b/services/prism-service/prism_service/api/graph.py
@@ -104,6 +104,25 @@ def communities(project: str = Query("default")) -> dict:
     return {"communities": svc.communities()}
 
 
+@router.get("/central")
+def central(
+    project: str = Query("default"),
+    limit: int = Query(20, ge=1, le=200),
+) -> dict:
+    """Top-N entities by PageRank centrality (v6.1.5).
+
+    Returns ``{entities: [{name, kind, file, line, community, centrality}]}``
+    sorted by centrality desc. The score is recomputed each graph_rebuild
+    and persisted on entities.centrality; rows with centrality == 0 are
+    excluded (pre-v6.1.5 builds had no column).
+    """
+    try:
+        svc = get_project(project).graph_svc
+    except Exception as exc:
+        raise HTTPException(404, f"unknown project: {project}: {exc}")
+    return {"entities": svc.top_central_entities(limit=limit)}
+
+
 @router.get("/community-files")
 def community_files(
     community_id: int = Query(..., ge=0),

--- a/services/prism-service/prism_service/services/graph_service.py
+++ b/services/prism-service/prism_service/services/graph_service.py
@@ -56,6 +56,10 @@ def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
         # when the user-provided name doesn't match the canonical
         # name exactly. Indexed below for cheap fallback resolution.
         ("norm_label",      "ALTER TABLE entities ADD COLUMN norm_label TEXT"),
+        # v6.1.5 — PageRank centrality, computed at rebuild and used as
+        # the universal rank/RRF/Sigma-size signal. Defaults to 0 for
+        # rows that predate the migration.
+        ("centrality",      "ALTER TABLE entities ADD COLUMN centrality REAL DEFAULT 0"),
     ):
         if col not in ent_cols:
             try:
@@ -68,6 +72,16 @@ def _graph_schema_migrations(conn: sqlite3.Connection) -> None:
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_ent_norm_label "
             "ON entities(norm_label) WHERE norm_label IS NOT NULL"
+        )
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+    # v6.1.5 — index centrality descending so "top hubs" queries scan
+    # cheaply (LIMIT 20 from a table with a few thousand entities).
+    try:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_ent_centrality "
+            "ON entities(centrality DESC) WHERE centrality > 0"
         )
         conn.commit()
     except sqlite3.OperationalError:
@@ -137,6 +151,50 @@ import re as _re
 from collections import Counter as _Counter
 
 _WORD_RE = _re.compile(r"[A-Za-z][A-Za-z0-9]*")
+
+
+def _compute_pagerank(
+    nodes: list[dict],
+    links: list[dict],
+    n_iter: int = 30,
+    damping: float = 0.85,
+) -> dict[str, float]:
+    """Power-iteration PageRank over the graphify (nodes, links) snapshot.
+
+    Returns ``{graphify_id: score}``. Pure-Python so no new dep is
+    pulled in for this single use; networkx would be overkill for an
+    entity table that's bounded by repo size (typically <10k nodes).
+
+    Dangling nodes (no outbound edges) redistribute their mass uniformly
+    every iteration so the score sum stays at 1.0. Empty graphs return
+    an empty dict.
+    """
+    node_ids = [n.get("id") for n in nodes if n.get("id")]
+    if not node_ids:
+        return {}
+    n = len(node_ids)
+    out_adj: dict[str, list[str]] = {nid: [] for nid in node_ids}
+    valid = set(node_ids)
+    for link in links:
+        src = link.get("source") or link.get("_src")
+        tgt = link.get("target") or link.get("_tgt")
+        if src in valid and tgt in valid:
+            out_adj[src].append(tgt)
+    teleport = (1.0 - damping) / n
+    ranks: dict[str, float] = {nid: 1.0 / n for nid in node_ids}
+    for _ in range(n_iter):
+        # Mass from dangling nodes (no outbound edges) gets uniformly
+        # redistributed so the total mass stays 1.0.
+        dangling_mass = sum(ranks[nid] for nid in node_ids if not out_adj[nid])
+        new = {nid: teleport + damping * dangling_mass / n for nid in node_ids}
+        for src, targets in out_adj.items():
+            if not targets:
+                continue
+            share = damping * ranks[src] / len(targets)
+            for tgt in targets:
+                new[tgt] += share
+        ranks = new
+    return ranks
 
 
 def _basename_stem(path: str) -> str:
@@ -819,6 +877,26 @@ class GraphService:
                 except sqlite3.IntegrityError:
                     pass
 
+            # -- Compute + persist PageRank centrality -------------------
+            # v6.1.5 — universal node score for rank/RRF/Sigma sizing
+            # (Ultimate Graph slice 3). Runs after the entity insert so
+            # the UPDATE matches on graphify_id. Bounded by repo size; a
+            # ~10k-node graph converges well within the 30 iterations.
+            pagerank = _compute_pagerank(nodes, links)
+            if pagerank:
+                for gid, score in pagerank.items():
+                    try:
+                        conn.execute(
+                            "UPDATE entities SET centrality = ? "
+                            "WHERE graphify_id = ?",
+                            (float(score), gid),
+                        )
+                    except sqlite3.OperationalError:
+                        # centrality column missing — schema migration
+                        # likely raced; the next rebuild will retry.
+                        break
+                result["centrality_nodes"] = len(pagerank)
+
             # -- Derive + persist community labels -----------------------
             from collections import defaultdict
             buckets: dict[int, list[dict]] = defaultdict(list)
@@ -982,6 +1060,44 @@ class GraphService:
             })
         conn.close()
         return out
+
+    def top_central_entities(self, limit: int = 20) -> list[dict]:
+        """Top-N entities by PageRank centrality (v6.1.5).
+
+        Returns ``[{name, kind, file, line, community, centrality}, ...]``
+        sorted by centrality desc. Empty list when the column is missing
+        (pre-v6.1.5 graph.db) or the rebuild hasn't populated it.
+        """
+        try:
+            conn = sqlite3.connect(self._graph_db, timeout=5.0)
+            conn.row_factory = sqlite3.Row
+        except sqlite3.Error:
+            return []
+        try:
+            rows = conn.execute(
+                "SELECT name, kind, file, line, community, centrality "
+                "FROM entities "
+                "WHERE centrality > 0 "
+                "ORDER BY centrality DESC "
+                "LIMIT ?",
+                (max(1, min(int(limit), 200)),),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            conn.close()
+            return []
+        conn.close()
+        return [
+            {
+                "name": r["name"] or "",
+                "kind": r["kind"] or "",
+                "file": r["file"] or "",
+                "line": int(r["line"]) if r["line"] is not None else None,
+                "community": (int(r["community"])
+                              if r["community"] is not None else None),
+                "centrality": float(r["centrality"] or 0.0),
+            }
+            for r in rows
+        ]
 
     def community_files(self, community_id: int) -> list[str]:
         """Distinct file paths whose entities belong to the given community."""

--- a/services/prism-service/prism_service/web/src/pages/GraphPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/GraphPage.tsx
@@ -13,13 +13,26 @@ type Summary = {
   viewer_url: string;
 };
 
+type CentralEntity = {
+  name: string;
+  kind: string;
+  file: string;
+  line: number | null;
+  community: number | null;
+  centrality: number;
+};
+
 export default function GraphPage() {
   const [project] = useProject();
   const [data, setData] = useState<Summary | null>(null);
+  const [central, setCentral] = useState<CentralEntity[] | null>(null);
   const [rebuilding, setRebuilding] = useState(false);
 
   const load = useCallback(() => {
     api.get<Summary>(`/api/graph/summary?project=${project}`).then(setData).catch(() => setData(null));
+    api.get<{ entities: CentralEntity[] }>(`/api/graph/central?project=${project}&limit=15`)
+      .then((r) => setCentral(r.entities))
+      .catch(() => setCentral([]));
   }, [project]);
 
   useEffect(load, [load]);
@@ -60,6 +73,34 @@ export default function GraphPage() {
               <div>No graph yet for this project — hit Rebuild.</div>
             </Empty>
           </div>
+        )}
+      </Card>
+
+      <Card className="!p-5">
+        <SectionLabel>Top hubs by PageRank</SectionLabel>
+        <div className="text-xs opacity-60 mb-3">
+          Universal centrality score persisted on every <code>graph_rebuild</code>.
+          Drives ranking, RRF boost, and Sigma node size as the Ultimate Graph
+          slices land.
+        </div>
+        {central && central.length > 0 ? (
+          <ol className="space-y-1.5 text-sm">
+            {central.map((e, i) => (
+              <li key={`${e.file}:${e.name}:${i}`} className="flex items-baseline gap-3">
+                <span className="opacity-40 font-mono w-6 text-right">{i + 1}.</span>
+                <span className="font-mono truncate">{e.name || "(anon)"}</span>
+                <span className="opacity-50 text-xs">{e.kind}</span>
+                <span className="opacity-40 text-xs truncate flex-1">{e.file}{e.line ? `:${e.line}` : ""}</span>
+                <span className="font-mono text-xs tabular-nums opacity-70">
+                  {e.centrality.toFixed(4)}
+                </span>
+              </li>
+            ))}
+          </ol>
+        ) : (
+          <Empty>
+            <div>No centrality yet — rebuild on v6.1.5+ to compute PageRank.</div>
+          </Empty>
         )}
       </Card>
     </Page>

--- a/services/prism-service/tests/unit/test_graph_pagerank.py
+++ b/services/prism-service/tests/unit/test_graph_pagerank.py
@@ -1,0 +1,131 @@
+"""Tests for v6.1.5 PageRank centrality on entities (Ultimate Graph slice 3)."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def test_pagerank_ordering_hub_beats_leaf():
+    """Hub with three in-edges should out-rank a leaf with one.
+
+    Topology: a, b, c all point at hub; a also points at leaf. Hub
+    therefore accumulates b's and c's mass plus half of a's; leaf only
+    sees half of a's. Hub > leaf > {a, b, c}.
+    """
+    from prism_service.services.graph_service import _compute_pagerank
+
+    nodes = [{"id": "hub"}, {"id": "a"}, {"id": "b"}, {"id": "c"}, {"id": "leaf"}]
+    links = [
+        {"source": "a", "target": "hub"},
+        {"source": "a", "target": "leaf"},
+        {"source": "b", "target": "hub"},
+        {"source": "c", "target": "hub"},
+    ]
+    ranks = _compute_pagerank(nodes, links)
+    assert set(ranks.keys()) == {"hub", "a", "b", "c", "leaf"}
+    assert ranks["hub"] > ranks["leaf"], ranks
+    assert ranks["leaf"] > ranks["a"], ranks
+    total = sum(ranks.values())
+    assert abs(total - 1.0) < 1e-6, total
+
+
+def test_pagerank_empty_graph_returns_empty():
+    from prism_service.services.graph_service import _compute_pagerank
+    assert _compute_pagerank([], []) == {}
+    assert _compute_pagerank([{"id": ""}], []) == {}
+
+
+def test_pagerank_dangling_redistributes_mass():
+    """All nodes dangling (no edges) — uniform 1/n score."""
+    from prism_service.services.graph_service import _compute_pagerank
+
+    nodes = [{"id": "x"}, {"id": "y"}, {"id": "z"}]
+    ranks = _compute_pagerank(nodes, [])
+    assert len(ranks) == 3
+    for v in ranks.values():
+        assert abs(v - 1.0 / 3.0) < 1e-6
+
+
+def test_schema_migration_adds_centrality(tmp_path: Path):
+    """_graph_schema_migrations is idempotent and lands centrality."""
+    from prism_service.services.graph_service import _graph_schema_migrations
+
+    db = tmp_path / "graph.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        "CREATE TABLE entities ("
+        "  id INTEGER PRIMARY KEY, name TEXT, kind TEXT,"
+        "  file TEXT, line INTEGER,"
+        "  UNIQUE(name, file)"
+        ");"
+        "CREATE TABLE relationships ("
+        "  id INTEGER PRIMARY KEY,"
+        "  source_id INTEGER, target_id INTEGER, relation TEXT"
+        ");"
+        "CREATE TABLE communities (id INTEGER PRIMARY KEY, label TEXT,"
+        "  size INTEGER, top_files TEXT, top_entities TEXT, summary TEXT);"
+    )
+    _graph_schema_migrations(conn)
+    # second call is a no-op (idempotent)
+    _graph_schema_migrations(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(entities)").fetchall()}
+    assert "centrality" in cols
+    # default 0 on a new row
+    conn.execute("INSERT INTO entities (name, file) VALUES ('foo', 'a.py')")
+    conn.commit()
+    row = conn.execute("SELECT centrality FROM entities WHERE name='foo'").fetchone()
+    assert row[0] == 0.0
+    conn.close()
+
+
+def test_top_central_entities_orders_desc(tmp_path: Path, monkeypatch):
+    """top_central_entities returns rows sorted by centrality desc, skips zero."""
+    from prism_service.services.graph_service import (
+        GraphService,
+        _graph_schema_migrations,
+    )
+
+    proj_dir = tmp_path / "proj"
+    proj_dir.mkdir()
+    db = tmp_path / "graph.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        "CREATE TABLE entities ("
+        "  id INTEGER PRIMARY KEY, name TEXT, kind TEXT,"
+        "  file TEXT, line INTEGER,"
+        "  UNIQUE(name, file)"
+        ");"
+        "CREATE TABLE relationships ("
+        "  id INTEGER PRIMARY KEY,"
+        "  source_id INTEGER, target_id INTEGER, relation TEXT"
+        ");"
+        "CREATE TABLE communities (id INTEGER PRIMARY KEY, label TEXT,"
+        "  size INTEGER, top_files TEXT, top_entities TEXT, summary TEXT);"
+    )
+    _graph_schema_migrations(conn)
+    conn.executemany(
+        "INSERT INTO entities (name, kind, file, line, centrality) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("hub", "func", "a.py", 10, 0.42),
+            ("mid", "func", "b.py", 20, 0.13),
+            ("leaf", "func", "c.py", 30, 0.05),
+            ("orphan", "func", "d.py", 40, 0.0),
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    svc = GraphService(project_data_dir=str(proj_dir), graph_db_path=str(db))
+    rows = svc.top_central_entities(limit=10)
+    assert [r["name"] for r in rows] == ["hub", "mid", "leaf"]
+    assert rows[0]["centrality"] > rows[1]["centrality"] > rows[2]["centrality"]
+    assert rows[0]["file"] == "a.py"
+    assert rows[0]["line"] == 10


### PR DESCRIPTION
## Summary
- First slice of the Ultimate Graph epic (#50). Adds a universal centrality score on entities that future slices (RRF boost, Sigma node sizing, rank fusion in `/understand`) consume.
- Pure-Python power-iteration PageRank in `graph_service._compute_pagerank` — no new dep; networkx would be overkill for entity tables bounded by repo size.
- Schema migration adds `centrality REAL DEFAULT 0` to `entities` + partial descending index; `_import_graph_json` writes the score on every rebuild.
- New `GET /api/graph/central?limit=N` + `GraphService.top_central_entities()`; `/graph` page renders a "Top hubs by PageRank" card so the slice has a visible UI surface today.

## Test plan
- [x] `pytest tests/unit/test_graph_pagerank.py` — 5 cases (ordering, empty, all-dangling, schema idempotency, top desc)
- [x] `pytest tests/unit/test_graph_*` — 14 passed, no regressions
- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `vite build` — clean (web_dist regenerated)
- [ ] After merge: bounce dev daemon at :8888, hit `/api/graph/rebuild?project=prism`, verify `GET /api/graph/central` returns top entities, check `/graph` page renders the Top hubs card with non-zero centralities

## Out of scope (follow-up slices)
- Slice 1 (graph_jobs + graph_annotations schema)
- Slice 2 (`graph_annotate` / `graph_jobs_next` MCP tools)
- Slice 4 (`POST /api/understand` + `brain_understand` MCP tool)
- Slice 5 (one React `/understand` page replacing `/brain` + `/graph`)
- Slice 6 (background enrichment loop)
- Wiring centrality into Sigma node sizing (graph_static.py currently uses local degree) + brain_search RRF boost — those land in their own commits once this base column exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)