### PR TITLE
fix(v6.2.7): restore auto-update (native version sync + service default on)

### DIFF
--- a/.github/workflows/release-tauri.yml
+++ b/.github/workflows/release-tauri.yml
@@ -127,6 +127,18 @@ jobs:
           cd services/prism-service/desktop/tauri-shell
           npm install --no-audit --no-fund
 
+      # Keep the native bundle + latest.json version in lockstep with
+      # PRISM_VERSION. Without this the shell version was frozen at 0.1.0,
+      # so every release's latest.json reported 0.1.0 and installed native
+      # clients (also 0.1.0) never saw a newer version -> no auto-update.
+      - name: Sync Tauri version to PRISM_VERSION
+        shell: bash
+        run: |
+          cd services/prism-service
+          V=$(python -c "import re,pathlib; print(re.search(r'PRISM_VERSION\s*=\s*\"([^\"]+)\"', pathlib.Path('prism_service/__version__.py').read_text()).group(1))")
+          python -c "import json,pathlib; p=pathlib.Path('desktop/tauri-shell/src-tauri/tauri.conf.json'); d=json.loads(p.read_text()); d['version']='$V'; p.write_text(json.dumps(d, indent=2) + '\n')"
+          echo "tauri.conf.json version -> $V"; grep '\"version\"' desktop/tauri-shell/src-tauri/tauri.conf.json
+
       - name: Build + sign Tauri bundle
         uses: tauri-apps/tauri-action@v0
         env:

--- a/services/prism-service/desktop/tauri-shell/src-tauri/tauri.conf.json
+++ b/services/prism-service/desktop/tauri-shell/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "PRISM",
-  "version": "0.1.0",
+  "version": "6.2.7",
   "identifier": "studio.prism.app",
   "build": {
     "frontendDist": "../src"

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,26 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.6"
+PRISM_VERSION = "6.2.7"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.7: fix auto-update — it had silently stopped. Two root causes. "
+    "(1) The native (Tauri) shell version was hardcoded '0.1.0' in "
+    "tauri.conf.json and never bumped, so EVERY release published a "
+    "latest.json reporting version 0.1.0; installed native clients (also "
+    "0.1.0) compared equal and never saw a newer version -> no bundle "
+    "auto-update, ever. Fix: tauri.conf.json -> 6.2.7 AND release-tauri.yml "
+    "now injects PRISM_VERSION into tauri.conf.json at build time so it can "
+    "never drift again. Because current installs are all 0.1.0, 6.2.7 > "
+    "0.1.0 -> the whole native fleet updates via the Tauri updater on its "
+    "next check (works through the existing update path). (2) v6.2.4 made "
+    "the SERVICE pip auto-update OPT-IN (PRISM_AUTO_UPDATE default off), "
+    "which broke the in-place self-update server/docker installs relied on. "
+    "The silent-death cause was the os.execvp self-restart (already removed "
+    "in v6.2.4), NOT the apply; apply runs pip in the daemon thread + only "
+    "sets restart_required (no process replacement, UI loop keeps serving). "
+    "So default is restored to ON; set PRISM_AUTO_UPDATE=off to opt out. "
     "v6.2.6: dashboard — drop the unclear Workflow-lanes panel; add Token "
     "usage tracking. /api/dashboard/activity now returns a tokens block "
     "(per-day series + total/sessions/avg) summed from scores.db "

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -62,12 +62,15 @@ GITHUB_REPO = os.environ.get("PRISM_UPDATE_REPO", "siegeon/.prism")
 _API_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases/latest"
 _USER_AGENT = f"prism-service/{PRISM_VERSION} (auto-updater)"
 _POLL_INTERVAL_S = int(os.environ.get("PRISM_AUTO_UPDATE_INTERVAL", "1800"))
-# Issue #66: auto-apply is now OPT-IN. A long-lived daemon silently
-# pip-installing a new wheel into itself (a multi-minute, blocking,
-# subprocess-heavy op inside the live server) wedged the UI port for
-# ~2 min and then vanished. Checking for updates stays on (so the SPA
-# can surface "update available"); APPLYING is off unless asked.
-_AUTO_APPLY = os.environ.get("PRISM_AUTO_UPDATE", "off").lower() in (
+# Auto-apply is ON by default (restored in v6.2.7). The v6.2.4 silent
+# death was the os.execvp self-restart (removed below), NOT the apply
+# itself: apply now runs `pip install --upgrade` in THIS background
+# daemon thread (the asyncio UI loop on the main thread keeps serving —
+# subprocess.run releases the GIL while waiting) and only sets
+# restart_required=True; it never replaces the live process. Native
+# (Tauri) installs update via the Tauri updater bundle-swap instead, so
+# the pip path there simply no-ops. Set PRISM_AUTO_UPDATE=off to opt out.
+_AUTO_APPLY = os.environ.get("PRISM_AUTO_UPDATE", "on").lower() in (
     "on", "true", "1", "yes",
 )
 # Issue #66: NEVER self-restart in-place. _self_restart() used os.execvp

--- a/services/prism-service/tests/unit/test_auto_updater.py
+++ b/services/prism-service/tests/unit/test_auto_updater.py
@@ -171,16 +171,19 @@ def test_restart_is_deferred_on_all_platforms():
     assert au._DEFER_RESTART is True
 
 
-def test_auto_apply_is_opt_in():
-    """#66: PRISM_AUTO_UPDATE defaults OFF — a long-lived daemon must not
-    pip-install into itself unattended."""
+def test_auto_apply_default_on_opt_out():
+    """v6.2.7: PRISM_AUTO_UPDATE defaults ON (opt-out) — auto-update was
+    silently broken while it defaulted off (v6.2.4-6.2.6). The #66
+    silent-death cause was the os.execvp self-restart (still deferred,
+    see test above), not the apply, so default-on is safe."""
     def _eval(env_val):
-        raw = (env_val if env_val is not None else "off").lower()
+        raw = (env_val if env_val is not None else "on").lower()
         return raw in ("on", "true", "1", "yes")
-    assert _eval(None) is False          # unset -> off
-    assert _eval("off") is False
+    assert _eval(None) is True            # unset -> on
+    assert _eval("off") is False          # explicit opt-out honored
+    assert _eval("false") is False
     assert _eval("on") is True
     assert _eval("1") is True
     # And the module honored the default at import time (env unset in CI).
     if not os.environ.get("PRISM_AUTO_UPDATE"):
-        assert au._AUTO_APPLY is False
+        assert au._AUTO_APPLY is True


### PR DESCRIPTION
## v6.2.7 — restore auto-update

Auto-update had silently stopped. Two independent root causes, both fixed.

### 1. Native (Tauri) client never saw new versions
`tauri.conf.json` `version` was hardcoded `0.1.0` and never bumped, so **every** release published a `latest.json` reporting `0.1.0`. Installed native clients (also `0.1.0`) compared equal → no update, ever.
- `tauri.conf.json` → `6.2.7`.
- `release-tauri.yml` now **injects `PRISM_VERSION` into `tauri.conf.json` at build time** so it can never drift again.
- Current installs are all `0.1.0`, so `6.2.7 > 0.1.0` → the native fleet updates via the existing Tauri updater on its next check (works through the current update path).

### 2. Service self-update was opt-in (default off since v6.2.4)
That broke the in-place pip self-update server/docker installs relied on. The #66 silent death was the `os.execvp` self-restart (still deferred — `_DEFER_RESTART`), **not** the apply (pip runs in the auto-updater daemon thread, only sets `restart_required`).
- `PRISM_AUTO_UPDATE` default restored to **on**; `=off` opts out.
- `test_auto_apply_*` updated to the new default-on/opt-out contract.

### Verification
- `pytest tests/unit` → **478 passed** (incl. updated auto-updater test).
- Dev :8888 bounced to **6.2.7** (`dev_mode: true`); dev launches with `PRISM_AUTO_UPDATE=off` so the editable install can't pip-clobber itself.
- Post-tag gate: confirm `latest.json` now reports `version: 6.2.7` (the proof native auto-update is unblocked).
