### PR TITLE
feat(v6.2.11): Ultimate Graph annotation layer (#50) + task↔session association

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.8"
+PRISM_VERSION = "6.2.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.9: activate the dormant task_sessions table — task<->session "
+    "association is now wired end-to-end. New task_link_session MCP verb "
+    "(in the task_* family + interactive profile) force-upserts a "
+    "task_sessions row; conductor advance_task / gate_decide auto-stamp "
+    "the row from their carried task_id + session_id; "
+    "TaskService.sessions_for_task LEFT JOINs session_outcomes for "
+    "per-session duration/tokens/files/skills. GET /api/tasks/{id} gains "
+    "a `sessions` field on the existing route, and TaskDetailPage renders "
+    "a 'Sessions (N)' card with per-session metrics + an explicit "
+    "0-session empty state. started_at is stamped on first link and never "
+    "overwritten; session_id is caller-passed (falls back to the MCP "
+    "request id when omitted). "
     "v6.2.8: dashboard charts are now responsive. PlotFigure hardcoded a "
     "fixed pixel width (880/420), so on a wide/full-screen window the "
     "graphs didn't fill their cards — they sat at a fixed size with empty "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -29,10 +29,18 @@ def next_task(project: str = Query("default")) -> dict:
 
 @router.get("/{task_id}")
 def get_task(task_id: str, project: str = Query("default")) -> dict:
-    t = _svc(project).get(task_id)
+    svc = _svc(project)
+    t = svc.get(task_id)
     if not t:
         raise HTTPException(404, "task not found")
-    return {"task": t, "history": _svc(project).history(task_id)}
+    # `sessions` rides the EXISTING task-detail route (no parallel
+    # top-level route) — the linked Claude sessions JOINed with their
+    # session_outcomes metrics. Empty list when nothing is linked.
+    return {
+        "task": t,
+        "history": svc.history(task_id),
+        "sessions": svc.sessions_for_task(task_id),
+    }
 
 
 class TaskUpdate(BaseModel):

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -2683,6 +2683,21 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                     "type": "session_outcome",
                     "session_id": str(arguments["session_id"]),
                 })
+            # AUTO WRITER (Stop path): the Stop hook POSTs record_session_outcome
+            # at session end. Tie this ending session to every in_progress task
+            # so association is captured server-side without an explicit
+            # task_link_session call. Best-effort, mirrors the task_update /
+            # memory record_outcome side-effect idiom: must NEVER break the
+            # primary session_outcomes record.
+            # DECISION (a1bed6bb): do NOT backfill historical
+            # verifier_runs/consolidation_candidates rows in this slice — out of
+            # scope; new associations accrue going forward only.
+            try:
+                _sid = str(arguments["session_id"])
+                for _t in task_svc.list(status="in_progress"):
+                    task_svc.link_session(_t.id, _sid)
+            except Exception:
+                pass  # best-effort — never break the session outcome record
             return [TextContent(type="text", text=_json({"recorded": ok}))]
 
         if name == "record_skill_usage":

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -949,6 +949,31 @@ TOOLS: list[Tool] = [
         },
     ),
     Tool(
+        name="task_link_session",
+        description=(
+            "Force-link a Claude session to a task — upserts a "
+            "task_sessions(task_id, session_id) row so per-task session "
+            "history/metrics surface on the task view. session_id is "
+            "caller-passed; when omitted the active request session is "
+            "used. Rides the task_* family (single route), not a "
+            "parallel surface."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "task_id": {"type": "string", "description": "Task ID to link"},
+                "session_id": {
+                    "type": "string",
+                    "description": (
+                        "Session to link. Optional — defaults to the "
+                        "active request session when omitted."
+                    ),
+                },
+            },
+            "required": ["task_id"],
+        },
+    ),
+    Tool(
         name="workflow_state",
         description="Get the current PRISM workflow state (active step, progress, session info)",
         inputSchema={
@@ -992,6 +1017,13 @@ TOOLS: list[Tool] = [
                 "validation": {
                     "type": "string",
                     "description": "Optional validation note recorded on the transition history row",
+                },
+                "session_id": {
+                    "type": "string",
+                    "description": (
+                        "Optional session to associate with this task on "
+                        "advance (auto-writer into task_sessions)."
+                    ),
                 },
             },
             "required": ["id"],
@@ -1230,6 +1262,7 @@ INTERACTIVE_TOOL_NAMES: set[str] = {
     "task_list",
     "task_next",
     "task_update",
+    "task_link_session",
     "workflow_state",
     "workflow_advance",
     "conductor_advance",
@@ -3105,6 +3138,25 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
             return [TextContent(type="text", text=_json(task))]
 
+        if name == "task_link_session":
+            # FORCED WRITER. session_id resolution: caller-passed wins;
+            # when omitted, fall back to the MCP request_id as the
+            # server-inferred session handle (no thread-locals).
+            tid = str(arguments["task_id"])
+            sid = arguments.get("session_id")
+            if not sid:
+                from prism_service.mcp.request_context import get_request_context
+                sid = get_request_context().request_id
+            if not sid:
+                return [TextContent(type="text", text=_json({
+                    "ok": False, "task_id": tid,
+                    "reason": "no session_id supplied and none inferable",
+                }))]
+            ok = task_svc.link_session(tid, str(sid))
+            return [TextContent(type="text", text=_json({
+                "ok": ok, "task_id": tid, "session_id": str(sid),
+            }))]
+
         # ------------------------------------------------------------------
         # Workflow tools
         # ------------------------------------------------------------------
@@ -3127,6 +3179,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
             result = conductor_svc.advance_task(
                 task_id,
                 validation=arguments.get("validation"),
+                session_id=arguments.get("session_id"),
             )
             task = task_svc.get(task_id)
             result["task"] = task
@@ -3139,6 +3192,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 arguments["action"],
                 reason=arguments.get("reason", ""),
                 override=bool(arguments.get("override", False)),
+                session_id=arguments.get("session_id"),
             )
             task = task_svc.get(task_id)
             result["task"] = task

--- a/services/prism-service/prism_service/project_context.py
+++ b/services/prism-service/prism_service/project_context.py
@@ -62,6 +62,7 @@ class ProjectContext:
             from prism_service.services.task_service import TaskService
             self._task_svc = TaskService(
                 db_path=str(self._data_dir / "tasks.db"),
+                scores_db=str(self._data_dir / "scores.db"),
             )
         return self._task_svc
 

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -793,6 +793,7 @@ class ConductorService:
         self,
         task_id: str,
         validation: Optional[str] = None,
+        session_id: Optional[str] = None,
     ) -> dict:
         """Move a task to the next entry in WORKFLOW_STEPS.
 
@@ -879,6 +880,11 @@ class ConductorService:
             actor="conductor",
         )
 
+        # Conductor-path auto-writer: stamp/refresh the task_sessions row
+        # from the carried task_id + session so the association is
+        # captured even if the session never reaches the Stop hook.
+        self._stamp_session(task_id, session_id)
+
         return {
             "ok": True,
             "task_id": task_id,
@@ -886,6 +892,22 @@ class ConductorService:
             "to_step": next_id,
             "gate_state": new_gate_state,
         }
+
+    def _stamp_session(
+        self, task_id: str, session_id: Optional[str],
+    ) -> None:
+        """Best-effort upsert of a task_sessions row via the single
+        TaskService writer. No-op when no session is carried or the
+        writer is unavailable — must never break a transition."""
+        if not session_id:
+            return
+        link = getattr(self._task_svc, "link_session", None)
+        if not callable(link):
+            return
+        try:
+            link(task_id, session_id)
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # Gate verification helpers (issue #79 [3/4])
@@ -1004,6 +1026,7 @@ class ConductorService:
         action: str,
         reason: str = "",
         override: bool = False,
+        session_id: Optional[str] = None,
     ) -> dict:
         """Resolve a pending gate on a task.
 
@@ -1036,6 +1059,10 @@ class ConductorService:
         if task is None:
             return {"ok": False, "task_id": task_id,
                     "reason": "unknown task"}
+
+        # Conductor-path auto-writer: stamp/refresh the task_sessions row
+        # from the carried task_id + session on every gate decision.
+        self._stamp_session(task_id, session_id)
 
         current_step = self._step_by_id(task.workflow_step)
         if current_step is None or current_step["type"] != "gate":

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -69,13 +69,22 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
 class TaskService:
     """Manages the tasks.db lifecycle and CRUD operations."""
 
-    def __init__(self, db_path: str, embed_fn: Optional[EmbedFn] = None) -> None:
+    def __init__(
+        self, db_path: str, embed_fn: Optional[EmbedFn] = None,
+        scores_db: Optional[str] = None,
+    ) -> None:
         self._db = sqlite3.connect(db_path, check_same_thread=False)
         self._db.row_factory = sqlite3.Row
         self._db.execute("PRAGMA journal_mode=WAL")
         self._db.execute("PRAGMA busy_timeout=5000")
         self._db.executescript(_CREATE_TASKS_SQL)
         self._migrate_task_columns()
+        # LL task-session association lives in scores.db (alongside
+        # session_outcomes), not tasks.db — the JOIN the reader needs is
+        # over that one file. None in unit contexts that never touch the
+        # association surface; link_session / sessions_for_task degrade
+        # gracefully (no-op writer, [] reader) when unset.
+        self._scores_db: Optional[str] = scores_db
         # Optional — when provided, task create/update embeds
         # ``title + "\n" + description`` into ``tasks.embedding`` so
         # LL-06's cosine-similarity retrieval has vectors to work with.
@@ -394,3 +403,85 @@ class TaskService:
             )
             for r in rows
         ]
+
+    # ------------------------------------------------------------------
+    # Task <-> session association (LL — activates task_sessions)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _ensure_task_sessions(conn: sqlite3.Connection) -> None:
+        """Idempotently materialize the task_sessions table on an
+        isolated scores.db handle — the schema normally ships from
+        brain_engine, but the writer/reader may run before Brain has
+        opened that DB (e.g. conductor-only flows)."""
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS task_sessions ("
+            "task_id TEXT NOT NULL, session_id TEXT NOT NULL, "
+            "started_at TEXT, ended_at TEXT, "
+            "PRIMARY KEY (task_id, session_id))"
+        )
+
+    def link_session(
+        self, task_id: str, session_id: str,
+        ended_at: Optional[str] = None,
+    ) -> bool:
+        """Upsert a task_sessions row tying `session_id` to `task_id`.
+
+        started_at semantics: stamped (UTC ISO8601) the FIRST time the
+        pair is linked and never overwritten on a re-link — it marks
+        when PRISM first observed the session working this task.
+        ended_at is refreshed whenever supplied (session-end signal).
+        Returns False (no-op) when no scores.db is bound.
+        """
+        if not self._scores_db:
+            return False
+        now = datetime.now(timezone.utc).isoformat()
+        conn = sqlite3.connect(self._scores_db, timeout=5.0)
+        try:
+            self._ensure_task_sessions(conn)
+            conn.execute(
+                "INSERT INTO task_sessions "
+                "(task_id, session_id, started_at, ended_at) "
+                "VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(task_id, session_id) DO UPDATE SET "
+                "ended_at=COALESCE(excluded.ended_at, task_sessions.ended_at)",
+                (task_id, session_id, now, ended_at),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return True
+
+    def sessions_for_task(self, task_id: str) -> list[dict]:
+        """Return the sessions linked to `task_id`, each row LEFT JOINed
+        against session_outcomes so the UI gets per-session timing +
+        token + file + skill metrics in one shape:
+          [{session_id, started_at, ended_at, duration_s, tokens_used,
+            files_read, files_modified, skills_invoked}]
+        Empty list when nothing is linked (backs the UI empty state).
+        """
+        if not self._scores_db:
+            return []
+        conn = sqlite3.connect(self._scores_db, timeout=5.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            self._ensure_task_sessions(conn)
+            rows = conn.execute(
+                "SELECT ts.session_id, ts.started_at, ts.ended_at, "
+                "COALESCE(so.duration_s, 0) AS duration_s, "
+                "COALESCE(so.tokens_used, 0) AS tokens_used, "
+                "COALESCE(so.files_read, 0) AS files_read, "
+                "COALESCE(so.files_modified, 0) AS files_modified, "
+                "COALESCE(so.skills_invoked, 0) AS skills_invoked "
+                "FROM task_sessions ts "
+                "LEFT JOIN session_outcomes so "
+                "ON so.session_id = ts.session_id "
+                "WHERE ts.task_id = ? "
+                "ORDER BY ts.started_at ASC",
+                (task_id,),
+            ).fetchall()
+        except sqlite3.OperationalError:
+            return []
+        finally:
+            conn.close()
+        return [dict(r) for r in rows]

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -55,6 +55,17 @@ type HistoryRow = {
   reason?: string;
 };
 
+type SessionRow = {
+  session_id: string;
+  started_at?: string | null;
+  ended_at?: string | null;
+  duration_s?: number;
+  tokens_used?: number;
+  files_read?: number;
+  files_modified?: number;
+  skills_invoked?: number;
+};
+
 const STATUS_CYCLE: Record<string, string[]> = {
   pending: ["in_progress", "blocked", "done"],
   in_progress: ["done", "blocked", "pending"],
@@ -73,6 +84,7 @@ export default function TaskDetailPage() {
   const [project] = useProject();
   const [task, setTask] = useState<Task | null>(null);
   const [history, setHistory] = useState<HistoryRow[]>([]);
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -80,11 +92,12 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[] }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[] }>(
         `/api/tasks/${id}?project=${project}`,
       );
       setTask(d.task);
       setHistory(d.history ?? []);
+      setSessions(d.sessions ?? []);
       setError(null);
     } catch (e) {
       setError((e as Error).message ?? "task not found");
@@ -302,6 +315,44 @@ export default function TaskDetailPage() {
             </div>
           )}
         </div>
+      </Card>
+
+      <Card>
+        <SectionLabel>Sessions ({sessions.length})</SectionLabel>
+        {sessions.length === 0 ? (
+          <Empty>No Claude sessions linked to this task yet.</Empty>
+        ) : (
+          <ul className="divide-y divide-[color:var(--midground-base)]/10 mt-2">
+            {sessions.map((s) => (
+              <li key={s.session_id} className="py-3">
+                <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                  <span className="font-mono text-[12px] break-all">{s.session_id}</span>
+                  <span className="text-[11px] opacity-50">
+                    {s.started_at ? String(s.started_at).slice(0, 19) : "—"}
+                    {s.ended_at ? ` → ${String(s.ended_at).slice(0, 19)}` : ""}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {[
+                    ["duration", `${s.duration_s ?? 0}s`],
+                    ["tokens", String(s.tokens_used ?? 0)],
+                    ["read", String(s.files_read ?? 0)],
+                    ["modified", String(s.files_modified ?? 0)],
+                    ["skills", String(s.skills_invoked ?? 0)],
+                  ].map(([label, value]) => (
+                    <span
+                      key={label}
+                      className="text-[11px] px-2 py-0.5 rounded bg-[color:var(--midground-base)]/10"
+                    >
+                      <span className="opacity-50">{label}</span>{" "}
+                      <span className="font-mono">{value}</span>
+                    </span>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
       </Card>
 
       <Card>

--- a/services/prism-service/tests/integration/test_task_session_association.py
+++ b/services/prism-service/tests/integration/test_task_session_association.py
@@ -1,0 +1,249 @@
+"""Task<->session association (LL task a1bed6bb) — red scaffold.
+
+Pins the USER-FACING seams of activating the dormant `task_sessions`
+table, end-to-end through the real dispatcher / API route / source
+surfaces — not just unit contracts:
+
+  * FORCED WRITER — task_link_session reachable through the MCP
+    DISPATCHER (handle_tool), registered in the task_* family +
+    profile, upserting a row that SURVIVES across a separate call.
+  * READER — sessions_for_task(task_id) JOINs session_outcomes and
+    returns the metric columns.
+  * CONDUCTOR WRITER — advance_task stamps a task_sessions row from
+    its carried task_id + session.
+  * API — GET /api/tasks/{id} returns a `sessions` field on the
+    existing route (no parallel route).
+  * UI — TaskDetailPage source renders "Sessions (N)" + an explicit
+    empty state, consuming the new field (no raw <pre>JSON).
+
+These FAIL today: task_sessions is schema-only (no writer/reader/verb/
+field/UI). Source-structure asserts mirror tests/unit/test_ui_learning.py
+(pages verified via the running deploy, helpers/contracts in Python).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_WEB_SRC = _SERVICE_ROOT / "prism_service" / "web" / "src"
+
+
+def _isolated_project(tmp_path, pid="test-task-sessions"):
+    from prism_service import config as cfg
+    original = cfg.PROJECTS_DIR
+    cfg.PROJECTS_DIR = tmp_path / "projects"
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    from prism_service import project_context as pc
+    pc._contexts.clear()
+    yield pid
+    cfg.PROJECTS_DIR = original
+    pc._contexts.clear()
+
+
+@pytest.fixture
+def project(tmp_path):
+    yield from _isolated_project(tmp_path)
+
+
+def _call(tool_name, arguments=None, project_id="test-task-sessions"):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool_name, arguments or {}, project_id=project_id))
+
+
+def _text(result):
+    assert len(result) == 1
+    return result[0].text
+
+
+# ----------------------------------------------------------------------
+# FORCED WRITER — task_link_session in the task_* family + dispatcher
+# ----------------------------------------------------------------------
+
+
+def test_task_link_session_registered_in_task_family():
+    """New verb is in TOOLS (single-route convention) and in the
+    interactive profile alongside the other task_* verbs."""
+    from prism_service.mcp.tools import TOOLS, tools_for_profile
+
+    names = {t.name for t in TOOLS}
+    assert "task_link_session" in names, "task_link_session not registered in TOOLS"
+
+    interactive = {t.name for t in tools_for_profile("interactive")}
+    assert "task_link_session" in interactive, (
+        "task_link_session missing from interactive profile — "
+        "must ride the task_* family, not a parallel route"
+    )
+
+
+def test_task_link_session_upsert_survives_separate_call(project, tmp_path):
+    """Force-link via the DISPATCHER, then read the row back through a
+    SEPARATE dispatcher call to a different verb. A row that only lived
+    in one in-memory instance would not survive this."""
+    from prism_service.project_context import get_project
+
+    t = json.loads(_text(_call("task_create", {"title": "wire sessions"})))
+    tid = t["id"]
+
+    linked = json.loads(_text(_call("task_link_session", {
+        "task_id": tid, "session_id": "S-forced",
+    })))
+    assert linked.get("ok") is True or linked.get("task_id") == tid
+
+    # Persisted to the project's scores.db (not a throwaway handle).
+    ctx = get_project(project)
+    conn = sqlite3.connect(str(ctx._data_dir / "scores.db"))
+    row = conn.execute(
+        "SELECT task_id, session_id, started_at FROM task_sessions "
+        "WHERE task_id=? AND session_id=?",
+        (tid, "S-forced"),
+    ).fetchone()
+    conn.close()
+    assert row is not None, "task_link_session did not upsert a task_sessions row"
+    assert row[2], "started_at must be stamped (defined semantics)"
+
+
+# ----------------------------------------------------------------------
+# READER — sessions_for_task JOINs session_outcomes metrics
+# ----------------------------------------------------------------------
+
+
+def test_sessions_for_task_joins_outcome_metrics(project):
+    """sessions_for_task(task_id) returns [{session_id, started_at,
+    ended_at, duration_s, tokens_used, files_read, files_modified,
+    skills_invoked}] — the row JOINed against session_outcomes."""
+    from prism_service.project_context import get_project
+
+    t = json.loads(_text(_call("task_create", {"title": "reader task"})))
+    tid = t["id"]
+
+    # Record session metrics, then force the association.
+    _call("record_session_outcome", {
+        "session_id": "S-read", "duration_s": 120, "tokens_used": 4096,
+        "files_read": 7, "files_modified": 3, "skills_invoked": 2,
+    })
+    _call("task_link_session", {"task_id": tid, "session_id": "S-read"})
+
+    ctx = get_project(project)
+    svc = ctx.task_svc
+    assert hasattr(svc, "sessions_for_task"), (
+        "TaskService.sessions_for_task accessor missing"
+    )
+    sessions = svc.sessions_for_task(tid)
+    assert isinstance(sessions, list) and len(sessions) == 1
+    s = sessions[0]
+    assert s["session_id"] == "S-read"
+    assert "started_at" in s and "ended_at" in s
+    # JOINed metrics from session_outcomes
+    assert s["duration_s"] == 120
+    assert s["tokens_used"] == 4096
+    assert s["files_read"] == 7
+    assert s["files_modified"] == 3
+    assert s["skills_invoked"] == 2
+
+
+def test_sessions_for_task_empty_when_no_link(project):
+    """A task with zero linked sessions returns []. Backs the UI empty
+    state."""
+    from prism_service.project_context import get_project
+
+    t = json.loads(_text(_call("task_create", {"title": "lonely task"})))
+    ctx = get_project(project)
+    assert ctx.task_svc.sessions_for_task(t["id"]) == []
+
+
+# ----------------------------------------------------------------------
+# CONDUCTOR WRITER — advance_task stamps task_sessions
+# ----------------------------------------------------------------------
+
+
+def test_conductor_advance_stamps_task_session(project):
+    """conductor advance carries task_id + a session; advancing must
+    stamp/refresh a task_sessions row so association is captured even if
+    a session never reaches the Stop hook."""
+    from prism_service.project_context import get_project
+
+    t = json.loads(_text(_call("task_create", {"title": "conductor task"})))
+    tid = t["id"]
+
+    # Advance once with a session attached.
+    _call("conductor_advance", {"id": tid, "session_id": "S-cond"})
+
+    ctx = get_project(project)
+    conn = sqlite3.connect(str(ctx._data_dir / "scores.db"))
+    row = conn.execute(
+        "SELECT task_id, session_id FROM task_sessions "
+        "WHERE task_id=? AND session_id=?",
+        (tid, "S-cond"),
+    ).fetchone()
+    conn.close()
+    assert row is not None, (
+        "conductor advance_task did not stamp a task_sessions row from "
+        "its carried task_id + session"
+    )
+
+
+# ----------------------------------------------------------------------
+# API — GET /api/tasks/{id} extended with a `sessions` field
+# ----------------------------------------------------------------------
+
+
+def test_api_task_detail_returns_sessions_field(project, tmp_path):
+    """The existing GET /api/tasks/{id} route returns a `sessions`
+    field (reusing the route — no new top-level route)."""
+    from fastapi.testclient import TestClient
+    from prism_service.api.tasks import router as tasks_router
+    from fastapi import FastAPI
+
+    t = json.loads(_text(_call("task_create", {"title": "api task"})))
+    tid = t["id"]
+    _call("record_session_outcome", {
+        "session_id": "S-api", "duration_s": 60, "tokens_used": 100,
+        "files_read": 1, "files_modified": 1, "skills_invoked": 0,
+    })
+    _call("task_link_session", {"task_id": tid, "session_id": "S-api"})
+
+    app = FastAPI()
+    app.include_router(tasks_router, prefix="/api/tasks")
+    client = TestClient(app)
+    resp = client.get(f"/api/tasks/{tid}?project=test-task-sessions")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "sessions" in body, "GET /api/tasks/{id} missing `sessions` field"
+    assert any(s["session_id"] == "S-api" for s in body["sessions"])
+
+
+# ----------------------------------------------------------------------
+# UI — TaskDetailPage renders Sessions (N) + explicit empty state
+# (page render is verified via the running deploy; here we pin that the
+#  source actually consumes the new field — no raw <pre>JSON. Mirrors
+#  tests/unit/test_ui_learning.py's "pages verified via deploy" note.)
+# ----------------------------------------------------------------------
+
+
+def test_task_detail_page_renders_sessions_section():
+    src = (_WEB_SRC / "pages" / "TaskDetailPage.tsx").read_text(encoding="utf-8")
+    assert "sessions" in src, (
+        "TaskDetailPage.tsx does not consume the `sessions` field"
+    )
+    assert "Sessions (" in src, (
+        "TaskDetailPage.tsx must render a 'Sessions (N)' section header"
+    )
+
+
+def test_task_detail_page_has_session_empty_state():
+    src = (_WEB_SRC / "pages" / "TaskDetailPage.tsx").read_text(encoding="utf-8")
+    # An explicit 0-session branch (e.g. sessions.length === 0 ? <empty>).
+    assert "sessions.length === 0" in src, (
+        "TaskDetailPage.tsx must render an explicit 0-session empty state"
+    )

--- a/services/prism-service/tests/integration/test_task_session_association.py
+++ b/services/prism-service/tests/integration/test_task_session_association.py
@@ -194,6 +194,38 @@ def test_conductor_advance_stamps_task_session(project):
 
 
 # ----------------------------------------------------------------------
+# AUTO WRITER (Stop path) — record_session_outcome links in_progress tasks
+# ----------------------------------------------------------------------
+
+
+def test_record_session_outcome_links_in_progress_task(project):
+    """When a session ends (the Stop hook POSTs record_session_outcome
+    through this very dispatcher) while a task is status='in_progress',
+    the server-side writer must upsert a task_sessions row tying that
+    session_id to the in_progress task — without any explicit
+    task_link_session call from the hook."""
+    from prism_service.project_context import get_project
+
+    t = json.loads(_text(_call("task_create", {"title": "active task"})))
+    tid = t["id"]
+    # Put the task in_progress — the precondition for the auto-writer.
+    _call("task_update", {"id": tid, "status": "in_progress"})
+
+    # Session ends: the Stop hook's record_session_outcome lands here.
+    _call("record_session_outcome", {
+        "session_id": "S-stop", "duration_s": 90, "tokens_used": 2048,
+        "files_read": 4, "files_modified": 2, "skills_invoked": 1,
+    })
+
+    ctx = get_project(project)
+    linked = ctx.task_svc.sessions_for_task(tid)
+    assert any(s["session_id"] == "S-stop" for s in linked), (
+        "record_session_outcome did not auto-link the ending session to "
+        "the in_progress task (AUTO WRITER / Stop path criterion)"
+    )
+
+
+# ----------------------------------------------------------------------
 # API — GET /api/tasks/{id} extended with a `sessions` field
 # ----------------------------------------------------------------------
 

--- a/services/prism-service/tests/unit/test_mcp_tool_profiles.py
+++ b/services/prism-service/tests/unit/test_mcp_tool_profiles.py
@@ -24,9 +24,11 @@ def test_interactive_profile_exposes_core_agent_tools_only():
     # 17 original core tools + 2 Conductor v2 tools
     # (conductor_advance / conductor_gate) + 10 v5.1 understand_* tools
     # (T9 nine + understand_configure follow-up) + brain_understand
-    # (v6.1.6 Ultimate Graph merge retrieval).
-    assert len(names) == 30
+    # (v6.1.6 Ultimate Graph merge retrieval) + task_link_session
+    # (v6.2.9 task<->session association — rides the task_* family).
+    assert len(names) == 31
     assert "brain_understand" in names
+    assert "task_link_session" in names
     assert {
         "brain_search",
         "brain_call_chain",


### PR DESCRIPTION
Combined release of two completed, green-gated workstreams (both driven through the conductor SDLC via the new `implement` workflow).

## 1. Ultimate Graph annotation pull-loop — final slice of #50
- READ: `understand_view.build_understanding` joins `graph.annotations_for(node/community/hierarchy)` into each per-file context bundle (was hardcoded `[]`); provenance discriminates `deterministic` vs `claude @ <date>`.
- WRITE: new `services/graph_annotate.py` — durable PULL loop backed by a `graph_jobs` queue (`UNIQUE(scope_kind,scope_id,input_hash)`), reachable via `graph_annotate_*` MCP verbs + SessionStart-hook brief delivery.
- UI: ExplorePage Narrative card renders each annotation with a provenance Pill (violet `claude @`, slate deterministic). No `<pre>` JSON.

closes #50

## 2. Task ↔ session association
- Activates the dormant `task_sessions` table end-to-end.
- `task_link_session` MCP verb (force-link); conductor advance/gate auto-stamp; `record_session_outcome` (Stop path) links in_progress tasks on session end.
- `sessions_for_task` LEFT JOINs `session_outcomes`; `GET /api/tasks/{id}` returns a `sessions` field; TaskDetailPage renders a "Sessions (N)" card + 0-session empty state.

## Verification
- 516 tests green on the branch (1 unrelated cold-start latency flake in `test_install_manifest.py`, passes isolated — flagged as a follow-up).
- Both features verified live on the dev daemon at `6.2.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)