### PR TITLE
feat(tasks): hierarchical tasks (parent_id) — roots-only board + child drilldown (v6.2.19)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,23 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.18"
+PRISM_VERSION = "6.2.19"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.19: Hierarchical tasks (parent → children) — first-class parent_id "
+    "on the Task model, distinct from dependencies (parent_id = structural "
+    "epic membership; dependencies = scheduling/blocking). Additive tasks.db "
+    "column (migrates existing DBs to '' = root). Threaded through "
+    "TaskService.create/update, GET/PATCH /api/tasks (TaskUpdate.parent_id), "
+    "and the task_create/task_update MCP tools. UI: the /tasks board now "
+    "shows ONLY root tasks; a parent card carries a child-count badge in its "
+    "top-right corner; TaskDetailPage gains a 'Child tasks (N/M done)' card "
+    "(click-through, status chips) plus a 'Parent ↑' backlink, and the back "
+    "button returns to the parent (from=/tasks/<id>) instead of the board. "
+    "Click-through navigation, not collapse. New unit tests at "
+    "tests/unit/test_task_hierarchy.py pin parent_id round-trip + the "
+    "roots/children partition. "
     "v6.2.18: Stop the consolidation noise pile + bound memory-summary "
     "token use. (1) The transcript importer no longer enqueues a "
     "consolidation_candidate for sessions with NO usable signal — "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -48,6 +48,7 @@ class TaskUpdate(BaseModel):
     priority: Optional[int] = None
     assigned_agent: Optional[str] = None
     blocked_reason: Optional[str] = None
+    parent_id: Optional[str] = None
 
 
 @router.patch("/{task_id}")

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -974,6 +974,7 @@ TOOLS: list[Tool] = [
                 },
                 "story_file": {"type": "string", "description": "Associated story file path"},
                 "assigned_agent": {"type": "string", "description": "Agent persona to assign (sm, dev, qa)"},
+                "parent_id": {"type": "string", "description": "Parent task ID — makes this a child (subtask) of an epic. Children are hidden from the /tasks board and reached via the parent's detail page."},
             },
             "required": ["title"],
         },
@@ -1016,6 +1017,7 @@ TOOLS: list[Tool] = [
                 "priority": {"type": "integer", "description": "New priority"},
                 "assigned_agent": {"type": "string", "description": "New agent assignment"},
                 "blocked_reason": {"type": "string", "description": "Reason for blocking (when status=blocked)"},
+                "parent_id": {"type": "string", "description": "Re-parent this task under an epic (or '' to make it a root)."},
             },
             "required": ["id"],
         },
@@ -3263,6 +3265,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 tags=arguments.get("tags"),
                 story_file=arguments.get("story_file", ""),
                 assigned_agent=arguments.get("assigned_agent", ""),
+                parent_id=arguments.get("parent_id", ""),
             )
             return [TextContent(type="text", text=_json(task))]
 
@@ -3283,7 +3286,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "task_update":
             update_kwargs: dict[str, Any] = {}
-            for key in ("status", "priority", "assigned_agent", "blocked_reason"):
+            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id"):
                 if key in arguments:
                     update_kwargs[key] = arguments[key]
             task = task_svc.update(arguments["id"], **update_kwargs)

--- a/services/prism-service/prism_service/models/task.py
+++ b/services/prism-service/prism_service/models/task.py
@@ -35,6 +35,12 @@ class Task:
     workflow_step: str = ""
     gate_state: str = "none"  # none | pending | passed | failed
     gate_reason: str = ""
+    # Structural hierarchy (parent → children). Empty string = a root/
+    # top-level task. Distinct from `dependencies` (scheduling/blocking):
+    # parent_id answers "what epic do I belong to?", dependencies answers
+    # "what must finish before I can start?". The /tasks board shows only
+    # roots; a parent's children are reached by clicking into its detail.
+    parent_id: str = ""
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS tasks (
     merged_at TEXT,
     workflow_step TEXT DEFAULT '',
     gate_state TEXT DEFAULT 'none',
-    gate_reason TEXT DEFAULT ''
+    gate_reason TEXT DEFAULT '',
+    parent_id TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS task_history (
@@ -63,6 +64,8 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
     ("workflow_step", "TEXT DEFAULT ''"),
     ("gate_state", "TEXT DEFAULT 'none'"),
     ("gate_reason", "TEXT DEFAULT ''"),
+    # Hierarchy (parent → children). Existing rows backfill to '' (root).
+    ("parent_id", "TEXT DEFAULT ''"),
 ]
 
 
@@ -164,6 +167,8 @@ class TaskService:
                         and row["gate_state"] is not None else "none"),
             gate_reason=(row["gate_reason"] if "gate_reason" in keys
                          and row["gate_reason"] is not None else ""),
+            parent_id=(row["parent_id"] if "parent_id" in keys
+                       and row["parent_id"] is not None else ""),
         )
 
     def _record_history(
@@ -200,6 +205,7 @@ class TaskService:
         tags: Optional[list[str]] = None,
         story_file: str = "",
         assigned_agent: str = "",
+        parent_id: str = "",
     ) -> Task:
         """Create a new task and return it."""
         task = Task(
@@ -210,13 +216,14 @@ class TaskService:
             assigned_agent=assigned_agent,
             dependencies=dependencies or [],
             tags=tags or [],
+            parent_id=parent_id,
         )
         self._db.execute(
             "INSERT INTO tasks "
             "(id, title, description, status, priority, story_file, "
             "assigned_agent, created_at, updated_at, completed_at, "
-            "blocked_reason, dependencies, tags) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "blocked_reason, dependencies, tags, parent_id) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task.id,
                 task.title,
@@ -231,6 +238,7 @@ class TaskService:
                 task.blocked_reason,
                 json.dumps(task.dependencies),
                 json.dumps(task.tags),
+                task.parent_id,
             ),
         )
         self._db.commit()
@@ -314,7 +322,8 @@ class TaskService:
             "UPDATE tasks SET title=?, description=?, status=?, priority=?, "
             "story_file=?, assigned_agent=?, updated_at=?, completed_at=?, "
             "blocked_reason=?, dependencies=?, tags=?, "
-            "workflow_step=?, gate_state=?, gate_reason=? WHERE id=?",
+            "workflow_step=?, gate_state=?, gate_reason=?, parent_id=? "
+            "WHERE id=?",
             (
                 task.title,
                 task.description,
@@ -330,6 +339,7 @@ class TaskService:
                 task.workflow_step,
                 task.gate_state,
                 task.gate_reason,
+                task.parent_id,
                 task.id,
             ),
         )

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -44,6 +44,16 @@ type Task = {
   workflow_step?: string;
   gate_state?: string;
   gate_reason?: string;
+  parent_id?: string;
+};
+
+// Slim shape for the child-task list — only what the row renders.
+type ChildTask = {
+  id?: string;
+  title?: string;
+  status?: string;
+  priority?: number | string;
+  parent_id?: string;
 };
 
 type HistoryRow = {
@@ -77,14 +87,21 @@ export default function TaskDetailPage() {
   const { id = "" } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const from = ((location.state as { from?: string } | null)?.from) === "/conductor"
-    ? "/conductor"
-    : "/tasks";
-  const backLabel = from === "/conductor" ? "back to conductor" : "back to tasks";
+  // `from` is the path the back button returns to. A child opened from its
+  // parent's detail carries from=/tasks/<parentId>, so back goes up to the
+  // parent rather than all the way out to the board.
+  const fromState = (location.state as { from?: string } | null)?.from;
+  const from = fromState || "/tasks";
+  const backLabel = from === "/conductor"
+    ? "back to conductor"
+    : from.startsWith("/tasks/")
+      ? "back to parent"
+      : "back to tasks";
   const [project] = useProject();
   const [task, setTask] = useState<Task | null>(null);
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [children, setChildren] = useState<ChildTask[]>([]);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -99,6 +116,14 @@ export default function TaskDetailPage() {
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
       setError(null);
+      // Children aren't on the detail payload — derive them from the task
+      // list (parent_id === this id). Cheap, and keeps the API unchanged.
+      try {
+        const all = await api.get<{ tasks: ChildTask[] }>(`/api/tasks?project=${project}`);
+        setChildren((all.tasks ?? []).filter((t) => t.parent_id === id));
+      } catch {
+        setChildren([]);
+      }
     } catch (e) {
       setError((e as Error).message ?? "task not found");
     }
@@ -289,6 +314,55 @@ export default function TaskDetailPage() {
           <Empty>No description.</Empty>
         )}
       </Card>
+
+      {task.parent_id && (
+        <Card>
+          <SectionLabel>Parent</SectionLabel>
+          <button
+            onClick={() => navigate(`/tasks/${task.parent_id}`, { state: { from: "/tasks" } })}
+            className="mt-2 text-sm underline decoration-dotted underline-offset-2 hover:opacity-100 font-mono"
+          >
+            ↑ {String(task.parent_id).slice(0, 8)}
+          </button>
+        </Card>
+      )}
+
+      {children.length > 0 && (
+        <Card>
+          <SectionLabel>
+            Child tasks ({children.filter((c) => (c.status ?? "") === "done").length}/{children.length} done)
+          </SectionLabel>
+          <div className="space-y-2 mt-2">
+            {children.map((c) => {
+              const cTone = STATUS_TONE[c.status ?? "pending"] ?? "slate";
+              return (
+                <button
+                  key={c.id}
+                  onClick={() => c.id && navigate(`/tasks/${c.id}`, { state: { from: `/tasks/${id}` } })}
+                  className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors flex items-center justify-between gap-3"
+                >
+                  <span className="text-sm font-medium">{c.title ?? c.id}</span>
+                  <span className="flex items-center gap-2 shrink-0">
+                    {typeof c.priority !== "undefined" && (
+                      <span className="text-[10px] opacity-50 font-mono">p{c.priority}</span>
+                    )}
+                    <span
+                      className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded"
+                      style={{
+                        background: `var(--accent-${cTone}-bg)`,
+                        color: `var(--accent-${cTone}-fg)`,
+                        boxShadow: `inset 0 0 0 1px var(--accent-${cTone}-ring)`,
+                      }}
+                    >
+                      {c.status ?? "pending"}
+                    </span>
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </Card>
+      )}
 
       <Card>
         <SectionLabel>Metadata</SectionLabel>

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -17,6 +17,7 @@ type Task = {
   workflow_step?: string;
   gate_state?: string;
   gate_reason?: string;
+  parent_id?: string;
 };
 
 // Workflow tones — same convention TaskDetailPage uses for its status
@@ -66,11 +67,20 @@ export default function TasksPage() {
 
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
+  // Hierarchy: the board shows only root tasks (no parent_id). A parent's
+  // children are reached by clicking into its detail page. childCount maps
+  // each task id → how many tasks name it as parent, for the corner badge.
+  const childCount = new Map<string, number>();
+  for (const t of tasks) {
+    if (t.parent_id) childCount.set(t.parent_id, (childCount.get(t.parent_id) ?? 0) + 1);
+  }
+  const roots = tasks.filter((t) => !t.parent_id);
+
   return (
     <Page>
       <section className="flex flex-wrap gap-3">
         {COLUMNS.map((c) => (
-          <Kpi key={c.key} label={c.label} value={tasks.filter((t) => (t.status ?? "pending") === c.key).length} />
+          <Kpi key={c.key} label={c.label} value={roots.filter((t) => (t.status ?? "pending") === c.key).length} />
         ))}
       </section>
 
@@ -91,7 +101,7 @@ export default function TasksPage() {
 
       <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
         {COLUMNS.map((col) => {
-          const items = tasks.filter((t) => (t.status ?? "pending") === col.key);
+          const items = roots.filter((t) => (t.status ?? "pending") === col.key);
           const colTone = STATUS_TONE[col.key] ?? "slate";
           return (
             <Card key={col.key} className="!p-4">
@@ -123,7 +133,22 @@ export default function TasksPage() {
                         onClick={() => t.id && navigate(`/tasks/${t.id}`, { state: { from: "/tasks" } })}
                         className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors cursor-pointer"
                       >
-                        <div className="text-sm font-medium">{t.title ?? "—"}</div>
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="text-sm font-medium">{t.title ?? "—"}</div>
+                          {(childCount.get(t.id ?? "") ?? 0) > 0 && (
+                            <span
+                              title={`${childCount.get(t.id ?? "")} child task(s) — open to view`}
+                              className="shrink-0 text-[10px] font-mono leading-none px-1.5 py-1 rounded-full ring-1 ring-inset"
+                              style={{
+                                background: "var(--accent-violet-bg)",
+                                color: "var(--accent-violet-fg)",
+                                boxShadow: "inset 0 0 0 1px var(--accent-violet-ring)",
+                              }}
+                            >
+                              {childCount.get(t.id ?? "")}
+                            </span>
+                          )}
+                        </div>
                         {conductorOn && (
                           <div className="flex items-center gap-1.5 mt-2 flex-wrap">
                             {step && (

--- a/services/prism-service/tests/unit/test_task_hierarchy.py
+++ b/services/prism-service/tests/unit/test_task_hierarchy.py
@@ -1,0 +1,77 @@
+"""Hierarchical tasks — parent_id round-trip + roots/children semantics.
+
+Pins v6.2.20: parent_id is a first-class Task field, additive on tasks.db,
+distinct from `dependencies`. The /tasks board shows only roots; a parent's
+children are the tasks naming it via parent_id.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _mk_service(tmp_path: Path):
+    from prism_service.services.task_service import TaskService
+    return TaskService(str(tmp_path / "tasks.db"))
+
+
+def test_parent_id_defaults_to_root(tmp_path):
+    """A task created without parent_id is a root ('')"""
+    svc = _mk_service(tmp_path)
+    t = svc.create(title="epic")
+    assert t.parent_id == ""
+    assert svc.get(t.id).parent_id == ""
+
+
+def test_parent_id_round_trips_on_create(tmp_path):
+    """parent_id passed to create persists and reads back."""
+    svc = _mk_service(tmp_path)
+    parent = svc.create(title="epic")
+    child = svc.create(title="child", parent_id=parent.id)
+    assert child.parent_id == parent.id
+    assert svc.get(child.id).parent_id == parent.id
+
+
+def test_parent_id_settable_via_update(tmp_path):
+    """A root task can be re-parented (the backfill path)."""
+    svc = _mk_service(tmp_path)
+    parent = svc.create(title="epic")
+    child = svc.create(title="orphan")
+    assert child.parent_id == ""
+    updated = svc.update(child.id, parent_id=parent.id)
+    assert updated.parent_id == parent.id
+    assert svc.get(child.id).parent_id == parent.id
+
+
+def test_roots_and_children_partition(tmp_path):
+    """The board's 'roots only' view = tasks with empty parent_id; the
+    rest are reachable as children grouped by parent_id."""
+    svc = _mk_service(tmp_path)
+    epic = svc.create(title="epic")
+    a = svc.create(title="a", parent_id=epic.id)
+    b = svc.create(title="b", parent_id=epic.id)
+    solo = svc.create(title="solo")
+
+    everything = svc.list()
+    roots = [t for t in everything if not t.parent_id]
+    children = [t for t in everything if t.parent_id == epic.id]
+
+    assert {t.id for t in roots} == {epic.id, solo.id}
+    assert {t.id for t in children} == {a.id, b.id}
+
+
+def test_parent_id_independent_of_dependencies(tmp_path):
+    """parent_id (hierarchy) and dependencies (blocking) are separate
+    fields and don't bleed into each other."""
+    svc = _mk_service(tmp_path)
+    epic = svc.create(title="epic")
+    child = svc.create(title="child", parent_id=epic.id, dependencies=["x"])
+    got = svc.get(child.id)
+    assert got.parent_id == epic.id
+    assert got.dependencies == ["x"]


### PR DESCRIPTION
@
## What

First-class **`parent_id`** on the Task model — distinct from `dependencies`:
- `parent_id` = structural epic membership (hierarchy)
- `dependencies` = scheduling/blocking (unchanged)

Additive `tasks.db` column (existing rows migrate to `""` = root), threaded through `TaskService.create/update`, `GET`/`PATCH /api/tasks` (`TaskUpdate.parent_id`), and the `task_create`/`task_update` MCP tools.

## UI (click-through, not collapse)

- `/tasks` board now shows **only root tasks**; a parent card carries a **child-count badge** in its top-right corner.
- `TaskDetailPage` gains a **"Child tasks (N/M done)"** card — clickable rows with status chips — plus a **"Parent ↑"** backlink. The back button returns to the parent when a child was opened from one.

## Why

Visual surface for the goalbuddy-concepts epic (parent → 3 children). Hierarchy was modelled with `parent_id` rather than overloading `dependencies` so a task with blockers is never mislabelled as having children.

## Verification

- `tests/unit/test_task_hierarchy.py` — parent_id round-trip (create/update), roots/children partition, independence from dependencies. 8/8 green incl. embedding regressions.
- SPA `tsc -b && vite build` clean.
- Verified live on dev: board renders roots-only with a "3" badge on the epic; detail page renders the clickable "Child tasks (0/3 done)" card.

Bumps **6.2.18 → 6.2.19**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@