### PR TITLE
fix(conductor): always link a session on advance/gate transitions (v6.2.22)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.21"
+PRISM_VERSION = "6.2.22"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.22: Conductor transitions always link a session. The MCP "
+    "conductor_advance and conductor_gate handlers now fall back to the "
+    "active request handle (get_request_context().request_id) when no "
+    "session_id is threaded in — mirroring task_link_session. conductor_gate "
+    "did not even expose session_id, so a terminal-gate close-out NEVER "
+    "recorded a session; a workflow drive that omitted session_id left the "
+    "task with 0 attached sessions (the ed7292bd symptom: shipped via "
+    "PR #103 but the task showed no sessions). Both handlers now stamp a "
+    "task_sessions row on every transition. New regression "
+    "tests/unit/test_conductor_session_link.py pins that advance_task and "
+    "gate_decide propagate the session into task_sessions. "
     "v6.2.21: Memory-operation runner framework (Tier 2). New "
     "prism_service/services/memory_ops/ chassis generalises the single-purpose "
     "reflection runner into a typed, pluggable family of scheduled memory ops. "

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -3342,10 +3342,20 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
         # ------------------------------------------------------------------
         if name == "conductor_advance":
             task_id = arguments["id"]
+            # Session capture: prefer the caller-threaded session_id (the human
+            # driving session a workflow passes as SID); else fall back to the
+            # MCP request handle so a conductor drive ALWAYS stamps a
+            # task_sessions row — mirrors task_link_session. Without this, a
+            # drive that omits session_id leaves the task with 0 linked
+            # sessions (the ed7292bd symptom).
+            _sid = arguments.get("session_id")
+            if not _sid:
+                from prism_service.mcp.request_context import get_request_context
+                _sid = get_request_context().request_id
             result = conductor_svc.advance_task(
                 task_id,
                 validation=arguments.get("validation"),
-                session_id=arguments.get("session_id"),
+                session_id=_sid,
             )
             task = task_svc.get(task_id)
             result["task"] = task
@@ -3353,12 +3363,21 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "conductor_gate":
             task_id = arguments["id"]
+            # Same session-capture fallback as conductor_advance. conductor_gate
+            # does not even expose session_id in its schema, so before this the
+            # gate transition NEVER linked a session — the request-handle
+            # fallback ensures a terminal gate (green_gate close-out) records
+            # the session that resolved it.
+            _sid = arguments.get("session_id")
+            if not _sid:
+                from prism_service.mcp.request_context import get_request_context
+                _sid = get_request_context().request_id
             result = conductor_svc.gate_decide(
                 task_id,
                 arguments["action"],
                 reason=arguments.get("reason", ""),
                 override=bool(arguments.get("override", False)),
-                session_id=arguments.get("session_id"),
+                session_id=_sid,
             )
             task = task_svc.get(task_id)
             result["task"] = task

--- a/services/prism-service/tests/unit/test_conductor_session_link.py
+++ b/services/prism-service/tests/unit/test_conductor_session_link.py
@@ -1,0 +1,79 @@
+"""Conductor transitions must link a session into task_sessions.
+
+Regression for the ed7292bd symptom: a task driven fully through the
+conductor showed 0 attached sessions. Root cause was the MCP layer not
+threading a session into advance_task/gate_decide (conductor_gate did not
+even expose session_id), so nothing stamped task_sessions.
+
+These pin the SERVICE contract the handler now always satisfies (the MCP
+handlers fall back to the request handle when no session_id is passed,
+mirroring task_link_session): when a session_id reaches advance_task or
+gate_decide, it MUST be linked and readable via sessions_for_task.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _services(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    scores = str(tmp_path / "scores.db")
+    # TaskService shares the SAME scores.db so its link writer targets the
+    # file ConductorService reads/writes.
+    task_svc = TaskService(str(tmp_path / "tasks.db"), scores_db=scores)
+    cond = ConductorService(scores, enable_engine=False, task_svc=task_svc)
+    return task_svc, cond, scores
+
+
+def _linked(scores_path, task_id):
+    # Read the task_sessions link rows directly. (sessions_for_task LEFT JOINs
+    # session_outcomes, which a bare test scores.db lacks; we only care that
+    # the conductor stamped the link.)
+    import sqlite3
+    conn = sqlite3.connect(scores_path)
+    try:
+        rows = conn.execute(
+            "SELECT session_id FROM task_sessions WHERE task_id=?", (task_id,)
+        ).fetchall()
+        return {r[0] for r in rows}
+    except sqlite3.OperationalError:
+        return set()
+    finally:
+        conn.close()
+
+
+def test_advance_task_links_session(tmp_path):
+    task_svc, cond, scores = _services(tmp_path)
+    t = task_svc.create(title="link on advance")
+    cond.advance_task(t.id, validation="entering", session_id="sess-advance")
+    assert "sess-advance" in _linked(scores, t.id)
+
+
+def test_gate_decide_links_session(tmp_path):
+    """The terminal-gate close-out path (conductor_gate) must record the
+    session that resolved the gate — this is the exact path that left
+    ed7292bd with 0 sessions."""
+    task_svc, cond, scores = _services(tmp_path)
+    t = task_svc.create(title="link on gate")
+
+    # Drive to the first blocking gate (red_gate).
+    guard = 0
+    while task_svc.get(t.id).workflow_step != "red_gate" and guard < 10:
+        cond.advance_task(t.id, validation="step", session_id="sess-advance")
+        guard += 1
+    assert task_svc.get(t.id).workflow_step == "red_gate"
+
+    cond.gate_decide(
+        t.id, "approve", reason="override close-out",
+        override=True, session_id="sess-gate",
+    )
+    assert "sess-gate" in _linked(scores, t.id)


### PR DESCRIPTION
## Problem

The task **"Fix consolidation candidate noise + memory-summary token drain"** (`ed7292bd`) shipped in v6.2.18 via PR #103, but its task page showed **0 attached sessions** — and it was left stranded at `green_gate`/`pending`.

Root cause: `conductor_gate` does not expose `session_id` at all, and neither conductor MCP handler fell back to the request handle. So a workflow drive that didn't thread `session_id` linked nothing — `task_sessions` stayed empty for the whole SDLC run.

## Fix

Both `conductor_advance` and `conductor_gate` now resolve `session_id` to `get_request_context().request_id` when none is passed (mirroring `task_link_session`), so **every** conductor transition stamps a `task_sessions` row.

## Verification

- New `tests/unit/test_conductor_session_link.py` — `advance_task` and `gate_decide` propagate the session into `task_sessions`. 16/16 green with the conductor state-machine suite.
- Verified **live**: closing out `ed7292bd` through `conductor_gate` (no explicit session) auto-linked the request handle — the task now shows 2 sessions where it had 0.

Bumps **6.2.21 → 6.2.22**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
