### PR TITLE
feat: agent-run telemetry spine (T8) — per-agent tracking for self-heal/self-learn

### DIFF
--- a/.claude/workflows/implement.js
+++ b/.claude/workflows/implement.js
@@ -30,6 +30,14 @@ const STOP_AFTER = (_in.stop_after || '').trim() // e.g. 'red_gate' to halt the 
 // env/process access). Threaded into task_link_session + conductor_advance
 // so the task<->session JOIN resolves. GUARDED: empty SID => today's behavior.
 const SID = (_in.session_id || '').trim()
+// Telemetry run id for the agent-run spine (task f4498190). One drive of this
+// workflow == one run_id; every step's agent() emits a row under it. Sourced
+// from args when the orchestrator supplies one, else derived from SID/task.
+const RUN_ID = (_in.run_id || _in.runId || SID || TASK_ID || `run-${Date.now()}`).trim()
+// Where the agent-run telemetry POSTs land. Defaults to the dev web port
+// (8888 on this box); overridable via args.api_base for the WSL release
+// topology (7778). The MCP daemon serves /api/* on the same FastAPI app.
+const API_BASE = (_in.api_base || 'http://127.0.0.1:8888').replace(/\/$/, '')
 
 // ── Conductor state machine (mirror of models/workflow.py:WORKFLOW_STEPS) ─
 // Only red_gate and green_gate are blocking gates. The *_complete/_coverage
@@ -75,6 +83,68 @@ const dryNote = DRY
 
 function preamble(role) {
   return `${PRISM_TOOLS}\n\nYou are acting as the PRISM "${role}" persona inside the conductor SDLC.\n\n${KNOWLEDGE}\n\n${CONVENTIONS}${dryNote}`
+}
+
+// ── Agent-run telemetry emitter (task f4498190) ─────────────────────────
+// ONE shared row builder + POST so the serial loop AND the parallel fanout
+// wrapper emit an IDENTICAL row shape — no telemetry gap between the two
+// execution paths. The agent_runs spine is idempotent on
+// (run_id, agent_id, step), so a retried step UPDATES rather than dupes.
+// Per-agent agentId/timing/tokens/tool_uses live in the harness journal +
+// completion notification; we thread whatever the step result + meta expose
+// (duration_ms/tokens/tool_uses), and ALWAYS thread the plumbed SID as
+// session_id. Guarded end-to-end: a failed POST never breaks the drive.
+async function postAgentRun(res, meta) {
+  if (DRY) return // dry-run never mutates / never POSTs telemetry
+  meta = meta || {}
+  const row = {
+    run_id: RUN_ID,
+    workflow_name: 'implement',
+    task_id: (res && res.task_id) || (typeof locate !== 'undefined' && locate.task_id) || TASK_ID,
+    session_id: SID,
+    agent_id: meta.agent_id || `${RUN_ID}:${meta.step || (res && res.step) || meta.label}`,
+    parent_agent_id: meta.parent_agent_id || null,
+    role: meta.role || null,
+    step: meta.step || (res && res.step) || meta.label || null,
+    model: meta.model || null,
+    started_at: meta.started_at || null,
+    ended_at: meta.ended_at || null,
+    duration_ms: meta.duration_ms != null ? meta.duration_ms : null,
+    tokens: meta.tokens != null ? meta.tokens : null,
+    tool_uses: meta.tool_uses != null ? meta.tool_uses : null,
+    ok: res ? res.ok === true : null,
+    gate_state: (res && res.gate_state) || meta.gate_state || null,
+    verdict_summary: (res && (res.validation || res.evidence)) || meta.verdict_summary || null,
+    evidence_ref: (res && res.evidence) ? String(res.evidence).slice(0, 200) : null,
+  }
+  try {
+    await fetch(`${API_BASE}/api/agent-runs/ingest?project=prism`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(row),
+    })
+  } catch (e) {
+    log(`agent-run telemetry POST failed (non-fatal): ${e && e.message}`)
+  }
+  return row
+}
+
+// Parallel fanout wrapper: run several step handlers concurrently and emit the
+// SAME telemetry row shape per branch via the shared postAgentRun emitter, so
+// a future parallel drive has NO telemetry gap vs the serial loop. Unused by
+// the default serial drive but kept on the same emitter contract.
+async function fanout(jobs) {
+  return Promise.all(jobs.map(async (j) => {
+    const started = Date.now()
+    const res = await j.run()
+    await postAgentRun(res, {
+      role: j.role, step: j.step, model: j.model,
+      started_at: new Date(started).toISOString(),
+      ended_at: new Date().toISOString(),
+      duration_ms: Date.now() - started,
+    })
+    return res
+  }))
 }
 
 // ── Schemas ─────────────────────────────────────────────────────────────
@@ -179,13 +249,29 @@ const HANDLERS = {
     { label: 'green_gate', phase: 'Green gate', schema: STEP_SCHEMA }),
 }
 
+// Role each step's agent persona carries — mirrors the HANDLERS defaults so
+// the telemetry row's `role` matches the persona that actually ran the step.
+const ROLE_BY_STEP = {
+  review_previous_notes: 'sm', draft_story: 'sm', verify_plan: 'sm',
+  write_failing_tests: 'qa', red_gate: 'qa',
+  implement_tasks: 'dev', verify_green_state: 'qa', green_gate: 'lead',
+}
+
 // ── Deterministic drive: one step at a time, halt on failure/gate-reject ─
 const trace = []
 let halted = null
 for (let i = startIdx; i < ORDER.length; i++) {
   const stepId = ORDER[i]
+  const _t0 = Date.now()
   const res = await HANDLERS[stepId]()
   trace.push(res)
+  // Emit one agent-run telemetry row after this step's agent() returns —
+  // serial path; the parallel fanout() wrapper routes the SAME emitter.
+  await postAgentRun(res, {
+    role: ROLE_BY_STEP[stepId], step: stepId,
+    started_at: new Date(_t0).toISOString(),
+    ended_at: new Date().toISOString(), duration_ms: Date.now() - _t0,
+  })
   if (!res || res.ok !== true) {
     halted = { at: stepId, reason: (res && res.halt_reason) || 'step reported ok:false', result: res }
     break

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,28 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.22"
+PRISM_VERSION = "6.2.23"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.23: Agent-run telemetry spine — per-agent/subagent tracking for "
+    "self-heal & self-learn. New scores.db agent_runs table (created in "
+    "brain_engine.py's CREATE TABLE block) keyed PK (run_id, agent_id, step) "
+    "so writes UPSERT idempotently. POST /api/agent-runs/ingest persists one "
+    "telemetry row; GET /api/agent-runs reads them back filtered by task_id/"
+    "session_id/workflow_name/role/step (resolves scores_db via "
+    "get_project(project)._data_dir, mirroring api/learning.py). New "
+    "services/agent_runs_data.py holds the pure upsert/read/rollup helpers; "
+    "get_task_agent_rollup rolls a task's runs into total token cost + the "
+    "ordered agent-path, and /api/learning now surfaces agent_runs aggregates "
+    "(avg duration/step, override rate, token cost/role). implement.js emits "
+    "one telemetry row via a shared postAgentRun emitter after EACH step's "
+    "agent() returns in the serial drive loop (and a fanout() wrapper reuses "
+    "the same emitter so parallel == serial shape), threading the plumbed SID "
+    "as session_id. UI: LearningPage gains an 'Agent runs · timeline' panel "
+    "(per-task role/step/model/duration/tokens) plus the cross-run aggregates. "
+    "New tests: test_api_agent_runs, test_learning_agent_timeline_ui, "
+    "test_implement_agent_run_emitter. "
     "v6.2.22: Conductor transitions always link a session. The MCP "
     "conductor_advance and conductor_gate handlers now fall back to the "
     "active request handle (get_request_context().request_id) when no "

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -10,6 +10,7 @@ app; the import-time side effects stay in the per-module routers.
 
 from fastapi import APIRouter
 
+from prism_service.api.agent_runs import router as agent_runs_router
 from prism_service.api.brain import router as brain_router
 from prism_service.api.claude_auth import router as claude_auth_router
 from prism_service.api.claude_runs import router as claude_runs_router
@@ -32,6 +33,7 @@ from prism_service.api.update import router as update_router
 from prism_service.api.version import router as version_router
 
 api_router = APIRouter(prefix="/api")
+api_router.include_router(agent_runs_router, prefix="/agent-runs", tags=["agent-runs"])
 api_router.include_router(brain_router, prefix="/brain", tags=["brain"])
 api_router.include_router(claude_auth_router, prefix="/claude-auth", tags=["claude-auth"])
 api_router.include_router(claude_runs_router, prefix="/claude-runs", tags=["claude-runs"])

--- a/services/prism-service/prism_service/api/agent_runs.py
+++ b/services/prism-service/prism_service/api/agent_runs.py
@@ -1,0 +1,54 @@
+"""Agent-run telemetry API (task f4498190).
+
+POST /ingest persists one per-agent/step telemetry row to scores.db
+(idempotent on (run_id, agent_id, step)); GET / reads rows back with
+filtering. Resolves scores_db via get_project(project)._data_dir — the
+exact pattern api/learning.py uses — so a row POSTed here is readable
+back through a SEPARATE GET (on-disk persistence, not in-memory).
+"""
+
+from typing import Optional
+
+from fastapi import APIRouter, Body, Query
+
+from prism_service.project_context import get_project
+from prism_service.services.agent_runs_data import (
+    get_agent_runs,
+    upsert_agent_run,
+)
+
+router = APIRouter()
+
+
+def _scores_db(project: str) -> str:
+    return str(get_project(project)._data_dir / "scores.db")
+
+
+@router.post("/ingest")
+def ingest(
+    project: str = Query("default"),
+    row: dict = Body(...),
+) -> dict:
+    """Persist one agent-run telemetry row. Re-POSTing the same
+    (run_id, agent_id, step) UPDATES the existing row."""
+    upsert_agent_run(_scores_db(project), row)
+    return {"ok": True, "run_id": row.get("run_id"),
+            "agent_id": row.get("agent_id"), "step": row.get("step")}
+
+
+@router.get("")
+def list_runs(
+    project: str = Query("default"),
+    task_id: Optional[str] = Query(None),
+    session_id: Optional[str] = Query(None),
+    workflow_name: Optional[str] = Query(None),
+    role: Optional[str] = Query(None),
+    step: Optional[str] = Query(None),
+    limit: int = Query(500, ge=1, le=2000),
+) -> dict:
+    rows = get_agent_runs(
+        _scores_db(project), limit=limit,
+        task_id=task_id, session_id=session_id,
+        workflow_name=workflow_name, role=role, step=step,
+    )
+    return {"rows": rows}

--- a/services/prism-service/prism_service/api/learning.py
+++ b/services/prism-service/prism_service/api/learning.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Query
 
 from prism_service.project_context import get_project
+from prism_service.services.agent_runs_data import get_agent_run_aggregates
 from prism_service.services.learning_data import (
     get_learning_rows,
     get_recent_reflections,
@@ -27,4 +28,7 @@ def overview(
         # longer empty after a reflection runs (task_quality_rollup needs
         # a task_id; transcript-derived candidates only carry session_id).
         "recent_reflections": get_recent_reflections(scores_db, limit=reflections_limit),
+        # task f4498190 — agent-run telemetry aggregates feed the /learning
+        # agent-timeline panel (avg duration/step, override rate, token/role).
+        "agent_runs": get_agent_run_aggregates(scores_db),
     }

--- a/services/prism-service/prism_service/engines/brain_engine.py
+++ b/services/prism-service/prism_service/engines/brain_engine.py
@@ -941,6 +941,40 @@ class Brain:
                 timestamp TEXT DEFAULT (datetime('now'))
             );
 
+            -- Per-agent/subagent run telemetry spine (task f4498190). One row
+            -- per (run_id, agent_id, step); idempotent upsert so a re-POST of
+            -- the same triple UPDATES rather than duplicates. Feeds self-heal
+            -- (flagging error/stall/token-heavy steps) + the /learning agent
+            -- timeline panel + the per-task agent cost/path rollup.
+            CREATE TABLE IF NOT EXISTS agent_runs (
+                run_id TEXT NOT NULL,
+                workflow_name TEXT,
+                task_id TEXT,
+                session_id TEXT,
+                agent_id TEXT NOT NULL,
+                parent_agent_id TEXT,
+                role TEXT,
+                step TEXT NOT NULL,
+                model TEXT,
+                started_at TEXT,
+                ended_at TEXT,
+                duration_ms INTEGER,
+                tokens INTEGER,
+                tool_uses INTEGER,
+                ok INTEGER,
+                gate_state TEXT,
+                verdict_summary TEXT,
+                evidence_ref TEXT,
+                recorded_at TEXT DEFAULT (datetime('now')),
+                PRIMARY KEY (run_id, agent_id, step)
+            );
+            CREATE INDEX IF NOT EXISTS idx_agent_runs_task_id
+                ON agent_runs(task_id);
+            CREATE INDEX IF NOT EXISTS idx_agent_runs_session_id
+                ON agent_runs(session_id);
+            CREATE INDEX IF NOT EXISTS idx_agent_runs_workflow
+                ON agent_runs(workflow_name);
+
             -- ---- Learning-loop v5 tables (LL-01) ----------------------------
             -- Ties Claude sessions to PRISM tasks so per-task rollup joins
             -- through the full session history. Schema-only; populated by

--- a/services/prism-service/prism_service/services/agent_runs_data.py
+++ b/services/prism-service/prism_service/services/agent_runs_data.py
@@ -1,0 +1,157 @@
+"""Pure data-access for the agent-run telemetry spine (task f4498190).
+
+Mirrors learning_data.py: every function takes ``scores_db: str``, guards
+``Path(scores_db).exists()``, opens ``sqlite3.connect`` with a Row factory,
+and returns plain dicts/lists. No FastAPI / project_context coupling.
+
+The spine is the self-heal / self-learn input: per-agent/subagent run rows
+keyed (run_id, agent_id, step). Writes UPSERT on that triple so a re-POST of
+the same step updates rather than duplicates.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+# Columns persisted on agent_runs (order == the ingest payload contract).
+_COLS = (
+    "run_id", "workflow_name", "task_id", "session_id", "agent_id",
+    "parent_agent_id", "role", "step", "model", "started_at", "ended_at",
+    "duration_ms", "tokens", "tool_uses", "ok", "gate_state",
+    "verdict_summary", "evidence_ref",
+)
+
+# Filterable GET params -> agent_runs columns.
+_FILTERS = ("task_id", "session_id", "workflow_name", "role", "step")
+
+
+def _connect(scores_db: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(scores_db)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def upsert_agent_run(scores_db: str, row: dict) -> None:
+    """Insert or update one telemetry row, idempotent on
+    (run_id, agent_id, step). Booleans are coerced to 0/1 for sqlite."""
+    vals = []
+    for c in _COLS:
+        v = row.get(c)
+        if isinstance(v, bool):
+            v = int(v)
+        vals.append(v)
+    placeholders = ", ".join("?" for _ in _COLS)
+    updates = ", ".join(
+        f"{c}=excluded.{c}" for c in _COLS
+        if c not in ("run_id", "agent_id", "step")
+    )
+    sql = (
+        f"INSERT INTO agent_runs ({', '.join(_COLS)}) "
+        f"VALUES ({placeholders}) "
+        f"ON CONFLICT(run_id, agent_id, step) DO UPDATE SET {updates}"
+    )
+    conn = _connect(scores_db)
+    try:
+        conn.execute(sql, vals)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def get_agent_runs(scores_db: str, limit: int = 500, **filters) -> list[dict]:
+    """Return agent_runs rows, newest-first, honoring task_id/session_id/
+    workflow_name/role/step filters (None/empty filters are ignored)."""
+    if not Path(scores_db).exists():
+        return []
+    where, params = [], []
+    for k in _FILTERS:
+        v = filters.get(k)
+        if v:
+            where.append(f"{k} = ?")
+            params.append(v)
+    clause = (" WHERE " + " AND ".join(where)) if where else ""
+    params.append(limit)
+    conn = _connect(scores_db)
+    try:
+        rows = conn.execute(
+            "SELECT * FROM agent_runs"
+            f"{clause} ORDER BY started_at DESC, recorded_at DESC LIMIT ?",
+            params,
+        ).fetchall()
+    finally:
+        conn.close()
+    out = []
+    for r in rows:
+        d = dict(r)
+        d["ok"] = bool(d.get("ok")) if d.get("ok") is not None else None
+        out.append(d)
+    return out
+
+
+def get_task_agent_rollup(scores_db: str, task_id: str) -> dict:
+    """Roll a task's agent_runs into total token cost + the ordered
+    agent-path (role/step in chronological order). The Tier-3 self-learn
+    signal: how much each task cost across its agents and the path taken."""
+    if not Path(scores_db).exists():
+        return {}
+    conn = _connect(scores_db)
+    try:
+        rows = conn.execute(
+            "SELECT role, step, model, tokens, duration_ms, started_at "
+            "FROM agent_runs WHERE task_id = ? "
+            "ORDER BY started_at ASC, recorded_at ASC",
+            (task_id,),
+        ).fetchall()
+    finally:
+        conn.close()
+    if not rows:
+        return {}
+    path = [dict(r) for r in rows]
+    total_tokens = sum(int(r["tokens"] or 0) for r in rows)
+    total_duration = sum(int(r["duration_ms"] or 0) for r in rows)
+    return {
+        "task_id": task_id,
+        "total_tokens": total_tokens,
+        "total_duration_ms": total_duration,
+        "agent_count": len(path),
+        "agent_path": path,
+    }
+
+
+def get_agent_run_aggregates(scores_db: str) -> dict:
+    """Cross-run aggregates for the /learning panel: avg duration per step,
+    override rate (gate steps that ended override/blind), token cost per
+    role. Returns empty lists when there is no data."""
+    if not Path(scores_db).exists():
+        return {"per_step": [], "per_role": [], "override_rate": 0.0,
+                "total_runs": 0}
+    conn = _connect(scores_db)
+    try:
+        per_step = [dict(r) for r in conn.execute(
+            "SELECT step, COUNT(*) AS n, AVG(duration_ms) AS avg_duration_ms, "
+            "       AVG(tokens) AS avg_tokens "
+            "FROM agent_runs GROUP BY step ORDER BY n DESC"
+        ).fetchall()]
+        per_role = [dict(r) for r in conn.execute(
+            "SELECT role, COUNT(*) AS n, SUM(tokens) AS total_tokens, "
+            "       AVG(tokens) AS avg_tokens "
+            "FROM agent_runs GROUP BY role ORDER BY total_tokens DESC"
+        ).fetchall()]
+        total = conn.execute(
+            "SELECT COUNT(*) FROM agent_runs").fetchone()[0] or 0
+        # Override rate: rows whose verdict mentions override/blind (the
+        # recurring structurally-blind-verifier recovery) over all rows.
+        overrides = conn.execute(
+            "SELECT COUNT(*) FROM agent_runs "
+            "WHERE LOWER(COALESCE(verdict_summary,'')) LIKE '%override%' "
+            "   OR LOWER(COALESCE(verdict_summary,'')) LIKE '%blind%'"
+        ).fetchone()[0] or 0
+    finally:
+        conn.close()
+    return {
+        "per_step": per_step,
+        "per_role": per_role,
+        "override_rate": (overrides / total) if total else 0.0,
+        "total_runs": total,
+    }

--- a/services/prism-service/prism_service/web/src/pages/LearningPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/LearningPage.tsx
@@ -27,6 +27,43 @@ type Reflection = {
   candidate_trigger?: string | null;
 };
 
+type AgentRun = {
+  run_id?: string;
+  task_id?: string;
+  role?: string;
+  step?: string;
+  model?: string;
+  duration_ms?: number | null;
+  tokens?: number | null;
+  gate_state?: string;
+  ok?: boolean | null;
+  started_at?: string;
+};
+
+type PerStepAgg = {
+  step?: string;
+  n?: number;
+  avg_duration_ms?: number | null;
+  avg_tokens?: number | null;
+};
+type PerRoleAgg = {
+  role?: string;
+  n?: number;
+  total_tokens?: number | null;
+  avg_tokens?: number | null;
+};
+type AgentRunAggregates = {
+  per_step?: PerStepAgg[];
+  per_role?: PerRoleAgg[];
+  override_rate?: number;
+  total_runs?: number;
+};
+
+function fmtMs(ms?: number | null): string {
+  if (ms == null) return "—";
+  return ms >= 1000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+
 function ScorePill({ value }: { value: number | null | undefined }) {
   if (value == null || Number.isNaN(value)) {
     return <span className="font-mono opacity-60">—</span>;
@@ -50,6 +87,8 @@ export default function LearningPage() {
   const [rows, setRows] = useState<Row[]>([]);
   const [variants, setVariants] = useState<Variant[]>([]);
   const [reflections, setReflections] = useState<Reflection[]>([]);
+  const [agentRuns, setAgentRuns] = useState<AgentRun[]>([]);
+  const [agentAgg, setAgentAgg] = useState<AgentRunAggregates>({});
 
   useEffect(() => {
     api
@@ -57,23 +96,114 @@ export default function LearningPage() {
         rows: Row[];
         variants: Variant[];
         recent_reflections?: Reflection[];
+        agent_runs?: AgentRunAggregates;
       }>(`/api/learning?project=${project}`)
       .then((d) => {
         setRows(d.rows ?? []);
         setVariants(d.variants ?? []);
         setReflections(d.recent_reflections ?? []);
+        setAgentAgg(d.agent_runs ?? {});
       })
       .catch(() => {
         setRows([]);
         setVariants([]);
         setReflections([]);
+        setAgentAgg({});
       });
+    // Per-task agent timeline: the raw agent-run rows (role/step/model/
+    // duration/tokens), newest-first, for the timeline panel below.
+    api
+      .get<{ rows: AgentRun[] }>(`/api/agent-runs?project=${project}`)
+      .then((d) => setAgentRuns(d.rows ?? []))
+      .catch(() => setAgentRuns([]));
   }, [project]);
 
   const lowN = variants.length > 0 && variants.every((v) => v.n < 20);
 
+  const overridePct = Math.round((agentAgg.override_rate ?? 0) * 100);
+
   return (
     <Page>
+      <Card raised>
+        <div className="flex items-baseline justify-between mb-3">
+          <SectionLabel>Agent runs · timeline</SectionLabel>
+          <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)]">
+            per-task agent path · role / step / model / duration / tokens
+          </div>
+        </div>
+        {/* Cross-run aggregates: avg duration per step, override rate, token
+            cost per role — the Tier-3 self-heal signals. */}
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-4">
+          <div className="rounded border border-[color:var(--border-default)]/40 p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] mb-1">
+              Avg duration per step
+            </div>
+            {(agentAgg.per_step ?? []).length === 0 ? (
+              <div className="text-xs opacity-50">—</div>
+            ) : (
+              (agentAgg.per_step ?? []).map((s) => (
+                <div key={s.step} className="flex justify-between text-xs py-0.5">
+                  <span className="font-mono opacity-80 truncate">{s.step}</span>
+                  <span className="font-mono opacity-60">{fmtMs(s.avg_duration_ms)}</span>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="rounded border border-[color:var(--border-default)]/40 p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] mb-1">
+              Override rate
+            </div>
+            <div className="text-2xl font-mono text-amber-300">{overridePct}%</div>
+            <div className="text-[11px] opacity-50">
+              {agentAgg.total_runs ?? 0} runs · blind-verifier override signal
+            </div>
+          </div>
+          <div className="rounded border border-[color:var(--border-default)]/40 p-2">
+            <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] mb-1">
+              Token cost per role
+            </div>
+            {(agentAgg.per_role ?? []).length === 0 ? (
+              <div className="text-xs opacity-50">—</div>
+            ) : (
+              (agentAgg.per_role ?? []).map((r) => (
+                <div key={r.role} className="flex justify-between text-xs py-0.5">
+                  <span className="font-mono opacity-80">{r.role ?? "—"}</span>
+                  <span className="font-mono opacity-60">{r.total_tokens ?? 0} tok</span>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+        {agentRuns.length === 0 ? (
+          <Empty>
+            No agent runs yet — they populate as the{" "}
+            <span className="font-mono">implement</span> workflow drives steps
+            and POSTs telemetry to <span className="font-mono">/api/agent-runs/ingest</span>.
+          </Empty>
+        ) : (
+          <div className="divide-y divide-[color:var(--border-default)]/40">
+            {agentRuns.map((a, i) => (
+              <div key={`${a.run_id}-${a.step}-${i}`} className="py-2 flex items-center gap-3 text-sm">
+                <span className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] w-10">
+                  {a.role ?? "—"}
+                </span>
+                <span className="font-mono opacity-80 flex-1 truncate" title={a.task_id}>
+                  {a.step ?? "—"}
+                </span>
+                <span className="text-xs opacity-50 w-40 truncate font-mono">{a.model ?? "—"}</span>
+                <span className="font-mono text-xs opacity-60 w-16 text-right">{fmtMs(a.duration_ms)}</span>
+                <span className="font-mono text-xs opacity-60 w-20 text-right">{a.tokens ?? "—"} tok</span>
+                {a.gate_state && a.gate_state !== "none" && (
+                  <span className="text-[10px] uppercase tracking-wider text-amber-300/80 w-14">
+                    {a.gate_state}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
       <Card raised>
         <div className="flex items-baseline justify-between mb-3">
           <SectionLabel>Recent reflections</SectionLabel>

--- a/services/prism-service/tests/integration/test_implement_agent_run_emitter.py
+++ b/services/prism-service/tests/integration/test_implement_agent_run_emitter.py
@@ -1,0 +1,119 @@
+"""RED scaffold — implement.js agent-run telemetry emitter (task f4498190).
+
+The conductor SDLC workflow (implement.js) must emit one agent-run
+telemetry row to /api/agent-runs/ingest after EACH step's agent()
+returns — in BOTH the serial drive loop and the parallel fanout wrapper.
+This is the USER-FACING seam: the JS the harness runs is what actually
+populates the agent_runs spine. A green backend with a workflow that
+never POSTs telemetry is a false-green — agent_runs stays empty in real
+drives (the exact gap the task calls out as 'currently transient').
+
+Source-structure asserts (mirror the session-wiring asserts in
+test_task_session_association.py): read the workflow file and assert the
+telemetry-emit wiring substrings are present.
+
+ALL FAIL today: implement.js has no /api/agent-runs/ingest POST, no
+emitter helper, and no parallel fanout wrapper.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_WORKFLOWS = _SERVICE_ROOT.parent.parent / ".claude" / "workflows"
+
+
+def _implement_src() -> str:
+    return (_WORKFLOWS / "implement.js").read_text(encoding="utf-8")
+
+
+def test_implement_posts_telemetry_to_agent_runs_ingest():
+    """implement.js must POST each agent's telemetry to the registered
+    ingest route /api/agent-runs/ingest."""
+    src = _implement_src()
+    assert "/api/agent-runs/ingest" in src, (
+        "implement.js never POSTs to /api/agent-runs/ingest — the agent_runs "
+        "spine is never populated by a real drive (telemetry stays transient)"
+    )
+
+
+def test_implement_has_agent_run_emitter_helper():
+    """A dedicated emitter (e.g. postAgentRun / emitAgentRun) builds the
+    telemetry row once so the serial and parallel paths emit identically."""
+    src = _implement_src()
+    assert ("postAgentRun" in src or "emitAgentRun" in src
+            or "agentRunRow" in src), (
+        "implement.js has no agent-run emitter helper — serial and parallel "
+        "paths cannot share one row shape without it"
+    )
+
+
+def test_emitter_carries_required_telemetry_fields():
+    """The emitted row must carry run_id, agent_id, role, step, model,
+    timing, ok, gate_state, and a validation/verdict summary — the columns
+    the agent_runs table persists."""
+    src = _implement_src()
+    for field in ("run_id", "agent_id", "role", "step", "model",
+                  "gate_state"):
+        assert field in src, (
+            f"implement.js telemetry emit does not carry {field!r}"
+        )
+    # Timing: duration_ms (or started/ended) must be threaded.
+    assert ("duration_ms" in src or "started_at" in src), (
+        "implement.js telemetry emit carries no timing field"
+    )
+    # The validation/verdict summary from the step result feeds the row.
+    assert ("verdict_summary" in src or "validation" in src), (
+        "implement.js telemetry emit carries no validation/verdict summary"
+    )
+
+
+def test_emitter_threads_plumbed_session_id_as_session_id():
+    """The emitter reuses the already-plumbed SID as the telemetry
+    session_id — same source as task_link_session / conductor_advance."""
+    src = _implement_src()
+    # The ingest payload must reference SID for the session_id field.
+    assert "session_id" in src and "SID" in src, (
+        "implement.js telemetry emit does not thread SID as session_id"
+    )
+
+
+def test_serial_loop_emits_after_each_step():
+    """The serial drive loop must call the emitter after each handler
+    returns — the loop body (HANDLERS[stepId]() -> trace.push) is where
+    the per-step telemetry POST belongs."""
+    src = _implement_src()
+    # Locate the deterministic drive loop and assert the emitter fires
+    # inside it (between the handler call and the next iteration).
+    assert "trace.push(res)" in src, "serial drive loop shape changed"
+    loop_start = src.index("for (let i = startIdx")
+    loop_body = src[loop_start:loop_start + 900]
+    assert ("postAgentRun" in loop_body or "emitAgentRun" in loop_body
+            or "/api/agent-runs/ingest" in loop_body), (
+        "serial loop does not emit an agent-run telemetry row after each "
+        "step's agent() returns"
+    )
+
+
+def test_parallel_fanout_wrapper_emits_same_shape():
+    """A parallel fanout wrapper must emit the SAME telemetry row shape as
+    the serial path — no telemetry gap between serial and parallel
+    execution. The wrapper must route through the SAME emitter helper."""
+    src = _implement_src()
+    # A fanout/parallel wrapper exists...
+    assert ("fanout" in src.lower() or "Promise.all" in src
+            or "parallel" in src.lower()), (
+        "implement.js has no parallel fanout wrapper — the task requires "
+        "serial AND parallel execution to emit identically"
+    )
+    # ...and it shares the emitter (no second, divergent POST shape).
+    emitter = ("postAgentRun" if "postAgentRun" in src
+               else "emitAgentRun" if "emitAgentRun" in src else None)
+    assert emitter is not None, "no shared emitter helper to reuse"
+    assert src.count(emitter + "(") >= 2, (
+        "the shared emitter is called fewer than twice — serial and "
+        "parallel paths must BOTH route through it for identical shape"
+    )

--- a/services/prism-service/tests/unit/test_api_agent_runs.py
+++ b/services/prism-service/tests/unit/test_api_agent_runs.py
@@ -1,0 +1,299 @@
+"""RED scaffold — agent-run telemetry spine (task f4498190).
+
+Drives the REAL agent_runs router with a FastAPI TestClient over a REAL
+scores.db on disk. This pins the USER-FACING seam end-to-end, not just a
+service method:
+
+  * the route is reachable through the REGISTERED api_router at
+    /api/agent-runs (mounted via api/__init__.py — not just defined);
+  * POST /api/agent-runs/ingest persists one telemetry row to scores.db;
+  * a SEPARATE GET /api/agent-runs reads it back (proves on-disk
+    persistence, not one in-memory instance);
+  * writes are idempotent on (run_id, agent_id, step) — re-POSTing the
+    same triple UPDATES rather than duplicates;
+  * GET honors filters: task_id, session_id, workflow_name, role, step.
+
+ALL FAIL today: there is no agent_runs table, no api/agent_runs.py
+module, and no include_router line in api/__init__.py.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _seed_schema(scores_db: str) -> None:
+    """Create the scores.db schema (incl. the new agent_runs table) the
+    same way production does — via Brain's CREATE TABLE IF NOT EXISTS
+    block in brain_engine.py."""
+    from prism_service.engines.brain_engine import Brain
+    Brain(
+        brain_db=str(Path(scores_db).parent / "brain.db"),
+        graph_db=str(Path(scores_db).parent / "graph.db"),
+        scores_db=scores_db,
+    )
+
+
+def _row(**kw) -> dict:
+    base = dict(
+        run_id="run-1",
+        workflow_name="implement",
+        task_id="T-1",
+        session_id="S-1",
+        agent_id="agent-aaa",
+        parent_agent_id=None,
+        role="qa",
+        step="write_failing_tests",
+        model="claude-opus-4-8",
+        started_at="2026-05-31T12:00:00+00:00",
+        ended_at="2026-05-31T12:01:00+00:00",
+        duration_ms=60000,
+        tokens=12345,
+        tool_uses=7,
+        ok=True,
+        gate_state="none",
+        verdict_summary="red trace captured",
+        evidence_ref="sha:abc1234",
+    )
+    base.update(kw)
+    return base
+
+
+def _client(tmp_path, monkeypatch):
+    """Mount the REAL agent_runs router over a REAL scores.db in tmp.
+    get_project(...) is patched so the router resolves scores_db via
+    ctx._data_dir / 'scores.db' — mirroring api/learning.py."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from prism_service.api import agent_runs as agent_runs_api
+
+    data_dir = tmp_path
+    scores_db = str(data_dir / "scores.db")
+    _seed_schema(scores_db)
+
+    class _Ctx:
+        _data_dir = data_dir
+
+    monkeypatch.setattr(agent_runs_api, "get_project", lambda p: _Ctx())
+
+    app = FastAPI()
+    app.include_router(agent_runs_api.router, prefix="/api/agent-runs")
+    return TestClient(app), scores_db
+
+
+# ----------------------------------------------------------------------
+# Route reachable through the REGISTERED api_router (dispatcher, not just
+# a module-local include). This is the false-green guard: a defined
+# router that is never mounted into api_router would 404 in production.
+# ----------------------------------------------------------------------
+
+
+def test_route_registered_on_api_router():
+    from prism_service.api import api_router
+    paths = {r.path for r in api_router.routes}
+    assert "/api/agent-runs" in paths, (
+        f"GET /api/agent-runs not mounted on api_router: {sorted(paths)}"
+    )
+    assert "/api/agent-runs/ingest" in paths, (
+        f"POST /api/agent-runs/ingest not mounted on api_router: {sorted(paths)}"
+    )
+
+
+# ----------------------------------------------------------------------
+# POST -> (separate) GET round-trip proves ON-DISK persistence.
+# ----------------------------------------------------------------------
+
+
+def test_ingest_then_get_roundtrip_across_separate_calls(tmp_path, monkeypatch):
+    client, scores_db = _client(tmp_path, monkeypatch)
+    post = client.post(
+        "/api/agent-runs/ingest",
+        params={"project": "prism"},
+        json=_row(),
+    )
+    assert post.status_code == 200, post.text
+
+    # SEPARATE GET call — must read the row back off scores.db.
+    got = client.get("/api/agent-runs", params={"project": "prism"})
+    assert got.status_code == 200, got.text
+    rows = got.json()["rows"]
+    assert len(rows) == 1, f"expected exactly one persisted row, got {rows}"
+    r = rows[0]
+    for field in (
+        "run_id", "workflow_name", "task_id", "session_id", "agent_id",
+        "parent_agent_id", "role", "step", "model", "started_at",
+        "ended_at", "duration_ms", "tokens", "tool_uses", "ok",
+        "gate_state", "verdict_summary", "evidence_ref",
+    ):
+        assert field in r, f"persisted row missing column {field!r}: {r}"
+    assert r["run_id"] == "run-1"
+    assert r["role"] == "qa"
+    assert r["step"] == "write_failing_tests"
+    assert int(r["tokens"]) == 12345
+
+
+def test_ingest_persists_to_disk_not_memory(tmp_path, monkeypatch):
+    """A fresh TestClient over the SAME scores_db still sees the row —
+    proves the write landed on disk, not in a per-request instance."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import agent_runs as agent_runs_api
+
+    client, scores_db = _client(tmp_path, monkeypatch)
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(run_id="durable", agent_id="ag-d"))
+
+    # Brand-new app/client pointed at the same on-disk scores.db.
+    class _Ctx:
+        _data_dir = Path(scores_db).parent
+    monkeypatch.setattr(agent_runs_api, "get_project", lambda p: _Ctx())
+    app2 = FastAPI()
+    app2.include_router(agent_runs_api.router, prefix="/api/agent-runs")
+    client2 = TestClient(app2)
+
+    rows = client2.get("/api/agent-runs", params={"project": "prism"}).json()["rows"]
+    assert any(r["run_id"] == "durable" for r in rows), (
+        "row did not survive into a separate client -> not on disk"
+    )
+
+
+# ----------------------------------------------------------------------
+# Idempotency on (run_id, agent_id, step): re-POST updates, not dupes.
+# ----------------------------------------------------------------------
+
+
+def test_ingest_idempotent_on_run_agent_step(tmp_path, monkeypatch):
+    client, scores_db = _client(tmp_path, monkeypatch)
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(verdict_summary="first", tokens=100))
+    # Same (run_id, agent_id, step) — different payload values.
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(verdict_summary="second", tokens=999))
+
+    rows = client.get("/api/agent-runs", params={"project": "prism"}).json()["rows"]
+    same = [r for r in rows
+            if r["run_id"] == "run-1" and r["agent_id"] == "agent-aaa"
+            and r["step"] == "write_failing_tests"]
+    assert len(same) == 1, f"re-POST must UPDATE, not duplicate: {same}"
+    assert same[0]["verdict_summary"] == "second", "row was not updated on re-POST"
+    assert int(same[0]["tokens"]) == 999
+
+
+def test_distinct_step_is_a_separate_row(tmp_path, monkeypatch):
+    """Same run+agent but a DIFFERENT step is a distinct telemetry row —
+    the agent-path of a run is preserved, not collapsed."""
+    client, _ = _client(tmp_path, monkeypatch)
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(step="write_failing_tests"))
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(step="implement_tasks"))
+    rows = client.get("/api/agent-runs", params={"project": "prism"}).json()["rows"]
+    steps = sorted(r["step"] for r in rows if r["run_id"] == "run-1")
+    assert steps == ["implement_tasks", "write_failing_tests"], steps
+
+
+# ----------------------------------------------------------------------
+# Filters: task_id, session_id, workflow_name, role, step.
+# ----------------------------------------------------------------------
+
+
+def _seed_mixed(client):
+    client.post("/api/agent-runs/ingest", params={"project": "prism"}, json=_row(
+        run_id="r-a", agent_id="a1", task_id="T-A", session_id="S-A",
+        workflow_name="implement", role="qa", step="write_failing_tests"))
+    client.post("/api/agent-runs/ingest", params={"project": "prism"}, json=_row(
+        run_id="r-b", agent_id="a2", task_id="T-B", session_id="S-B",
+        workflow_name="prototype", role="dev", step="implement_tasks"))
+
+
+@pytest.mark.parametrize("param,value,expect_run", [
+    ("task_id", "T-A", "r-a"),
+    ("session_id", "S-B", "r-b"),
+    ("workflow_name", "prototype", "r-b"),
+    ("role", "qa", "r-a"),
+    ("step", "implement_tasks", "r-b"),
+])
+def test_get_honors_filter(tmp_path, monkeypatch, param, value, expect_run):
+    client, _ = _client(tmp_path, monkeypatch)
+    _seed_mixed(client)
+    got = client.get("/api/agent-runs",
+                     params={"project": "prism", param: value})
+    assert got.status_code == 200, got.text
+    rows = got.json()["rows"]
+    assert rows, f"filter {param}={value} returned nothing"
+    assert all(str(r[param]) == value for r in rows), (
+        f"filter {param}={value} leaked non-matching rows: {rows}"
+    )
+    assert {r["run_id"] for r in rows} == {expect_run}, rows
+
+
+# ----------------------------------------------------------------------
+# Per-task agent cost + agent-path rollup into a learning surface.
+# ----------------------------------------------------------------------
+
+
+def test_per_task_agent_rollup_cost_and_path(tmp_path, monkeypatch):
+    """The learning surface rolls agent_runs up per task: total token
+    cost + the ordered agent-path (role/step sequence). This is the
+    self-learn signal the Tier-3 loop reads."""
+    from prism_service.services.agent_runs_data import get_task_agent_rollup
+
+    client, scores_db = _client(tmp_path, monkeypatch)
+    # Two steps of one run on task T-roll, in order.
+    client.post("/api/agent-runs/ingest", params={"project": "prism"}, json=_row(
+        run_id="rr", agent_id="a1", task_id="T-roll", role="qa",
+        step="write_failing_tests", tokens=1000,
+        started_at="2026-05-31T12:00:00+00:00"))
+    client.post("/api/agent-runs/ingest", params={"project": "prism"}, json=_row(
+        run_id="rr", agent_id="a2", task_id="T-roll", role="dev",
+        step="implement_tasks", tokens=2500,
+        started_at="2026-05-31T12:05:00+00:00"))
+
+    roll = get_task_agent_rollup(scores_db, task_id="T-roll")
+    assert roll, "rollup returned nothing for a task with agent_runs"
+    assert int(roll["total_tokens"]) == 3500, roll
+    # Ordered agent-path: role/step in chronological order.
+    path = roll["agent_path"]
+    assert path[0]["step"] == "write_failing_tests"
+    assert path[1]["step"] == "implement_tasks"
+    assert path[0]["role"] == "qa" and path[1]["role"] == "dev"
+
+
+def test_learning_overview_surfaces_agent_runs(tmp_path, monkeypatch):
+    """The /api/learning overview must expose agent-run aggregates so the
+    /learning-page panel has data — not a separate orphan endpoint."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import learning as learning_api
+    from prism_service.api import agent_runs as agent_runs_api
+
+    data_dir = tmp_path
+    scores_db = str(data_dir / "scores.db")
+    _seed_schema(scores_db)
+
+    class _Ctx:
+        _data_dir = data_dir
+    monkeypatch.setattr(agent_runs_api, "get_project", lambda p: _Ctx())
+    monkeypatch.setattr(learning_api, "get_project", lambda p: _Ctx())
+
+    app = FastAPI()
+    app.include_router(agent_runs_api.router, prefix="/api/agent-runs")
+    app.include_router(learning_api.router, prefix="/api/learning")
+    client = TestClient(app)
+
+    client.post("/api/agent-runs/ingest", params={"project": "prism"},
+                json=_row(task_id="T-learn", tokens=4242))
+
+    body = client.get("/api/learning", params={"project": "prism"}).json()
+    assert "agent_runs" in body, (
+        f"/api/learning must surface agent_runs aggregates: keys={list(body)}"
+    )

--- a/services/prism-service/tests/unit/test_learning_agent_timeline_ui.py
+++ b/services/prism-service/tests/unit/test_learning_agent_timeline_ui.py
@@ -1,0 +1,67 @@
+"""RED scaffold — LearningPage agent-timeline panel (task f4498190).
+
+The web app has no JS test runner, so the UI-FIRST acceptance criteria
+are pinned by asserting the LearningPage.tsx SOURCE (same pattern as
+test_memory_page_activation_ui.py):
+
+  * a per-task agent timeline rendering role/step/model/duration/tokens;
+  * cross-run aggregates: avg duration per step, override rate, token
+    cost per role;
+  * the panel fetches the new /api/agent-runs surface.
+
+FAILS today: LearningPage.tsx has no agent-runs fetch, no timeline panel,
+and no cross-run aggregate rendering.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_WEB = (_HERE.parent.parent.parent / "prism_service" / "web" / "src"
+        / "pages" / "LearningPage.tsx")
+
+
+def _src() -> str:
+    return _WEB.read_text(encoding="utf-8")
+
+
+def test_learning_page_fetches_agent_runs():
+    src = _src()
+    assert "agent-runs" in src or "agent_runs" in src, (
+        "LearningPage must fetch the /api/agent-runs surface to render the "
+        "agent timeline — a panel with no data source is headless"
+    )
+
+
+def test_agent_timeline_renders_role_step_model_duration_tokens():
+    src = _src()
+    lower = src.lower()
+    # The timeline tile must surface each per-agent dimension.
+    for token in ("role", "step", "model", "duration", "tokens"):
+        assert token in lower, (
+            f"agent timeline panel does not render {token!r}"
+        )
+
+
+def test_cross_run_aggregates_present():
+    src = _src()
+    lower = src.lower()
+    # Avg duration per step.
+    assert "avg" in lower or "average" in lower, (
+        "no avg-duration-per-step aggregate rendered"
+    )
+    # Override rate — the recurring blind-verifier override is the Tier-3
+    # signal the panel surfaces.
+    assert "override" in lower, "no override-rate aggregate rendered"
+    # Token cost per role.
+    assert "token" in lower, "no token-cost aggregate rendered"
+
+
+def test_timeline_panel_is_a_distinct_section():
+    src = _src()
+    # A labelled panel/section so it is visible in the SPA, not buried.
+    assert ("Agent" in src and ("Timeline" in src or "timeline" in src
+            or "Runs" in src or "Run" in src)), (
+        "LearningPage has no distinct 'Agent timeline/runs' panel heading"
+    )


### PR DESCRIPTION
Lands T8 of the unified-memory epic (f295db8d): durable per-agent/subagent telemetry feeding the self-improvement loop.

- New `agent_runs` table (run_id, agent_id, role, step, model, timing, tokens, ok, gate_state, verdict) — idempotent on (run_id, agent_id, step)
- `POST /api/agent-runs/ingest` + `GET /api/agent-runs` (filter by task/session/workflow/role/step)
- `implement.js` emits a telemetry row after each agent step (shared seam, fanout-safe)
- `/learning` panel: per-task agent timeline + cross-run aggregates

Stacked on the merged framework; only T8's 2 commits beyond main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)