### PR TITLE
feat(oracle): upfront observable completion signal on tasks — goalbuddy port (v6.2.25)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.24"
+PRISM_VERSION = "6.2.25"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.25: Oracle field (goalbuddy-ported) — first goalbuddy concept built. "
+    "Task gains oracle / proof_type / completion_proof: an upfront, observable "
+    "completion signal defined before work and checked at green_gate, closing "
+    "the tests-pass≠feature-works gap. Additive tasks.db columns (migrate to "
+    "''), threaded through TaskService.create/update, GET/PATCH /api/tasks, and "
+    "task_create/task_update MCP tools. New module-level is_weak_proof() in "
+    "conductor_service (ported verbatim from goalbuddy check-goal-state.mjs "
+    "isWeakProof: rejects ''/unknown/tbd/todo/none/<placeholder>); at the "
+    "terminal green_gate, gate_decide annotates the gate_reason with an "
+    "advisory '⚠ oracle: no completion_proof recorded' when proof is weak "
+    "(annotate, never block — hooks doctrine). TaskDetailPage renders an "
+    "'Oracle — observable completion signal' card (proof_type chip + oracle "
+    "text + completion_proof, amber not-yet-recorded state). Tests: "
+    "test_task_oracle.py (field round-trip, is_weak_proof port, green_gate "
+    "flag present/absent). Backs goalbuddy epic 56e3a518 child 1/3. "
     "v6.2.24: Memory-op runner FLEET (Tier 2) — four MemoryOperation families "
     "plug into the memory_ops chassis, each env-gated (off by default): "
     "merge (synthesize duplicate memories via the activation prior + Brain "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -49,6 +49,9 @@ class TaskUpdate(BaseModel):
     assigned_agent: Optional[str] = None
     blocked_reason: Optional[str] = None
     parent_id: Optional[str] = None
+    oracle: Optional[str] = None
+    proof_type: Optional[str] = None
+    completion_proof: Optional[str] = None
 
 
 @router.patch("/{task_id}")

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -975,6 +975,9 @@ TOOLS: list[Tool] = [
                 "story_file": {"type": "string", "description": "Associated story file path"},
                 "assigned_agent": {"type": "string", "description": "Agent persona to assign (sm, dev, qa)"},
                 "parent_id": {"type": "string", "description": "Parent task ID — makes this a child (subtask) of an epic. Children are hidden from the /tasks board and reached via the parent's detail page."},
+                "oracle": {"type": "string", "description": "The observable signal that proves the user outcome is actually met (the 'oracle' — defined before work starts). E.g. a test suite, demo, artifact, metric, review, or decision."},
+                "proof_type": {"type": "string", "description": "Kind of completion evidence: test|demo|artifact|metric|review|source_backed_answer|decision."},
+                "completion_proof": {"type": "string", "description": "Receipt-backed evidence the oracle is satisfied; recorded when done and checked (advisory) at green_gate."},
             },
             "required": ["title"],
         },
@@ -1018,6 +1021,9 @@ TOOLS: list[Tool] = [
                 "assigned_agent": {"type": "string", "description": "New agent assignment"},
                 "blocked_reason": {"type": "string", "description": "Reason for blocking (when status=blocked)"},
                 "parent_id": {"type": "string", "description": "Re-parent this task under an epic (or '' to make it a root)."},
+                "oracle": {"type": "string", "description": "Set/replace the oracle — the observable signal that proves the outcome."},
+                "proof_type": {"type": "string", "description": "test|demo|artifact|metric|review|source_backed_answer|decision."},
+                "completion_proof": {"type": "string", "description": "Receipt-backed evidence the oracle is satisfied (checked advisory at green_gate)."},
             },
             "required": ["id"],
         },
@@ -3266,6 +3272,9 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 story_file=arguments.get("story_file", ""),
                 assigned_agent=arguments.get("assigned_agent", ""),
                 parent_id=arguments.get("parent_id", ""),
+                oracle=arguments.get("oracle", ""),
+                proof_type=arguments.get("proof_type", ""),
+                completion_proof=arguments.get("completion_proof", ""),
             )
             return [TextContent(type="text", text=_json(task))]
 
@@ -3286,7 +3295,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "task_update":
             update_kwargs: dict[str, Any] = {}
-            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id"):
+            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id", "oracle", "proof_type", "completion_proof"):
                 if key in arguments:
                     update_kwargs[key] = arguments[key]
             task = task_svc.update(arguments["id"], **update_kwargs)

--- a/services/prism-service/prism_service/models/task.py
+++ b/services/prism-service/prism_service/models/task.py
@@ -41,6 +41,16 @@ class Task:
     # "what must finish before I can start?". The /tasks board shows only
     # roots; a parent's children are reached by clicking into its detail.
     parent_id: str = ""
+    # Oracle (ported from goalbuddy state.yaml goal.oracle/intake) — an
+    # upfront, observable completion signal defined BEFORE work starts and
+    # checked at green_gate, closing the "tests-pass ≠ feature-works" gap.
+    #   oracle           — the observable signal that proves the user outcome
+    #   proof_type       — test|demo|artifact|metric|review|
+    #                      source_backed_answer|decision
+    #   completion_proof — receipt-backed evidence captured when done
+    oracle: str = ""
+    proof_type: str = ""
+    completion_proof: str = ""
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -26,6 +26,22 @@ EPSILON_MIN = 0.05
 EPSILON_DECAY = 0.05
 
 
+def is_weak_proof(value: object) -> bool:
+    """Ported from goalbuddy scripts/check-goal-state.mjs isWeakProof().
+
+    A completion proof / oracle signal is "weak" when it is absent or a
+    placeholder — i.e. it does not actually evidence the outcome. Used to
+    flag (advisory) a green_gate close that carries no real proof.
+    """
+    if value is None:
+        return True
+    s = str(value).strip().lower()
+    if s in ("", "unknown", "tbd", "todo", "none"):
+        return True
+    # placeholder tokens like "<fill me>" / "<observable signal>"
+    return s.startswith("<") and s.endswith(">")
+
+
 class ConductorService:
     """Service layer for Conductor engine and scores.db queries.
 
@@ -1220,6 +1236,14 @@ class ConductorService:
             passed_gate_reason = f"verified ({verifier_validation}): {reason}"
         else:
             passed_gate_reason = reason
+        # Oracle (goalbuddy "no completion on weak proof"): at the terminal
+        # green_gate, flag a close with no real completion_proof. Advisory per
+        # the hooks doctrine — annotate the reason, never block — so it
+        # surfaces on the task/swimlane without breaking override-driven closes.
+        if gate_step_id == "green_gate":
+            _proof = getattr(self._task_svc.get(task_id), "completion_proof", "")
+            if is_weak_proof(_proof):
+                passed_gate_reason += "  ⚠ oracle: no completion_proof recorded"
         self._task_svc.update(
             task_id,
             gate_state="passed",

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -37,7 +37,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     workflow_step TEXT DEFAULT '',
     gate_state TEXT DEFAULT 'none',
     gate_reason TEXT DEFAULT '',
-    parent_id TEXT DEFAULT ''
+    parent_id TEXT DEFAULT '',
+    oracle TEXT DEFAULT '',
+    proof_type TEXT DEFAULT '',
+    completion_proof TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS task_history (
@@ -66,6 +69,10 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
     ("gate_reason", "TEXT DEFAULT ''"),
     # Hierarchy (parent → children). Existing rows backfill to '' (root).
     ("parent_id", "TEXT DEFAULT ''"),
+    # Oracle (goalbuddy-ported): upfront observable completion signal.
+    ("oracle", "TEXT DEFAULT ''"),
+    ("proof_type", "TEXT DEFAULT ''"),
+    ("completion_proof", "TEXT DEFAULT ''"),
 ]
 
 
@@ -169,6 +176,13 @@ class TaskService:
                          and row["gate_reason"] is not None else ""),
             parent_id=(row["parent_id"] if "parent_id" in keys
                        and row["parent_id"] is not None else ""),
+            oracle=(row["oracle"] if "oracle" in keys
+                    and row["oracle"] is not None else ""),
+            proof_type=(row["proof_type"] if "proof_type" in keys
+                        and row["proof_type"] is not None else ""),
+            completion_proof=(row["completion_proof"]
+                              if "completion_proof" in keys
+                              and row["completion_proof"] is not None else ""),
         )
 
     def _record_history(
@@ -206,6 +220,9 @@ class TaskService:
         story_file: str = "",
         assigned_agent: str = "",
         parent_id: str = "",
+        oracle: str = "",
+        proof_type: str = "",
+        completion_proof: str = "",
     ) -> Task:
         """Create a new task and return it."""
         task = Task(
@@ -217,13 +234,17 @@ class TaskService:
             dependencies=dependencies or [],
             tags=tags or [],
             parent_id=parent_id,
+            oracle=oracle,
+            proof_type=proof_type,
+            completion_proof=completion_proof,
         )
         self._db.execute(
             "INSERT INTO tasks "
             "(id, title, description, status, priority, story_file, "
             "assigned_agent, created_at, updated_at, completed_at, "
-            "blocked_reason, dependencies, tags, parent_id) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "blocked_reason, dependencies, tags, parent_id, "
+            "oracle, proof_type, completion_proof) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task.id,
                 task.title,
@@ -239,6 +260,9 @@ class TaskService:
                 json.dumps(task.dependencies),
                 json.dumps(task.tags),
                 task.parent_id,
+                task.oracle,
+                task.proof_type,
+                task.completion_proof,
             ),
         )
         self._db.commit()
@@ -322,7 +346,8 @@ class TaskService:
             "UPDATE tasks SET title=?, description=?, status=?, priority=?, "
             "story_file=?, assigned_agent=?, updated_at=?, completed_at=?, "
             "blocked_reason=?, dependencies=?, tags=?, "
-            "workflow_step=?, gate_state=?, gate_reason=?, parent_id=? "
+            "workflow_step=?, gate_state=?, gate_reason=?, parent_id=?, "
+            "oracle=?, proof_type=?, completion_proof=? "
             "WHERE id=?",
             (
                 task.title,
@@ -340,6 +365,9 @@ class TaskService:
                 task.gate_state,
                 task.gate_reason,
                 task.parent_id,
+                task.oracle,
+                task.proof_type,
+                task.completion_proof,
                 task.id,
             ),
         )

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -45,6 +45,9 @@ type Task = {
   gate_state?: string;
   gate_reason?: string;
   parent_id?: string;
+  oracle?: string;
+  proof_type?: string;
+  completion_proof?: string;
 };
 
 // Slim shape for the child-task list — only what the row renders.
@@ -314,6 +317,36 @@ export default function TaskDetailPage() {
           <Empty>No description.</Empty>
         )}
       </Card>
+
+      {(task.oracle || task.proof_type || task.completion_proof) && (
+        <Card>
+          <SectionLabel>Oracle — observable completion signal</SectionLabel>
+          <div className="mt-2 space-y-3 text-[13px]">
+            <div className="flex items-start gap-2 flex-wrap">
+              {task.proof_type && (
+                <span
+                  className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded shrink-0"
+                  style={{
+                    background: "var(--accent-violet-bg)",
+                    color: "var(--accent-violet-fg)",
+                    boxShadow: "inset 0 0 0 1px var(--accent-violet-ring)",
+                  }}
+                  title="proof type"
+                >
+                  {task.proof_type}
+                </span>
+              )}
+              <span className="opacity-90 leading-relaxed">{task.oracle || <span className="opacity-50">— no oracle defined —</span>}</span>
+            </div>
+            <div>
+              <div className="opacity-50 mb-1 text-[11px] uppercase tracking-wider">completion proof</div>
+              {task.completion_proof
+                ? <div className="leading-relaxed opacity-90">{task.completion_proof}</div>
+                : <div className="text-amber-300/90 text-[12px]">⚠ not yet recorded — green_gate will flag this</div>}
+            </div>
+          </div>
+        </Card>
+      )}
 
       {task.parent_id && (
         <Card>

--- a/services/prism-service/tests/unit/test_task_oracle.py
+++ b/services/prism-service/tests/unit/test_task_oracle.py
@@ -1,0 +1,95 @@
+"""Oracle field (ported from goalbuddy) — upfront observable completion signal.
+
+Pins: oracle/proof_type/completion_proof round-trip on the Task model + DB,
+the is_weak_proof() guard (ported from goalbuddy check-goal-state.mjs), and
+the advisory green_gate annotation when a task closes with no real proof.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _services(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"), enable_engine=False, task_svc=task_svc
+    )
+    return task_svc, cond
+
+
+# ---- field round-trip -------------------------------------------------
+
+def test_oracle_fields_default_empty(tmp_path):
+    task_svc, _ = _services(tmp_path)
+    t = task_svc.create(title="x")
+    assert (t.oracle, t.proof_type, t.completion_proof) == ("", "", "")
+    g = task_svc.get(t.id)
+    assert (g.oracle, g.proof_type, g.completion_proof) == ("", "", "")
+
+
+def test_oracle_fields_round_trip_create_and_update(tmp_path):
+    task_svc, _ = _services(tmp_path)
+    t = task_svc.create(
+        title="x", oracle="curl /api/foo returns 200", proof_type="demo"
+    )
+    assert t.oracle == "curl /api/foo returns 200"
+    assert t.proof_type == "demo"
+    task_svc.update(t.id, completion_proof="ran curl, got 200 (screenshot)")
+    g = task_svc.get(t.id)
+    assert g.oracle == "curl /api/foo returns 200"
+    assert g.proof_type == "demo"
+    assert g.completion_proof == "ran curl, got 200 (screenshot)"
+
+
+# ---- is_weak_proof (goalbuddy port) -----------------------------------
+
+def test_is_weak_proof_matches_goalbuddy_semantics():
+    from prism_service.services.conductor_service import is_weak_proof
+
+    for weak in [None, "", "   ", "unknown", "TBD", "todo", "None",
+                 "<observable signal>", "<fill me>"]:
+        assert is_weak_proof(weak) is True, weak
+    for real in ["532 tests pass", "demo recorded at /x.mp4", "0"]:
+        assert is_weak_proof(real) is False, real
+
+
+# ---- green_gate advisory annotation -----------------------------------
+
+def _drive_to_green_gate(task_svc, cond, t):
+    guard = 0
+    while task_svc.get(t.id).workflow_step != "green_gate" and guard < 20:
+        step = task_svc.get(t.id).workflow_step
+        gate = task_svc.get(t.id).gate_state
+        if gate == "pending":
+            cond.gate_decide(t.id, "approve", reason="ok", override=True)
+        else:
+            cond.advance_task(t.id, validation="step")
+        guard += 1
+    assert task_svc.get(t.id).workflow_step == "green_gate"
+
+
+def test_green_gate_flags_missing_completion_proof(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    t = task_svc.create(title="no proof")  # completion_proof == ""
+    _drive_to_green_gate(task_svc, cond, t)
+    cond.gate_decide(t.id, "approve", reason="full green", override=True)
+    assert "no completion_proof recorded" in task_svc.get(t.id).gate_reason
+
+
+def test_green_gate_clean_when_proof_present(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    t = task_svc.create(title="has proof",
+                        completion_proof="532 tests pass + demo")
+    _drive_to_green_gate(task_svc, cond, t)
+    cond.gate_decide(t.id, "approve", reason="full green", override=True)
+    assert "no completion_proof recorded" not in task_svc.get(t.id).gate_reason


### PR DESCRIPTION
## What

First of the three goalbuddy concepts, actually built (not just specced). Adds an **Oracle** to the Task model — `oracle` / `proof_type` / `completion_proof`: an upfront, observable completion signal defined before work starts and checked at `green_gate`, closing the tests-pass != feature-works gap.

- Additive `tasks.db` columns (existing rows migrate to `""`), threaded through `TaskService.create/update`, `GET`/`PATCH /api/tasks`, and the `task_create`/`task_update` MCP tools.
- `is_weak_proof()` in `conductor_service` is **ported verbatim** from goalbuddy `scripts/check-goal-state.mjs` `isWeakProof()` (rejects ''/unknown/tbd/todo/none/<placeholder>).
- At the terminal `green_gate`, `gate_decide` annotates the reason with an advisory `⚠ oracle: no completion_proof recorded` when proof is weak (annotate, never block — hooks doctrine).
- `TaskDetailPage` renders an "Oracle — observable completion signal" card (proof_type chip + oracle text + completion_proof, amber not-yet-recorded state).

## Verification

- `tests/unit/test_task_oracle.py` — field round-trip, the `is_weak_proof` port, and green_gate flag present/absent. 5/5 green (24/24 with hierarchy + conductor suites).
- Verified live on dev: set the oracle fields on the goalbuddy Oracle child via the API; the detail card renders proof_type + oracle + completion_proof.

Bumps **6.2.24 → 6.2.25**. Backs goalbuddy epic `56e3a518` (child 1/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
