### PR TITLE
feat(conductor): anti-busywork green_gate audit — goalbuddy port (v6.2.26)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.25"
+PRISM_VERSION = "6.2.26"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.2.26: Anti-busywork audit (goalbuddy Judge doctrine) — second goalbuddy "
+    "concept built. New green_gate_proof_note() in conductor_service encodes "
+    "'lots of files is not completion': at the terminal green_gate, gate_decide "
+    "now sums files_modified across the task's linked sessions and, when code "
+    "churned but completion_proof is weak, annotates '⚠ busywork risk: N "
+    "file-change(s) but no completion_proof (effort ≠ outcome)'; no churn + no "
+    "proof stays the '⚠ oracle' note; a real proof is clean. Advisory per the "
+    "hooks doctrine — annotate, never block; surfaces in gate_reason on the "
+    "TaskDetailPage Conductor card + swimlane tooltips. Tests: "
+    "test_task_busywork.py (busywork / oracle / clean / placeholder branches). "
+    "Backs goalbuddy epic 56e3a518 child 2/3. "
     "v6.2.25: Oracle field (goalbuddy-ported) — first goalbuddy concept built. "
     "Task gains oracle / proof_type / completion_proof: an upfront, observable "
     "completion signal defined before work and checked at green_gate, closing "

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -42,6 +42,23 @@ def is_weak_proof(value: object) -> bool:
     return s.startswith("<") and s.endswith(">")
 
 
+def green_gate_proof_note(files_modified: int, completion_proof: object) -> str:
+    """Advisory note appended to a green_gate close (annotate, never block).
+
+    Encodes the goalbuddy Judge doctrine "lots of files is not completion":
+      * code changed (files_modified>0) but no real completion_proof
+        -> BUSYWORK RISK: effort without demonstrated outcome.
+      * nothing changed and no proof -> ORACLE: no completion signal at all.
+      * a real completion_proof -> clean ('').
+    """
+    if not is_weak_proof(completion_proof):
+        return ""
+    if files_modified > 0:
+        return (f"  ⚠ busywork risk: {files_modified} file-change(s) but no "
+                f"completion_proof (effort ≠ outcome)")
+    return "  ⚠ oracle: no completion_proof recorded"
+
+
 class ConductorService:
     """Service layer for Conductor engine and scores.db queries.
 
@@ -1236,14 +1253,19 @@ class ConductorService:
             passed_gate_reason = f"verified ({verifier_validation}): {reason}"
         else:
             passed_gate_reason = reason
-        # Oracle (goalbuddy "no completion on weak proof"): at the terminal
-        # green_gate, flag a close with no real completion_proof. Advisory per
-        # the hooks doctrine — annotate the reason, never block — so it
-        # surfaces on the task/swimlane without breaking override-driven closes.
+        # Oracle + anti-busywork (goalbuddy): at the terminal green_gate, flag a
+        # close with no real completion_proof — and escalate to BUSYWORK RISK
+        # when code churned without an outcome ("lots of files is not
+        # completion"). Advisory per the hooks doctrine — annotate the reason,
+        # never block — so it surfaces without breaking override-driven closes.
         if gate_step_id == "green_gate":
             _proof = getattr(self._task_svc.get(task_id), "completion_proof", "")
-            if is_weak_proof(_proof):
-                passed_gate_reason += "  ⚠ oracle: no completion_proof recorded"
+            try:
+                _churn = sum(int(s.get("files_modified", 0) or 0)
+                             for s in self._task_svc.sessions_for_task(task_id))
+            except Exception:
+                _churn = 0
+            passed_gate_reason += green_gate_proof_note(_churn, _proof)
         self._task_svc.update(
             task_id,
             gate_state="passed",

--- a/services/prism-service/tests/unit/test_task_busywork.py
+++ b/services/prism-service/tests/unit/test_task_busywork.py
@@ -1,0 +1,42 @@
+"""Anti-busywork audit (goalbuddy Judge doctrine) — green_gate proof note.
+
+Pins green_gate_proof_note(): "lots of files is not completion." A green_gate
+close with code churn but no completion_proof is BUSYWORK RISK; with no churn
+and no proof it's an ORACLE gap; with a real proof it's clean. Advisory only.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def test_churn_without_proof_is_busywork():
+    from prism_service.services.conductor_service import green_gate_proof_note
+    note = green_gate_proof_note(7, "")
+    assert "busywork risk" in note
+    assert "7 file-change" in note
+
+
+def test_no_churn_no_proof_is_oracle_gap():
+    from prism_service.services.conductor_service import green_gate_proof_note
+    note = green_gate_proof_note(0, "tbd")
+    assert "oracle: no completion_proof" in note
+    assert "busywork" not in note
+
+
+def test_real_proof_is_clean_regardless_of_churn():
+    from prism_service.services.conductor_service import green_gate_proof_note
+    assert green_gate_proof_note(42, "532 tests pass + demo recorded") == ""
+    assert green_gate_proof_note(0, "demo at /x.mp4") == ""
+
+
+def test_placeholder_proof_still_flagged_as_busywork_when_churned():
+    from prism_service.services.conductor_service import green_gate_proof_note
+    note = green_gate_proof_note(3, "<fill in evidence>")
+    assert "busywork risk" in note


### PR DESCRIPTION
## What

Second of the three goalbuddy concepts, built. Adds the **anti-busywork** audit at the terminal `green_gate`, encoding goalbuddy's Judge doctrine *"lots of files is not completion."*

- New pure `green_gate_proof_note(files_modified, completion_proof)` in `conductor_service`:
  - code churned (`files_modified>0`) but weak `completion_proof` → `⚠ busywork risk: N file-change(s) but no completion_proof (effort ≠ outcome)`
  - no churn + no proof → `⚠ oracle: no completion_proof recorded`
  - real proof → clean (`""`)
- `gate_decide` sums `files_modified` across the task's linked sessions (`sessions_for_task`) and appends the note. Advisory per the hooks doctrine — **annotate, never block** — surfaced in `gate_reason` on the TaskDetail Conductor card + swimlane tooltips.

## Verification

- `tests/unit/test_task_busywork.py` — busywork / oracle / clean / placeholder branches. 9/9 green with the oracle suite (the refactor keeps the existing oracle tests passing).

Bumps **6.2.25 → 6.2.26**. Backs goalbuddy epic `56e3a518` (child 2/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
