### PR TITLE
feat: make the learning loop self-sustaining + bounded

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.28"
+PRISM_VERSION = "6.2.29"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/api/consolidation.py
+++ b/services/prism-service/prism_service/api/consolidation.py
@@ -48,9 +48,8 @@ def workers() -> dict:
     RUNNING by design' string. v6.1.1 adds a `prompt` field on workers
     that shell out to claude_cli, so the /settings/activity drilldown
     can render the actual instructions that drive each one."""
-    reflection_on = os.environ.get("PRISM_REFLECTION_WORKER", "").lower() in (
-        "1", "on", "true", "yes",
-    )
+    from prism_service.services import reflection_worker
+    reflection_on = reflection_worker.is_enabled()
     reflection_interval = int(
         os.environ.get("PRISM_REFLECTION_WORKER_INTERVAL", "900")
     )
@@ -61,8 +60,9 @@ def workers() -> dict:
             "running": True,
             "cadence_s": reflection_interval,
             "description": (
-                "Opt-in (PRISM_REFLECTION_WORKER=on). Picks the oldest "
-                "pending consolidation_candidate every "
+                "Default ON (PRISM_REFLECTION_WORKER=off to opt out). "
+                "Picks the oldest real-signal pending "
+                "consolidation_candidate every "
                 f"{reflection_interval}s, dispatches the same headless "
                 "claude_cli path /api/consolidation/run-reflection uses, "
                 "and persists the verdict + minted memories."
@@ -114,6 +114,28 @@ def workers() -> dict:
         ),
         "prompt_kind": "static",
         "prompt": memory_summary_worker.SUMMARY_PROMPT_TEMPLATE,
+    }
+    from prism_service.services import adaptive_policy
+    adaptive_enabled = adaptive_policy.is_enabled()
+    adaptive_entry = {
+        "id": adaptive_policy.WORKER_ID,
+        "label": adaptive_policy.WORKER_LABEL,
+        "running": adaptive_enabled,
+        "cadence_s": (
+            int(os.environ.get("PRISM_ADAPTIVE_POLICY_WORKER_INTERVAL", "3600"))
+            if adaptive_enabled else 0
+        ),
+        "description": (
+            "Self-tunes the memory knobs (forget_cutoff / decay_weight / "
+            "merge_similarity_threshold) from the recall->outcome signal, "
+            "persisting one policy_knobs row per tick for the /learning "
+            "'Adaptive policy' panel. Default ON, daily cadence — set "
+            "PRISM_ADAPTIVE_POLICY_WORKER=off to disable."
+            if adaptive_enabled else
+            "OFF (PRISM_ADAPTIVE_POLICY_WORKER=off). Set "
+            "PRISM_ADAPTIVE_POLICY_WORKER=on to self-tune memory knobs."
+        ),
+        "prompt_kind": "none",
     }
     return {
         "workers": [
@@ -178,6 +200,7 @@ def workers() -> dict:
             },
             reflection_entry,
             memory_summary_entry,
+            adaptive_entry,
         ],
     }
 
@@ -257,6 +280,27 @@ def backfill(project: str = Query("default"), limit: int = Query(500, ge=1, le=5
     ctx = get_project(project)
     scores_db = str(ctx._data_dir / "scores.db")
     return backfill_from_sessions(scores_db, limit=limit)
+
+
+@router.post("/drain")
+def drain(project: str = Query("default")) -> dict:
+    """FIX 1d — one-call backlog drain. Runs the reflection worker once,
+    pinned to this project, to process the existing pending real-signal
+    candidates in a single request (the noise filter still skips no-signal
+    briefs). Reports how many it ran. The PRISM_REFLECTION_WORKER daemon
+    does the same on a cadence; this is the manual catch-up button."""
+    import os as _os
+    from prism_service.services import reflection_worker as rw
+    prev = _os.environ.get("PRISM_REFLECTION_WORKER_PROJECT")
+    _os.environ["PRISM_REFLECTION_WORKER_PROJECT"] = project
+    try:
+        summary = rw.run_once()
+    finally:
+        if prev is None:
+            _os.environ.pop("PRISM_REFLECTION_WORKER_PROJECT", None)
+        else:
+            _os.environ["PRISM_REFLECTION_WORKER_PROJECT"] = prev
+    return {"drained": summary.get("ran", 0), **summary}
 
 
 @router.post("/prune-noise")

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -151,6 +151,21 @@ def start_governance_timer():
                     get_project(pid).governance.run_cycle()
                 except Exception as e:
                     print(f"Governance cycle error ({pid}): {e}")
+                # FIX 4a — bounded retention sweep on the governance
+                # cadence: prune old completed candidates + cap stale
+                # session_outcomes so the queue/log can't grow forever.
+                try:
+                    from prism_service.services.consolidation_data import (
+                        retention_sweep,
+                    )
+                    scores_db = str(get_project(pid)._data_dir / "scores.db")
+                    rep = retention_sweep(scores_db)
+                    if rep.get("candidates_pruned") or rep.get(
+                        "session_outcomes_pruned"
+                    ):
+                        print(f"[retention] {pid}: pruned {rep}")
+                except Exception as e:
+                    print(f"Retention sweep error ({pid}): {e}")
         except Exception as e:
             print(f"Governance timer error: {e}")
         time.sleep(GOVERNANCE_INTERVAL_SECONDS)
@@ -343,6 +358,15 @@ async def lifespan(_app: FastAPI):
             start_memory_ops_workers,
         )
         start_memory_ops_workers()
+        # Tier-3 — adaptive policy. Self-tunes the memory knobs
+        # (forget_cutoff / decay_weight / merge_similarity_threshold) from
+        # the recall->outcome signal, persisting one policy_knobs row per
+        # tick. Env-gated PRISM_ADAPTIVE_POLICY_WORKER (default ON), daily
+        # cadence (PRISM_ADAPTIVE_POLICY_WORKER_INTERVAL, default 3600s).
+        from prism_service.services.adaptive_policy import (
+            start_adaptive_policy_worker,
+        )
+        start_adaptive_policy_worker()
 
         # Ultimate Graph narrative layer (#50) — names the code hierarchy
         # (domain/service/module) with inference, escaping scopes whose

--- a/services/prism-service/prism_service/services/adaptive_policy.py
+++ b/services/prism-service/prism_service/services/adaptive_policy.py
@@ -27,9 +27,42 @@ surfacing — a clean, testable first version.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
+import sys as _sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, Optional
+
+WORKER_ID = "adaptive_policy_worker"
+WORKER_LABEL = "Adaptive policy"
+
+
+def _env_truthy(name: str, default: bool) -> bool:
+    raw = os.environ.get(name, "").lower()
+    if raw in ("1", "on", "true", "yes"):
+        return True
+    if raw in ("0", "off", "false", "no"):
+        return False
+    return default
+
+
+def is_enabled() -> bool:
+    """Honor PRISM_ADAPTIVE_POLICY_WORKER but default to ON so the
+    self-tuning loop runs without an explicit opt-in (surfaced for
+    /api/consolidation/workers)."""
+    return _env_truthy("PRISM_ADAPTIVE_POLICY_WORKER", default=True)
+
+
+def _interval_s() -> int:
+    # Daily-ish by default — knob nudges are meant to drift slowly.
+    try:
+        return max(60, int(os.environ.get(
+            "PRISM_ADAPTIVE_POLICY_WORKER_INTERVAL", "3600",
+        )))
+    except ValueError:
+        return 3600
 
 # Frozen-constant baselines the loop nudges away from. forget_cutoff mirrors
 # memory_ops.forget.FADING_THRESHOLD (the value it replaces as a consumer).
@@ -251,3 +284,56 @@ class AdaptivePolicyService:
         finally:
             conn.close()
         return [dict(r) for r in rows]
+
+
+def _log(msg: str) -> None:
+    print(f"[{WORKER_ID}] {msg}", file=_sys.stderr, flush=True)
+
+
+def run_once() -> dict:
+    """FIX 3a — one worker tick. For every project, tune + persist the
+    knobs off the recall->outcome signal. Returns a small summary the
+    /settings/activity panel + tests can inspect."""
+    from prism_service.project_context import get_project, get_all_projects
+    summary: dict = {"projects": [], "tuned": 0, "errors": 0}
+    try:
+        projects = get_all_projects()
+    except Exception as exc:
+        _log(f"get_all_projects failed: {exc}")
+        return summary
+    for project in projects:
+        try:
+            ctx = get_project(project)
+            scores_db = str(ctx._data_dir / "scores.db")
+            if not Path(scores_db).exists():
+                continue
+            mem = getattr(ctx, "memory_svc", None)
+            AdaptivePolicyService(scores_db, mem).tune(project=project)
+            summary["tuned"] += 1
+            summary["projects"].append(project)
+        except Exception as exc:
+            _log(f"{project}: tune failed: {exc}")
+            summary["errors"] += 1
+    return summary
+
+
+def _loop() -> None:
+    interval = _interval_s()
+    _log(f"started; interval={interval}s")
+    while True:
+        try:
+            run_once()
+        except Exception as exc:
+            _log(f"run_once raised: {exc}")
+        time.sleep(interval)
+
+
+def start_adaptive_policy_worker() -> threading.Thread | None:
+    """Spawn the daemon thread unless PRISM_ADAPTIVE_POLICY_WORKER=off."""
+    if not is_enabled():
+        return None
+    t = threading.Thread(
+        target=_loop, name="prism-adaptive-policy-worker", daemon=True,
+    )
+    t.start()
+    return t

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -280,7 +280,12 @@ def format_transcript_excerpt(signals: dict) -> str:
     if pushbacks:
         parts.append(f"Pushbacks ({len(pushbacks)}):")
         for p in pushbacks:
-            parts.append(f"- [{p.get('ts','')}] user: {p.get('text','')}")
+            # Real path passes dicts {ts,text}; tolerate bare strings too
+            # so a malformed/legacy signal can't crash the enqueue path.
+            if isinstance(p, dict):
+                parts.append(f"- [{p.get('ts','')}] user: {p.get('text','')}")
+            else:
+                parts.append(f"- user: {p}")
     bg = signals.get("bg_signals") or []
     if bg:
         parts.append(f"\nBackground protocol ({len(bg)}):")
@@ -425,8 +430,17 @@ def _enqueue_with_signals(
 ) -> None:
     """Wrap enqueue_for_session with a rich scope built from signals."""
     try:
-        from prism_service.services.consolidation_data import enqueue_for_session
+        from prism_service.services.consolidation_data import (
+            enqueue_for_session, resolve_task_id_for_session,
+        )
         signals = metrics.get("signals") or {}
+        # FIX 2a — the disk path has no task_id of its own, but a session
+        # that was task-linked (task_sessions) must stamp that task_id onto
+        # the candidate so /learning's Layer-B rollup fills. Resolve it here
+        # so the noise filter below also sees the link.
+        task_id = metrics.get("task_id") or resolve_task_id_for_session(
+            scores_db, session_id,
+        )
         skill_invocations = metrics.get("skill_invocations") or []
         scope: dict = {
             "files_read": metrics.get("files_read", 0),
@@ -455,7 +469,7 @@ def _enqueue_with_signals(
         # it so a future task-linked path is never filtered.
         sc = scope["signal_counts"]
         if (
-            metrics.get("task_id") is None
+            task_id is None
             and all(int(sc.get(k) or 0) == 0 for k in sc)
             and int(scope.get("files_modified", 0) or 0) == 0
         ):
@@ -468,6 +482,7 @@ def _enqueue_with_signals(
             return
         enqueue_for_session(
             scores_db, session_id, scope=scope, trigger="transcript_imported",
+            task_id=task_id,
         )
     except Exception:
         pass  # never break the metrics insert path

--- a/services/prism-service/prism_service/services/consolidation_data.py
+++ b/services/prism-service/prism_service/services/consolidation_data.py
@@ -243,17 +243,45 @@ def get_recent_runs(scores_db: str, limit: int = 20) -> list[dict]:
 # on insert, and an on-demand backfill endpoint sweeps everything
 # historical. Idempotent on session_id, so calling twice is a no-op.
 
+def resolve_task_id_for_session(scores_db: str, session_id: str) -> str | None:
+    """Return the task_id linked to ``session_id`` via task_sessions, or
+    None. The transcript disk path has no task_id of its own; when a
+    session was task-linked (conductor_advance/task_link_session writes
+    task_sessions), the consolidation_candidate must carry that task_id
+    so /learning's Layer-B rollup can fill (FIX 2a)."""
+    if not session_id or not Path(scores_db).exists():
+        return None
+    conn = sqlite3.connect(scores_db)
+    try:
+        try:
+            row = conn.execute(
+                "SELECT task_id FROM task_sessions WHERE session_id=? "
+                "ORDER BY started_at DESC LIMIT 1",
+                (session_id,),
+            ).fetchone()
+        except sqlite3.OperationalError:
+            return None  # table absent on a fresh db
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
 def enqueue_for_session(
     scores_db: str,
     session_id: str,
     scope: dict | None = None,
     trigger: str = "session_completed",
+    task_id: str | None = None,
 ) -> str | None:
     """Insert a pending consolidation_candidate for ``session_id`` if one
     doesn't already exist. Returns the new candidate id, or None when
-    the session already had one (idempotent)."""
+    the session already had one (idempotent). When ``task_id`` is None it
+    is resolved from task_sessions so a task-linked session stamps its
+    task_id onto the candidate (FIX 2a)."""
     if not session_id or not Path(scores_db).exists():
         return None
+    if task_id is None:
+        task_id = resolve_task_id_for_session(scores_db, session_id)
     conn = sqlite3.connect(scores_db)
     conn.row_factory = sqlite3.Row
     try:
@@ -267,9 +295,9 @@ def enqueue_for_session(
         conn.execute(
             "INSERT INTO consolidation_candidates "
             "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
-            "VALUES (?, NULL, ?, ?, ?, 'pending', ?)",
+            "VALUES (?, ?, ?, ?, ?, 'pending', ?)",
             (
-                cid, session_id, trigger,
+                cid, task_id, session_id, trigger,
                 json.dumps(scope or {}),
                 datetime.now(timezone.utc).isoformat(),
             ),
@@ -345,3 +373,67 @@ def prune_noise_candidates(scores_db: str) -> int:
         return len(doomed)
     finally:
         conn.close()
+
+
+# Default retention windows — how long a completed candidate / session
+# outcome is kept before the governance sweep prunes it.
+_CANDIDATE_RETENTION_DAYS = 30
+_SESSION_OUTCOME_CAP = 5000
+
+
+def retention_sweep(
+    scores_db: str,
+    candidate_retention_days: int = _CANDIDATE_RETENTION_DAYS,
+    session_outcome_cap: int = _SESSION_OUTCOME_CAP,
+    now: datetime | None = None,
+) -> dict:
+    """FIX 4a — bounded, idempotent retention sweep on the governance
+    cadence.
+
+    Deletes ONLY rows that have aged out, never the working set:
+      * consolidation_candidates with status='completed' whose
+        completed_at is older than ``candidate_retention_days`` — pending
+        candidates (any age) and recent completed rows always survive;
+      * the oldest session_outcomes beyond ``session_outcome_cap`` rows,
+        so the session log can't grow unbounded.
+
+    Returns {candidates_pruned, session_outcomes_pruned} so the timer can
+    log what it pruned. Idempotent — a second call finds nothing aged out
+    and prunes 0.
+    """
+    report = {"candidates_pruned": 0, "session_outcomes_pruned": 0}
+    if not Path(scores_db).exists():
+        return report
+    if now is None:
+        now = datetime.now(timezone.utc)
+    cutoff = (now - timedelta(days=candidate_retention_days)).isoformat()
+    conn = sqlite3.connect(scores_db)
+    try:
+        cur = conn.execute(
+            "DELETE FROM consolidation_candidates "
+            "WHERE status='completed' AND completed_at IS NOT NULL "
+            "AND completed_at < ?",
+            (cutoff,),
+        )
+        report["candidates_pruned"] = cur.rowcount or 0
+        # Cap session_outcomes to the newest N rows (archive the tail by
+        # deleting it — the reflected signal already lives in candidates).
+        try:
+            total = conn.execute(
+                "SELECT COUNT(*) FROM session_outcomes"
+            ).fetchone()[0]
+            if total > session_outcome_cap:
+                cur2 = conn.execute(
+                    "DELETE FROM session_outcomes WHERE session_id IN ("
+                    "  SELECT session_id FROM session_outcomes "
+                    "  ORDER BY timestamp DESC LIMIT -1 OFFSET ?"
+                    ")",
+                    (session_outcome_cap,),
+                )
+                report["session_outcomes_pruned"] = cur2.rowcount or 0
+        except sqlite3.OperationalError:
+            pass  # session_outcomes absent on a bare db
+        conn.commit()
+    finally:
+        conn.close()
+    return report

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -352,6 +352,23 @@ def run_one(
         except Exception as exc:
             skipped_mem.append({"reason": str(exc), "entry": nm})
 
+    # FIX 2b — feed the recall->outcome signal for a task-linked candidate
+    # so the adaptive policy has something to tune on. JanitorService.submit
+    # already wrote the Layer-B task_quality_rollup (qualitative_score) onto
+    # the task; here we close the loop by labelling that task's recalls with
+    # the outcome derived from the qualitative score (>=0.5 => positive).
+    task_id = row["task_id"]
+    if task_id:
+        try:
+            qscore = float(verdict.get("qualitative_score") or 0.0)
+            outcome = "positive" if qscore >= 0.5 else "negative"
+            mem = getattr(ctx, "memory_svc", None)
+            if mem is not None and hasattr(mem, "record_outcome"):
+                mem.record_outcome(task_id, outcome)
+        except Exception as exc:  # never fail the reflection on this
+            print(f"[reflection_runner] record_outcome({task_id}) failed: {exc}",
+                  flush=True)
+
     return ReflectionResult(
         ok=True, submitted=submitted, verdict=verdict,
         memories_stored=stored, memories_skipped=skipped_mem,
@@ -360,17 +377,25 @@ def run_one(
     )
 
 
-def next_pending_candidate_id(scores_db: str) -> str | None:
+def next_pending_candidate_id(
+    scores_db: str, exclude: set[str] | None = None,
+) -> str | None:
     """Return the oldest pending candidate id, or None if the queue is
-    empty. Used by the opt-in PRISM_REFLECTION_WORKER daemon."""
+    empty. Used by the PRISM_REFLECTION_WORKER daemon. ``exclude`` skips
+    ids the caller already classified as noise this cycle so the loop
+    advances past them instead of re-claiming the same head."""
     if not Path(scores_db).exists():
         return None
     conn = sqlite3.connect(scores_db)
     try:
-        row = conn.execute(
+        rows = conn.execute(
             "SELECT id FROM consolidation_candidates "
-            "WHERE status='pending' ORDER BY queued_at ASC LIMIT 1"
-        ).fetchone()
+            "WHERE status='pending' ORDER BY queued_at ASC"
+        ).fetchall()
     finally:
         conn.close()
-    return row[0] if row else None
+    skip = exclude or set()
+    for (cid,) in rows:
+        if cid not in skip:
+            return cid
+    return None

--- a/services/prism-service/prism_service/services/reflection_worker.py
+++ b/services/prism-service/prism_service/services/reflection_worker.py
@@ -21,15 +21,67 @@ errors) are logged but never crash the thread.
 
 from __future__ import annotations
 
+import json as _json
 import os
+import sqlite3
 import sys as _sys
 import threading
 import time
 from pathlib import Path
 
 
-def _env_truthy(name: str) -> bool:
-    return os.environ.get(name, "").lower() in ("1", "on", "true", "yes")
+def _is_noise_candidate(scores_db: str, candidate_id: str) -> bool:
+    """True when a candidate carries no usable signal — task_id NULL AND
+    every signal_counts bucket zero. Mirrors the v6.2.18 enqueue-time
+    noise filter so the self-draining loop reflects real signal only and
+    never burns claude tokens on an empty brief."""
+    try:
+        conn = sqlite3.connect(scores_db)
+        try:
+            row = conn.execute(
+                "SELECT task_id, scope_json FROM consolidation_candidates "
+                "WHERE id=?", (candidate_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
+    if not row:
+        return False
+    if row[0] is not None:
+        return False
+    try:
+        sc = (_json.loads(row[1] or "{}").get("signal_counts")) or {}
+    except Exception:
+        sc = {}
+    return all(int(sc.get(k) or 0) == 0 for k in (
+        "pushbacks", "bg_signals", "tool_failures", "memory_writes",
+    ))
+
+
+def _env_truthy(name: str, default: bool = False) -> bool:
+    """Mirror memory_summary_worker._env_truthy: tri-state with a default.
+
+    Recognises on/off synonyms; anything unset returns ``default``. The
+    reflection worker now defaults ON (the learning loop must self-drain),
+    so start_reflection_worker spawns without an explicit
+    PRISM_REFLECTION_WORKER=on, while =off still fully opts out.
+    """
+    raw = os.environ.get(name, "").lower()
+    if raw in ("1", "on", "true", "yes"):
+        return True
+    if raw in ("0", "off", "false", "no"):
+        return False
+    return default
+
+
+def is_enabled() -> bool:
+    """Honor PRISM_REFLECTION_WORKER=off but default to ON.
+
+    Surfaced for /api/consolidation/workers so the activity panel's
+    'running' dot reflects reality, and read by start_reflection_worker.
+    """
+    return _env_truthy("PRISM_REFLECTION_WORKER", default=True)
 
 
 def _interval_s() -> int:
@@ -91,10 +143,20 @@ def run_once() -> dict:
             continue
 
         ran_here = 0
+        seen_noise: set[str] = set()
         for _ in range(n_max):
-            cid = next_pending_candidate_id(scores_db)
+            cid = next_pending_candidate_id(scores_db, exclude=seen_noise)
             if not cid:
                 break
+            # v6.2.29 — honor the noise filter at drain time. A no-signal
+            # candidate (task_id NULL, all signal_counts zero) is skipped,
+            # never dispatched to claude. Exclude it so the loop advances
+            # to the next real-signal candidate instead of spinning.
+            if _is_noise_candidate(scores_db, cid):
+                _log(f"{project}: skip noise candidate={cid}")
+                seen_noise.add(cid)
+                summary["skipped"] += 1
+                continue
             _log(f"{project}: dispatching reflection for candidate={cid}")
             try:
                 result = run_one(project=project, candidate_id=cid)
@@ -138,7 +200,7 @@ def start_reflection_worker() -> threading.Thread | None:
     Returns the thread (or None when disabled). Idempotent if called
     multiple times — the lifespan call site is the only legitimate
     one, but tests may opt in directly."""
-    if not _env_truthy("PRISM_REFLECTION_WORKER"):
+    if not is_enabled():
         return None
     t = threading.Thread(
         target=_loop, name="prism-reflection-worker", daemon=True,

--- a/services/prism-service/tests/integration/test_learning_loop_self_sustaining.py
+++ b/services/prism-service/tests/integration/test_learning_loop_self_sustaining.py
@@ -1,0 +1,497 @@
+"""RED scaffold — learning loop self-sustaining + bounded (task fc2d8aeb).
+
+Pins the acceptance criteria for making the learning loop drain itself on
+a bounded cadence and surface its workers, end-to-end against the REAL
+seams (env defaults, the transcript enqueue path, the janitor rollup
+write, the adaptive-policy worker registration, and a retention sweep).
+
+These are integration-level: they assert the user-facing seam, not a
+unit echo —
+  * reflection worker DEFAULTS ON (is_enabled) and spawns without an
+    explicit PRISM_REFLECTION_WORKER=on, but =off still disables it;
+  * the noise filter is still honored at enqueue time;
+  * a one-call backlog drain exists in api/consolidation;
+  * a task-linked session yields a candidate carrying that task_id;
+  * a completed reflection writes a task_quality_rollup row joined with
+    Layer-A and learning_data.get_learning_rows returns it;
+  * an env-gated AdaptivePolicyService worker is registered in main.py
+    and surfaces in /api/consolidation/workers;
+  * a bounded retention sweep prunes only completed/old candidates and
+    caps stale session_outcomes.
+
+Every test FAILS today. Parent task: fc2d8aeb.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _make_scores_db(tmp_path: Path) -> str:
+    """Real scores.db with the full consolidation/learning schema."""
+    from prism_service.engines.brain_engine import Brain
+
+    scores = tmp_path / "scores.db"
+    Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(scores),
+    )
+    return str(scores)
+
+
+# =====================================================================
+# FIX 1a/1b/1c — reflection worker self-drains on a bounded cadence,
+# defaults ON, honors =off, and respects the v6.2.18 noise filter.
+# =====================================================================
+
+
+def test_reflection_worker_is_enabled_defaults_on(monkeypatch):
+    """FIX 1a — mirror memory_summary_worker.is_enabled(): default ON.
+
+    There must be an is_enabled() that returns True with the env var
+    UNSET, so start_reflection_worker spawns the thread without an
+    explicit PRISM_REFLECTION_WORKER=on."""
+    from prism_service.services import reflection_worker as rw
+
+    monkeypatch.delenv("PRISM_REFLECTION_WORKER", raising=False)
+    assert hasattr(rw, "is_enabled"), (
+        "reflection_worker must expose is_enabled() mirroring "
+        "memory_summary_worker"
+    )
+    assert rw.is_enabled() is True, (
+        "reflection worker must DEFAULT ON (self-sustaining loop)"
+    )
+
+
+def test_reflection_worker_off_switch_preserved(monkeypatch):
+    """FIX 1b — PRISM_REFLECTION_WORKER=off fully disables the worker."""
+    from prism_service.services import reflection_worker as rw
+
+    monkeypatch.setenv("PRISM_REFLECTION_WORKER", "off")
+    assert rw.is_enabled() is False
+    assert rw.start_reflection_worker() is None, (
+        "=off must keep the opt-out: no thread spawned"
+    )
+
+
+def test_start_reflection_worker_spawns_without_explicit_on(monkeypatch):
+    """FIX 1a — with the env var UNSET, the worker still starts."""
+    from prism_service.services import reflection_worker as rw
+
+    monkeypatch.delenv("PRISM_REFLECTION_WORKER", raising=False)
+
+    # Keep the daemon from looping forever: single-pass loop + no-op cycle.
+    monkeypatch.setattr(rw, "run_once", lambda: {
+        "projects": [], "ran": 0, "errors": 0, "skipped": 0,
+    })
+    monkeypatch.setattr(rw, "_loop", lambda: rw.run_once())
+
+    t = rw.start_reflection_worker()
+    assert t is not None, (
+        "default-ON: thread must spawn with PRISM_REFLECTION_WORKER unset"
+    )
+    t.join(timeout=2)
+
+
+def test_reflection_worker_skips_noise_candidate(tmp_path, monkeypatch):
+    """FIX 1c — a no-signal candidate (task_id NULL, zero signals) must
+    NOT be dispatched to reflection_runner; the loop drains real signal
+    only."""
+    from prism_service.services import reflection_worker as rw
+
+    scores = _make_scores_db(tmp_path)
+    conn = sqlite3.connect(scores)
+    try:
+        conn.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
+            "VALUES ('noise-1', NULL, 'sess-noise', 'transcript_imported', "
+            " '{\"signal_counts\": {\"pushbacks\": 0, \"bg_signals\": 0, "
+            "   \"tool_failures\": 0, \"memory_writes\": 0}}', 'pending', "
+            " '2026-05-25T10:00:00+00:00')",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    class _Ctx:
+        _data_dir = tmp_path
+
+    monkeypatch.setattr(rw, "_projects_in_scope", lambda: ["p"])
+    dispatched: list[str] = []
+
+    def _fake_run_one(*, project, candidate_id):
+        dispatched.append(candidate_id)
+        raise AssertionError("noise candidate must not be reflected")
+
+    from unittest.mock import patch
+    with patch(
+        "prism_service.project_context.get_project", return_value=_Ctx()
+    ):
+        monkeypatch.setattr(
+            "prism_service.services.reflection_runner.run_one", _fake_run_one
+        )
+        summary = rw.run_once()
+
+    assert dispatched == [], (
+        "noise candidate must be skipped, not dispatched for reflection"
+    )
+    assert summary["ran"] == 0
+
+
+# =====================================================================
+# FIX 1d — a one-call backlog drain exists in api/consolidation.
+# =====================================================================
+
+
+def test_backlog_drain_endpoint_drains_pending(tmp_path, monkeypatch):
+    """FIX 1d — POST /api/consolidation/drain (or equivalent) processes
+    the existing pending candidates in one call and reports how many it
+    drained. Wired through the real FastAPI app + route dispatcher."""
+    from fastapi.testclient import TestClient
+
+    scores = _make_scores_db(tmp_path)
+    conn = sqlite3.connect(scores)
+    try:
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO consolidation_candidates "
+                "(id, task_id, session_id, trigger, scope_json, status, "
+                " queued_at) VALUES (?, 'T-1', ?, 'task_done', "
+                " '{\"signal_counts\": {\"pushbacks\": 1}}', 'pending', ?)",
+                (f"cand-{i}", f"sess-{i}", f"2026-05-2{i}T10:00:00+00:00"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+    class _Ctx:
+        _data_dir = Path(scores).parent
+
+    monkeypatch.setattr(
+        "prism_service.api.consolidation.get_project", lambda p: _Ctx()
+    )
+    # Don't actually shell out to claude — count the dispatch instead.
+    drained: list[str] = []
+    monkeypatch.setattr(
+        "prism_service.services.reflection_worker.run_once",
+        lambda: {"ran": 0, "errors": 0, "skipped": 0, "projects": []},
+        raising=False,
+    )
+
+    from prism_service.main import app
+    client = TestClient(app)
+    resp = client.post("/api/consolidation/drain?project=p")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "drained" in body or "ran" in body, (
+        "drain endpoint must report how many candidates it processed"
+    )
+
+
+# =====================================================================
+# FIX 2a — a task-linked session produces a candidate carrying task_id.
+# =====================================================================
+
+
+def test_task_linked_session_candidate_carries_task_id(tmp_path):
+    """FIX 2a — when scores.db task_sessions links a session to a task,
+    claude_transcripts._enqueue_with_signals must stamp that task_id onto
+    the consolidation_candidate (no longer NULL)."""
+    from prism_service.services.claude_transcripts import _enqueue_with_signals
+
+    scores = _make_scores_db(tmp_path)
+    # Link session -> task in task_sessions (the LL association table).
+    conn = sqlite3.connect(scores)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS task_sessions ("
+            "task_id TEXT NOT NULL, session_id TEXT NOT NULL, "
+            "started_at TEXT, ended_at TEXT, "
+            "PRIMARY KEY (task_id, session_id))"
+        )
+        conn.execute(
+            "INSERT INTO task_sessions (task_id, session_id) VALUES (?, ?)",
+            ("TASK-42", "sess-linked"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    metrics = {
+        "session_id": "sess-linked",
+        "files_modified": 1,
+        "signals": {"pushbacks": ["p"]},
+    }
+    _enqueue_with_signals(scores, "sess-linked", metrics,
+                          "2026-05-25T10:00:00+00:00")
+
+    conn = sqlite3.connect(scores)
+    try:
+        row = conn.execute(
+            "SELECT task_id FROM consolidation_candidates "
+            "WHERE session_id=?", ("sess-linked",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "a candidate must be enqueued for the session"
+    assert row[0] == "TASK-42", (
+        f"candidate must carry the linked task_id, got {row[0]!r} (still NULL "
+        f"means FIX 2a not wired)"
+    )
+
+
+# =====================================================================
+# FIX 2b — a completed reflection writes a task_quality_rollup (Layer-B)
+# joined with Layer-A, and learning_data.get_learning_rows returns it.
+# =====================================================================
+
+
+def test_completed_reflection_writes_rollup_and_feeds_outcome(
+    tmp_path, monkeypatch
+):
+    """FIX 2b — a completed reflection (via reflection_runner.run_one)
+    must (1) write the Layer-B task_quality_rollup joined with Layer-A so
+    learning_data.get_learning_rows returns it, AND (2) feed the
+    recall->outcome signal via memory_service.record_outcome so the
+    adaptive policy has something to tune on. The record_outcome call is
+    the wire that is MISSING today."""
+    import prism_service.services.reflection_runner as rr
+    from prism_service.services.learning_data import get_learning_rows
+
+    scores = _make_scores_db(tmp_path)
+    conn = sqlite3.connect(scores)
+    try:
+        conn.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
+            "VALUES ('cand-q', 'TASK-Q', 'sess-q', 'task_done', '{}', "
+            " 'pending', '2026-05-25T10:00:00+00:00')",
+        )
+        # Layer-A metric already present for the same task.
+        conn.execute(
+            "INSERT INTO task_quality_rollup (task_id, quality_score) "
+            "VALUES ('TASK-Q', 0.91)",
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    recorded: list[tuple] = []
+
+    class _Mem:
+        def record_outcome(self, task_id, outcome):
+            recorded.append((task_id, outcome))
+            return 1
+
+        def store(self, **kw):
+            class _E:
+                id = "e1"
+                name = kw.get("name")
+                domain = kw.get("domain")
+            return _E()
+
+    class _Ctx:
+        _data_dir = tmp_path
+        memory_svc = _Mem()
+
+    monkeypatch.setattr(rr, "get_project", lambda p: _Ctx(), raising=False)
+    monkeypatch.setattr(
+        "prism_service.project_context.get_project", lambda p: _Ctx()
+    )
+
+    # Stub the claude shell-out: return a clean qualitative verdict.
+    class _Res:
+        run_id = "run-q"
+        exit_code = 0
+        duration_s = 1.0
+
+        def final_text(self):
+            return (
+                '{"qualitative_score": 0.77, "narrative": "clean", '
+                '"new_memories": [], "invalidate_memory_ids": [], '
+                '"confidence": 0.6}'
+            )
+
+    monkeypatch.setattr(
+        "prism_service.inference.claude_cli.invoke",
+        lambda **kw: _Res(),
+    )
+    monkeypatch.setattr(
+        "prism_service.services.source_service.source_dir_for",
+        lambda p: str(tmp_path), raising=False,
+    )
+
+    res = rr.run_one(project="p", candidate_id="cand-q")
+    assert res.ok, res.to_dict()
+
+    # (1) Layer-B rollup row joined with Layer-A, surfaced via learning_data.
+    rows = get_learning_rows(scores)
+    by_task = {r["task_id"]: r for r in rows}
+    assert "TASK-Q" in by_task, (
+        "get_learning_rows must surface the task-linked rollup row"
+    )
+    row = by_task["TASK-Q"]
+    assert abs(row["qualitative_score"] - 0.77) < 1e-9, (
+        "Layer-B qualitative_score must be written onto the rollup"
+    )
+    assert row["quality_score"] is not None and row["quality_score"] >= 0.9, (
+        "Layer-B row must join the existing Layer-A quality_score"
+    )
+
+    # (2) The recall->outcome signal must be fed for the task.
+    assert any(t == "TASK-Q" for (t, _o) in recorded), (
+        "completed reflection must call memory_service.record_outcome for "
+        f"the task; recorded={recorded!r}"
+    )
+
+
+# =====================================================================
+# FIX 3a — AdaptivePolicyService is an env-gated worker registered in
+# main.py lifespan and a tick persists >=1 policy_knobs row.
+# =====================================================================
+
+
+def test_adaptive_policy_worker_is_registered_in_lifespan():
+    """FIX 3a — main.py wires up an env-gated adaptive-policy worker
+    (PRISM_ADAPTIVE_POLICY_WORKER) alongside the other lifespan workers."""
+    main_src = (_SERVICE_ROOT / "prism_service" / "main.py").read_text(
+        encoding="utf-8"
+    )
+    assert "PRISM_ADAPTIVE_POLICY_WORKER" in main_src, (
+        "main.py lifespan must register an env-gated adaptive-policy worker"
+    )
+    assert "adaptive_policy" in main_src, (
+        "main.py must import/start the adaptive-policy worker"
+    )
+
+
+def test_adaptive_policy_worker_persists_knob_row(tmp_path, monkeypatch):
+    """FIX 3a — one worker tick nudges + persists at least one
+    policy_knobs row from the recall->outcome signal."""
+    from prism_service.services import adaptive_policy as ap
+
+    scores = _make_scores_db(tmp_path)
+
+    class _Ctx:
+        _data_dir = tmp_path
+        memory_svc = None
+
+    monkeypatch.setattr(
+        "prism_service.project_context.get_project", lambda p: _Ctx()
+    )
+    monkeypatch.setattr(
+        "prism_service.project_context.get_all_projects", lambda: ["p"]
+    )
+
+    assert hasattr(ap, "run_once") or hasattr(ap, "tick"), (
+        "adaptive_policy must expose a worker entrypoint (run_once/tick) "
+        "the lifespan thread can call"
+    )
+    runner = getattr(ap, "run_once", None) or getattr(ap, "tick", None)
+    runner()
+
+    conn = sqlite3.connect(scores)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM policy_knobs").fetchone()[0]
+    finally:
+        conn.close()
+    assert n >= 1, (
+        "an adaptive-policy worker tick must persist >=1 policy_knobs row"
+    )
+
+
+# =====================================================================
+# FIX 3b — the adaptive-policy worker appears in /api/consolidation/workers.
+# =====================================================================
+
+
+def test_adaptive_policy_worker_in_workers_endpoint(monkeypatch):
+    """FIX 3b — /api/consolidation/workers lists the adaptive-policy
+    worker so the /settings/activity + /learning panels can render it."""
+    from prism_service.api.consolidation import workers
+
+    monkeypatch.setenv("PRISM_ADAPTIVE_POLICY_WORKER", "on")
+    payload = workers()
+    ids = {w["id"] for w in payload["workers"]}
+    assert "adaptive_policy_worker" in ids or "adaptive_policy" in ids, (
+        f"adaptive-policy worker must appear in /api/consolidation/workers; "
+        f"got {sorted(ids)}"
+    )
+
+
+# =====================================================================
+# FIX 4a — bounded, idempotent retention sweep prunes only intended rows.
+# =====================================================================
+
+
+def test_retention_sweep_prunes_only_intended_rows(tmp_path):
+    """FIX 4a — a retention sweep prunes completed + old candidates and
+    caps/archives stale session_outcomes, deleting ONLY the intended rows
+    (recent + pending survive) and reporting what it pruned. Idempotent:
+    a second call deletes nothing more."""
+    from prism_service.services import consolidation_data as cd
+
+    scores = _make_scores_db(tmp_path)
+    old = (datetime.now(timezone.utc) - timedelta(days=120)).isoformat()
+    recent = datetime.now(timezone.utc).isoformat()
+    conn = sqlite3.connect(scores)
+    try:
+        # Old completed -> should be pruned.
+        conn.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, status, queued_at, completed_at) "
+            "VALUES ('old-done', 'T', 'completed', ?, ?)", (old, old),
+        )
+        # Recent completed -> must SURVIVE.
+        conn.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, status, queued_at, completed_at) "
+            "VALUES ('new-done', 'T', 'completed', ?, ?)", (recent, recent),
+        )
+        # Pending -> must SURVIVE regardless of age.
+        conn.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, status, queued_at) "
+            "VALUES ('old-pending', 'T', 'pending', ?)", (old,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert hasattr(cd, "retention_sweep"), (
+        "consolidation_data must expose a bounded retention_sweep()"
+    )
+    report = cd.retention_sweep(scores)
+    assert isinstance(report, dict), "retention_sweep must report what it pruned"
+
+    conn = sqlite3.connect(scores)
+    try:
+        survivors = {
+            r[0] for r in conn.execute(
+                "SELECT id FROM consolidation_candidates"
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+    assert "old-done" not in survivors, "old completed candidate must be pruned"
+    assert "new-done" in survivors, "recent completed candidate must survive"
+    assert "old-pending" in survivors, "pending candidate must never be pruned"
+
+    # Idempotent: nothing left to prune on the second pass.
+    report2 = cd.retention_sweep(scores)
+    pruned2 = sum(
+        v for v in report2.values() if isinstance(v, int)
+    )
+    assert pruned2 == 0, (
+        f"retention_sweep must be idempotent; second pass pruned {pruned2}"
+    )

--- a/services/prism-service/tests/unit/test_lifespan_lock_recovery.py
+++ b/services/prism-service/tests/unit/test_lifespan_lock_recovery.py
@@ -43,19 +43,23 @@ def test_lifespan_starts_threads_when_no_lock(isolated_lock):
             patch("prism_service.main._install_stackdump_handler"):
         _run_lifespan()
 
-    # 10 daemon threads as of v6.2.0:
+    # 12 daemon threads as of v6.2.29:
     #   7 explicit in main.py — mcp + governance + drift + quality +
     #     understand_drainer + trash_sweeper + transcript_importer
     #   1 from start_auto_updater() (always starts)
     #   1 from start_memory_summary_worker() (defaults ON, v6.1.1+)
     #   1 from start_graph_enrich_worker() (defaults ON, v6.2.0+)
-    # reflection_worker is OFF by default (PRISM_REFLECTION_WORKER=on
-    # to opt in) so it does NOT add to the count here.
+    #   1 from start_reflection_worker() (defaults ON, v6.2.29 / FIX 1a —
+    #     PRISM_REFLECTION_WORKER=off to opt out)
+    #   1 from start_adaptive_policy_worker() (defaults ON, v6.2.29 / FIX 3a —
+    #     PRISM_ADAPTIVE_POLICY_WORKER=off to opt out)
+    # start_memory_ops_workers() is OFF by default (no PRISM_<OP>_WORKER set)
+    # so it adds 0 here.
     # patch("prism_service.main.threading.Thread") mutates the global
     # threading module, so threads started inside the indirectly-imported
     # services are also intercepted.
     started = [c for c in mock_t.return_value.start.mock_calls]
-    assert len(started) == 10
+    assert len(started) == 12
 
 
 def test_lifespan_reclaims_stale_lock_and_starts_threads(isolated_lock, capsys):
@@ -68,8 +72,8 @@ def test_lifespan_reclaims_stale_lock_and_starts_threads(isolated_lock, capsys):
         _run_lifespan()
 
     started = [c for c in mock_t.return_value.start.mock_calls]
-    # Same 10 threads — see test_lifespan_starts_threads_when_no_lock.
-    assert len(started) == 10  # threads started despite the stale lock
+    # Same 12 threads — see test_lifespan_starts_threads_when_no_lock.
+    assert len(started) == 12  # threads started despite the stale lock
 
     err = capsys.readouterr().err
     assert "stale lock detected" in err

--- a/services/prism-service/tests/unit/test_reflection_worker.py
+++ b/services/prism-service/tests/unit/test_reflection_worker.py
@@ -96,11 +96,14 @@ def test_run_once_dispatches_run_one_for_pending(monkeypatch, tmp_path):
     )
     c = sqlite3.connect(str(scores))
     try:
+        # v6.2.29 — give the candidate a real signal so the drain-time
+        # noise filter (FIX 1c) dispatches it instead of skipping it.
         c.execute(
             "INSERT INTO consolidation_candidates "
-            "(id, task_id, session_id, trigger, status, queued_at) "
-            "VALUES (?, NULL, ?, ?, 'pending', ?)",
+            "(id, task_id, session_id, trigger, scope_json, status, queued_at) "
+            "VALUES (?, NULL, ?, ?, ?, 'pending', ?)",
             ("cand-1", "sess-1", "transcript_imported",
+             '{"signal_counts": {"pushbacks": 1}}',
              "2026-05-25T10:00:00+00:00"),
         )
         c.commit()

--- a/services/prism-service/tests/unit/test_reflection_worker.py
+++ b/services/prism-service/tests/unit/test_reflection_worker.py
@@ -12,11 +12,26 @@ if str(_SERVICE_ROOT) not in sys.path:
     sys.path.insert(0, str(_SERVICE_ROOT))
 
 
-def test_start_reflection_worker_returns_none_when_disabled(monkeypatch):
-    """Off by default — a zero-LLM service shouldn't burn tokens
-    unprompted."""
-    from prism_service.services.reflection_worker import start_reflection_worker
+def test_start_reflection_worker_starts_by_default(monkeypatch):
+    """FIX 1a (task fc2d8aeb) — DEFAULT ON. The self-sustaining loop must
+    drain pending candidates without an explicit PRISM_REFLECTION_WORKER=on,
+    mirroring memory_summary_worker.is_enabled(default=True)."""
+    from prism_service.services import reflection_worker as rw
     monkeypatch.delenv("PRISM_REFLECTION_WORKER", raising=False)
+    # Keep the daemon from looping forever.
+    monkeypatch.setattr(rw, "run_once", lambda: {
+        "projects": [], "ran": 0, "errors": 0, "skipped": 0,
+    })
+    monkeypatch.setattr(rw, "_loop", lambda: rw.run_once())
+    t = rw.start_reflection_worker()
+    assert t is not None, "worker must spawn by default (env unset)"
+    t.join(timeout=2)
+
+
+def test_start_reflection_worker_returns_none_when_off(monkeypatch):
+    """FIX 1b — PRISM_REFLECTION_WORKER=off preserves the opt-out."""
+    from prism_service.services.reflection_worker import start_reflection_worker
+    monkeypatch.setenv("PRISM_REFLECTION_WORKER", "off")
     assert start_reflection_worker() is None
 
 
@@ -126,7 +141,8 @@ def test_run_once_dispatches_run_one_for_pending(monkeypatch, tmp_path):
 
 def test_workers_endpoint_reflects_env_state(monkeypatch):
     """/api/consolidation/workers shows the reflection worker as
-    running/cadence when the env var is on."""
+    running/cadence. FIX 1a — DEFAULT ON: with the env var UNSET the
+    worker reports running=True; only =off flips it to running=False."""
     from prism_service.api.consolidation import workers
 
     monkeypatch.setenv("PRISM_REFLECTION_WORKER", "on")
@@ -136,7 +152,16 @@ def test_workers_endpoint_reflects_env_state(monkeypatch):
     assert rw_entry["running"] is True
     assert rw_entry["cadence_s"] == 300
 
+    # Env UNSET -> still running (default ON).
     monkeypatch.delenv("PRISM_REFLECTION_WORKER")
+    payload = workers()
+    rw_entry = [w for w in payload["workers"] if w["id"] == "reflection_worker"][0]
+    assert rw_entry["running"] is True, (
+        "reflection worker must default ON when the env var is unset"
+    )
+
+    # Explicit off -> not running.
+    monkeypatch.setenv("PRISM_REFLECTION_WORKER", "off")
     payload = workers()
     rw_entry = [w for w in payload["workers"] if w["id"] == "reflection_worker"][0]
     assert rw_entry["running"] is False


### PR DESCRIPTION
Fixes the learning loop discovered to be half-wired (41 candidates piling up, /learning empty). Four fixes:
1. **Reflection worker default-ON** (mirrors memory_summary_worker) so pending real-signal candidates drain automatically; PRISM_REFLECTION_WORKER=off opt-out preserved.
2. **Task-linked consolidation** — `claude_transcripts._enqueue_with_signals` resolves task_id from `task_sessions`, which unblocks the *existing* `janitor` rollup writer so `task_quality_rollup` fills.
3. **Adaptive-policy scheduler** — `AdaptivePolicyService` now runs as an env-gated worker → `policy_knobs` populates; surfaced in the worker list.
4. **Retention/prune** — bounded governance sweep prunes completed/old candidates + caps stale session_outcomes so the queue/log don't grow forever.

Full suite: 663 passed. Verified against the live :8888 daemon (real-verification mandate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)