### PR TITLE
feat(v6.3.0): animate conductor tasks + real-time SDLC phase progress

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.31"
+PRISM_VERSION = "6.3.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.0: Animate conductor tasks + real-time SDLC phase progress. New "
+    "web/src/lib/motion.ts motion vocabulary (EASE_OUT/EASE_IN, DUR enter>exit, "
+    "SPRING_SNAPPY bounce<0.1, capped 0.04s stagger); board AnimatePresence + "
+    "motion.div layout reorder + step/gate chip cross-fade; route transitions "
+    "via AnimatePresence mode=wait; index.css prefers-reduced-motion reset + "
+    "useReducedMotion guards throughout. NEW server seam ConductorService."
+    "phase_progress() -> {pct,basis,in_step_s,typical_s,children_done,"
+    "children_total,tokens_since_step} (time baseline min(0.95,in/typical), "
+    "children-done override, live token effort), on GET /api/conductor/state "
+    "managed_tasks + GET /api/tasks/{id}. New components/conductor/SdlcProgress "
+    "renders a segmented 8-step bar (done solid / current animated fill tweening "
+    "between polls / future muted) on conductor tiles (~2x height) AND the "
+    "TaskDetailPage Conductor card; child tasks render as an animated checkbox "
+    "checklist (spring tick) feeding the sub-step fill; detail page polls 5s for "
+    "live updates. Rolls up the unshipped 6.2.31. "
     "v6.2.30: Render task plans as rich HTML. Task gains plan_doc (markdown "
     "proposed-change) + plan_diagram (Mermaid source) — additive tasks.db "
     "columns (migrate to ''), threaded through TaskService.create/update + row "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.2.30"
+PRISM_VERSION = "6.2.31"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -36,11 +36,21 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
     # `sessions` rides the EXISTING task-detail route (no parallel
     # top-level route) — the linked Claude sessions JOINed with their
     # session_outcomes metrics. Empty list when nothing is linked.
-    return {
+    out = {
         "task": t,
         "history": svc.history(task_id),
         "sessions": svc.sessions_for_task(task_id),
     }
+    # phase_progress (a5e0d9f5): the animated SDLC bar in the detail header
+    # reads the blended current-step fill. Best-effort — never break the
+    # detail route if conductor is unavailable.
+    try:
+        cond = get_project(project).conductor_svc
+        if cond is not None and hasattr(cond, "phase_progress"):
+            out["phase_progress"] = cond.phase_progress(task_id)
+    except Exception:
+        pass
+    return out
 
 
 class TaskUpdate(BaseModel):

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -510,9 +510,16 @@ def start_transcript_importer() -> None:
                 try:
                     ctx = get_project(pid)
                     scores_db = str(ctx._data_dir / "scores.db")
-                    from prism_service.services import claude_memory as cm
+                    # claude_memory is an OPTIONAL add-on (the auto-memory
+                    # bridge). It must never gate session/token import — if it's
+                    # unavailable, guard the import so import_unseen still runs.
+                    # (Bug: an unguarded import here zeroed ALL token import.)
+                    try:
+                        from prism_service.services import claude_memory as cm
+                    except Exception:
+                        cm = None
                     sp = _project_source_path(pid)
-                    cpd = cm.configured_project_dir(pid)
+                    cpd = cm.configured_project_dir(pid) if cm else None
                     if not sp and not cpd:
                         continue
                     n = import_unseen(

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1482,6 +1482,9 @@ class ConductorService:
                 "created_at": getattr(t, "created_at", "") or "",
                 "updated_at": getattr(t, "updated_at", "") or "",
                 "tags": list(getattr(t, "tags", []) or []),
+                # Animated SDLC progress bar (a5e0d9f5): blended current-step
+                # fill so the tile bar tweens between polls.
+                "phase_progress": self.phase_progress(t.id),
             })
         return out
 
@@ -1507,3 +1510,122 @@ class ConductorService:
             if step and status != "done":
                 counter[step] += 1
         return dict(counter)
+
+    # ------------------------------------------------------------------
+    # phase_progress — blended current-step fill for the SDLC bar
+    # ------------------------------------------------------------------
+    #   pct = min(0.95, in_step_s / typical_s)  (time baseline)
+    #   OVERRIDDEN by children_done / children_total when child tasks exist.
+    # Drives the animated current-segment fill on the conductor tiles +
+    # TaskDetailPage header so the bar tweens between 5s polls instead of
+    # snapping at each advance.
+    _TYPICAL_S_FALLBACK = 900.0  # 15 min — positive default when no history
+
+    @staticmethod
+    def _parse_iso(ts: str) -> Optional[float]:
+        """ISO-8601 timestamp -> epoch seconds; None if unparseable."""
+        if not ts:
+            return None
+        try:
+            from datetime import datetime
+            return datetime.fromisoformat(ts).timestamp()
+        except Exception:
+            return None
+
+    def _median_step_s(self) -> float:
+        """Median gap between consecutive advance_task rows across all task
+        history — the empirical 'typical' time a task dwells in one step.
+        Falls back to a positive constant when there is no history yet."""
+        if self._task_svc is None:
+            return self._TYPICAL_S_FALLBACK
+        try:
+            tasks = self._task_svc.list()
+        except Exception:
+            return self._TYPICAL_S_FALLBACK
+        gaps: list[float] = []
+        for t in tasks:
+            try:
+                rows = self._task_svc.history(t.id)
+            except Exception:
+                continue
+            advs = [self._parse_iso(getattr(r, "timestamp", "") or "")
+                    for r in rows
+                    if getattr(r, "action", "") == "advance_task"]
+            advs = [a for a in advs if a is not None]
+            for a, b in zip(advs, advs[1:]):
+                if b > a:
+                    gaps.append(b - a)
+        if not gaps:
+            return self._TYPICAL_S_FALLBACK
+        gaps.sort()
+        n = len(gaps)
+        mid = n // 2
+        med = gaps[mid] if n % 2 else (gaps[mid - 1] + gaps[mid]) / 2.0
+        return med if med > 0 else self._TYPICAL_S_FALLBACK
+
+    def _in_step_s(self, task_id: str) -> float:
+        """Seconds since the most recent advance_task row for this task —
+        how long it has dwelt in the current step. 0.0 when unknown."""
+        if self._task_svc is None:
+            return 0.0
+        try:
+            rows = self._task_svc.history(task_id)
+        except Exception:
+            return 0.0
+        last: Optional[float] = None
+        for r in rows:
+            if getattr(r, "action", "") == "advance_task":
+                ts = self._parse_iso(getattr(r, "timestamp", "") or "")
+                if ts is not None:
+                    last = ts
+        if last is None:
+            return 0.0
+        from datetime import datetime, timezone
+        elapsed = datetime.now(timezone.utc).timestamp() - last
+        return elapsed if elapsed > 0 else 0.0
+
+    def phase_progress(self, task_id: str) -> dict:
+        """Blended estimate of how far through the CURRENT workflow step a
+        task is. Shape:
+          {pct, basis, in_step_s, typical_s,
+           children_done, children_total, tokens_since_step}
+        - baseline (basis='time'): min(0.95, in_step_s / typical_s) from the
+          median step history; the 0.95 ceiling means it never reads 'done'
+          before the actual advance.
+        - override (basis='children'): when child tasks exist (parent_id ==
+          task_id), pct is the exact children_done/children_total ratio.
+        """
+        typical_s = self._median_step_s()
+        in_step_s = self._in_step_s(task_id)
+
+        children_done = 0
+        children_total = 0
+        if self._task_svc is not None:
+            try:
+                for t in self._task_svc.list():
+                    if (getattr(t, "parent_id", "") or "") == task_id:
+                        children_total += 1
+                        if (getattr(t, "status", "") or "") == "done":
+                            children_done += 1
+            except Exception:
+                children_total = 0
+
+        if children_total > 0:
+            pct = children_done / children_total
+            basis = "children"
+        else:
+            ratio = in_step_s / typical_s if typical_s > 0 else 0.0
+            pct = min(0.95, ratio)
+            basis = "time"
+
+        return {
+            "pct": round(max(0.0, min(1.0, pct)), 6),
+            "basis": basis,
+            "in_step_s": round(in_step_s, 3),
+            "typical_s": round(typical_s, 3),
+            "children_done": children_done,
+            "children_total": children_total,
+            # Live token effort is imported on the ~60s session cadence, not
+            # computed here on the 5s poll path. 0 until that pipeline lands.
+            "tokens_since_step": 0,
+        }

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1618,6 +1618,19 @@ class ConductorService:
             pct = min(0.95, ratio)
             basis = "time"
 
+        # Real token effort: sum tokens across the sessions linked to this task
+        # (the importer populates sessions.tokens_used). Per-message timestamps
+        # aren't imported, so this is task-TOTAL spend, not a per-step slice —
+        # but it's a real, growing number the bar surfaces as "N tok".
+        tokens = 0
+        if self._task_svc is not None:
+            try:
+                for s in self._task_svc.sessions_for_task(task_id):
+                    used = s.get("tokens_used") if isinstance(s, dict) else getattr(s, "tokens_used", 0)
+                    tokens += int(used or 0)
+            except Exception:
+                tokens = 0
+
         return {
             "pct": round(max(0.0, min(1.0, pct)), 6),
             "basis": basis,
@@ -1625,7 +1638,6 @@ class ConductorService:
             "typical_s": round(typical_s, 3),
             "children_done": children_done,
             "children_total": children_total,
-            # Live token effort is imported on the ~60s session cadence, not
-            # computed here on the 5s poll path. 0 until that pipeline lands.
-            "tokens_since_step": 0,
+            # Task-total linked-session tokens (see note above).
+            "tokens_since_step": tokens,
         }

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -12,6 +12,7 @@ import MemoryPage from "@/pages/MemoryPage";
 import MemoryDetailPage from "@/pages/MemoryDetailPage";
 import TasksPage from "@/pages/TasksPage";
 import TaskDetailPage from "@/pages/TaskDetailPage";
+import TaskTextPage from "@/pages/TaskTextPage";
 import ConductorPage from "@/pages/ConductorPage";
 import SessionsPage from "@/pages/SessionsPage";
 import RetrievalsPage from "@/pages/RetrievalsPage";
@@ -47,6 +48,7 @@ export default function App() {
             <Route path="/memory/:id" element={<MemoryDetailPage />} />
             <Route path="/tasks" element={<TasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetailPage />} />
+            <Route path="/tasks/:id/:section" element={<TaskTextPage />} />
             <Route path="/conductor" element={<ConductorPage />} />
             <Route path="/sessions" element={<SessionsPage />} />
             <Route path="/retrievals" element={<RetrievalsPage />} />

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -1,4 +1,5 @@
-import { Routes, Route, Navigate } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { AnimatePresence } from "motion/react";
 import Sidebar from "@/components/Sidebar";
 import PageHeader from "@/components/PageHeader";
 import Backdrop from "@/components/Backdrop";
@@ -20,6 +21,12 @@ import UnderstandPage from "@/pages/UnderstandPage";
 import SettingsPage from "@/pages/SettingsPage";
 
 export default function App() {
+  // Route-swap transition: AnimatePresence mode="wait" keyed on the pathname
+  // lets the leaving page finish its exit before the next mounts. We pass an
+  // explicit `location` to <Routes> so AnimatePresence sees a stable tree to
+  // animate out. The single flex-1 overflow-y-auto scroll container is
+  // preserved as the wrapper, and the two <Navigate> redirects are untouched.
+  const location = useLocation();
   return (
     <div className="h-full w-full flex bg-[color:var(--background-base)] text-[color:var(--midground-base)] relative">
       <Backdrop />
@@ -28,7 +35,8 @@ export default function App() {
         <LiveStatusStrip />
         <PageHeader />
         <div className="flex-1 overflow-y-auto">
-          <Routes>
+          <AnimatePresence mode="wait">
+          <Routes location={location} key={location.pathname}>
             <Route path="/" element={<DashboardPage />} />
             {/* Brain = the one place to explore the knowledge. /graph and
                 the old /explore redirect here so nothing breaks. */}
@@ -48,6 +56,7 @@ export default function App() {
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/:section" element={<SettingsPage />} />
           </Routes>
+          </AnimatePresence>
         </div>
       </main>
     </div>

--- a/services/prism-service/prism_service/web/src/components/EvidenceView.tsx
+++ b/services/prism-service/prism_service/web/src/components/EvidenceView.tsx
@@ -1,0 +1,92 @@
+// Readable renderer for receipt-style evidence text (gate validation,
+// completion proof) — these arrive as one long line with `code` spans and
+// "Label: detail" clauses. Splits into rows, renders `code` as teal mono chips,
+// tones the leading Label, and highlights pass/fail/green result tokens. Uses
+// the shared --accent-* / --text-* palette (same as /understand). No <pre>.
+import { type ReactNode } from "react";
+
+// NUL sentinel for masking code spans — cannot appear in real evidence text.
+const SENT = String.fromCharCode(0);
+
+// Highlight verdict/result tokens so the signal pops out of the prose.
+function highlight(s: string): ReactNode[] {
+  const out: ReactNode[] = [];
+  const re = /(\d[\d,.]*\s+(?:passed|failed|warning|tests?)|ok:true|ok:false|GREEN|PASSED|FAIL(?:ED)?)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let k = 0;
+  while ((m = re.exec(s))) {
+    if (m.index > last) out.push(s.slice(last, m.index));
+    const tok = m[0];
+    const tone = /passed|ok:true|GREEN|PASSED/.test(tok)
+      ? "emerald"
+      : /warning/.test(tok)
+        ? "amber"
+        : "rose";
+    out.push(
+      <span key={`h${k++}`} className="font-medium" style={{ color: `var(--accent-${tone}-fg)` }}>
+        {tok}
+      </span>,
+    );
+    last = m.index + tok.length;
+  }
+  if (last < s.length) out.push(s.slice(last));
+  return out;
+}
+
+function renderInline(s: string): ReactNode[] {
+  // odd indices are the contents of `backtick` spans
+  return s.split(/`([^`]+)`/g).map((p, i) =>
+    i % 2 === 1 ? (
+      <code
+        key={`c${i}`}
+        className="font-mono text-[11px] px-1.5 py-0.5 rounded bg-[color:var(--surface-3)] text-[color:var(--accent-teal-fg)] break-all"
+      >
+        {p}
+      </code>
+    ) : (
+      <span key={`t${i}`}>{highlight(p)}</span>
+    ),
+  );
+}
+
+export default function EvidenceView({ text }: { text: string }) {
+  // Mask `code` spans with a NUL-wrapped index so sentence-splitting never
+  // breaks on dots inside code (e.g. `.dict()`, `api/tasks.py:80`).
+  const masked: string[] = [];
+  const safe = text.replace(/`[^`]+`/g, (mm) => {
+    masked.push(mm);
+    return SENT + (masked.length - 1) + SENT;
+  });
+  const restore = (x: string) =>
+    x.replace(new RegExp(SENT + "(\\d+)" + SENT, "g"), (_, i) => masked[Number(i)]);
+  const rows = safe
+    .split(/(?<=[.;])\s+(?=[-A-Z( ])/)
+    .map((x) => x.trim())
+    .filter(Boolean);
+
+  return (
+    <div className="space-y-1.5 max-w-[880px]">
+      {rows.map((raw, i) => {
+        const full = restore(raw.replace(/^[-•]\s*/, ""));
+        const m = full.match(/^([A-Z][\w ./()\-]{2,44}?):\s+([\s\S]*)$/);
+        return (
+          <div key={i} className="flex gap-2.5 text-sm leading-relaxed">
+            <span className="text-[color:var(--accent-violet-fg)] select-none mt-[3px] shrink-0">›</span>
+            <p className="text-[color:var(--text-secondary)] min-w-0">
+              {m ? (
+                <>
+                  <span className="text-[color:var(--text-primary)] font-medium">{m[1]}</span>
+                  {": "}
+                  {renderInline(m[2])}
+                </>
+              ) : (
+                renderInline(full)
+              )}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -2,8 +2,9 @@
 // -frame estimate from the server `phase_progress` field: between the 5s polls
 // the current-step fill is EXTRAPOLATED from wall-clock time so the bar creeps,
 // the % readout ticks in decimals, and a mm:ss in-step timer counts up every
-// second — unmistakably real-time. A sweeping shimmer marks the active step as
-// alive. Completed steps solid (emerald); future muted. GPU-only; tokens only.
+// second. The state pill reflects the REAL task status (in progress / done /
+// blocked) — NOT a guessed activity ping — with a shimmer + pulse while the
+// task is actively in progress. Completed steps solid (emerald); future muted.
 import { useEffect, useRef, useState } from "react";
 import { motion, useMotionValue, useTransform, useAnimationFrame } from "motion/react";
 import { WORKFLOW_STEPS_ORDERED, stepLabel } from "@/lib/workflowChips";
@@ -29,9 +30,14 @@ function fmtClock(s: number): string {
   return `${m}:${String(sec).padStart(2, "0")}`;
 }
 
-// Live current-step fill. Children basis = EXACT done/total (holds steady).
-// Time basis = extrapolated asymptotic creep (1 - e^(-t/typical)) that always
-// inches upward but never claims "done" before the conductor advances.
+// Real task status → label + accent tone (honest; no guessed "idle").
+const STATUS_META: Record<string, { label: string; tone: string }> = {
+  in_progress: { label: "in progress", tone: "teal" },
+  done: { label: "done", tone: "emerald" },
+  blocked: { label: "blocked", tone: "rose" },
+  pending: { label: "pending", tone: "slate" },
+};
+
 function liveFraction(p: PhaseProgress, elapsedS: number): number {
   if ((p.basis ?? "time") === "children" && (p.children_total ?? 0) > 0) {
     return Math.min(1, (p.children_done ?? 0) / (p.children_total ?? 1));
@@ -44,11 +50,13 @@ function liveFraction(p: PhaseProgress, elapsedS: number): number {
 export default function SdlcProgress({
   step,
   phase,
+  status,
   reduced,
   showCaption = true,
 }: {
   step?: string;
   phase?: PhaseProgress | null;
+  status?: string;
   reduced?: boolean | null;
   showCaption?: boolean;
 }) {
@@ -59,49 +67,38 @@ export default function SdlcProgress({
   const tokFrac = Math.max(0, Math.min(1, tokens / 500_000));
   const seed = Math.max(0, Math.min(1, phase?.pct ?? 0));
 
-  // Overall task progress toward DONE: completed steps + the current phase's
-  // fraction, over all 8 steps. Only nears 100% as the whole task completes —
-  // never because one step ran long.
+  const meta = STATUS_META[(status ?? "").toLowerCase()] ?? { label: status || "", tone: "slate" };
+  // "live" = the task is genuinely being worked (status in_progress) — the
+  // honest basis for the shimmer + pulse, instead of a laggy token delta.
+  const live = (status ?? "").toLowerCase() === "in_progress";
+
+  // Overall task progress toward DONE: completed steps + current phase fraction.
   const overallSeed = curIdx >= 0 ? (curIdx + seed) / steps.length : seed;
-  const fill = useMotionValue(seed);
-  const widthPct = useTransform(fill, (v) => `${(v * 100).toFixed(3)}%`);
   const [liveLabel, setLiveLabel] = useState(overallSeed * 100);
   const [liveInStep, setLiveInStep] = useState(phase?.in_step_s ?? 0);
-  // "active" = token spend on this step rose recently (the real work signal).
-  // Flat tokens + a ticking clock = idle/stuck; rising tokens = progressing.
-  const [active, setActive] = useState(false);
-  const prevTokens = useRef(tokens);
-  const lastGrowAt = useRef(-1e9);
+  // current-SEGMENT fill (within the active step) drives just that segment.
+  const segFill = useMotionValue(seed);
+  const segWidth = useTransform(segFill, (v) => `${(v * 100).toFixed(3)}%`);
 
-  // Re-anchor the extrapolation clock on each fresh server value, and note
-  // when the token count grew (so we can show active vs idle honestly).
   const anchor = useRef({ t0: 0 });
   useEffect(() => {
     anchor.current.t0 = performance.now();
-    if (tokens > prevTokens.current) lastGrowAt.current = performance.now();
-    prevTokens.current = tokens;
-  }, [phase, tokens]);
+  }, [phase]);
 
   const lastPctAt = useRef(0);
   const lastClockAt = useRef(0);
-  // The frame loop ALWAYS runs (it carries information — the live % + timer —
-  // not just decoration); only the shimmer/easing below are gated on reduced.
   useAnimationFrame((t) => {
     if (!phase || curIdx < 0) return;
     const elapsedS = (performance.now() - anchor.current.t0) / 1000;
-    const wf = liveFraction(phase, elapsedS); // within the current phase (0..0.97)
-    fill.set(wf); // the current SEGMENT fills by its own phase fraction
+    const wf = liveFraction(phase, elapsedS);
+    segFill.set(wf);
     if (t - lastPctAt.current > 120) {
       lastPctAt.current = t;
-      // headline = OVERALL task progress, so it only nears 100% as the whole
-      // task completes — not because the current step ran long.
       setLiveLabel(((curIdx + wf) / steps.length) * 100);
     }
     if (t - lastClockAt.current > 500) {
       lastClockAt.current = t;
       setLiveInStep((phase.in_step_s ?? 0) + elapsedS);
-      // active if tokens grew within the importer's cadence window (~90s).
-      setActive(tokens > 0 && performance.now() - lastGrowAt.current < 90_000);
     }
   });
 
@@ -128,9 +125,9 @@ export default function SdlcProgress({
               <div key={s.id} className={base} title={stepLabel(s.id)} style={{ background: "var(--surface-3)" }}>
                 <motion.div
                   className="absolute inset-y-0 left-0 rounded-full"
-                  style={{ width: widthPct, background: "var(--accent-teal-bg)", boxShadow: "inset 0 0 0 1px var(--accent-teal-ring)" }}
+                  style={{ width: segWidth, background: "var(--accent-teal-bg)", boxShadow: "inset 0 0 0 1px var(--accent-teal-ring)" }}
                 />
-                {!reduced && active && (
+                {!reduced && live && (
                   <motion.div
                     className="absolute inset-y-0 left-0 w-1/2 pointer-events-none"
                     style={{ background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)" }}
@@ -163,13 +160,13 @@ export default function SdlcProgress({
             <span className="flex items-center gap-1.5 shrink-0 tabular-nums">
               <motion.span
                 className="inline-block h-1.5 w-1.5 rounded-full"
-                style={{ background: active ? "var(--accent-emerald-fg)" : "var(--text-muted)" }}
-                animate={!reduced && active ? { opacity: [1, 0.25, 1] } : { opacity: active ? 1 : 0.4 }}
-                transition={!reduced && active ? { duration: 1.2, repeat: Infinity, ease: "easeInOut" } : { duration: 0.2 }}
+                style={{ background: `var(--accent-${meta.tone}-fg)` }}
+                animate={!reduced && live ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
+                transition={!reduced && live ? { duration: 1.2, repeat: Infinity, ease: "easeInOut" } : { duration: 0.2 }}
               />
               <span>{fmtClock(liveInStep)}</span>
               <span className="opacity-70">· {fmtTokens(tokens)} tok</span>
-              <span className={active ? "" : "opacity-60"}>· {active ? "active" : "idle"}</span>
+              {meta.label && <span style={{ color: `var(--accent-${meta.tone}-fg)` }}>· {meta.label}</span>}
             </span>
           </div>
           {tokens > 0 && (

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -1,0 +1,190 @@
+// Segmented 8-step SDLC progress bar (task a5e0d9f5). Renders a LIVE, frame-by
+// -frame estimate from the server `phase_progress` field: between the 5s polls
+// the current-step fill is EXTRAPOLATED from wall-clock time so the bar creeps,
+// the % readout ticks in decimals, and a mm:ss in-step timer counts up every
+// second — unmistakably real-time. A sweeping shimmer marks the active step as
+// alive. Completed steps solid (emerald); future muted. GPU-only; tokens only.
+import { useEffect, useRef, useState } from "react";
+import { motion, useMotionValue, useTransform, useAnimationFrame } from "motion/react";
+import { WORKFLOW_STEPS_ORDERED, stepLabel } from "@/lib/workflowChips";
+
+export type PhaseProgress = {
+  pct?: number;
+  basis?: string;
+  in_step_s?: number;
+  typical_s?: number;
+  children_done?: number;
+  children_total?: number;
+  tokens_since_step?: number;
+};
+
+function fmtTokens(t: number): string {
+  if (t >= 1000) return `${(t / 1000).toFixed(t >= 10000 ? 0 : 1)}k`;
+  return `${t}`;
+}
+
+function fmtClock(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = Math.floor(s % 60);
+  return `${m}:${String(sec).padStart(2, "0")}`;
+}
+
+// Live current-step fill. Children basis = EXACT done/total (holds steady).
+// Time basis = extrapolated asymptotic creep (1 - e^(-t/typical)) that always
+// inches upward but never claims "done" before the conductor advances.
+function liveFraction(p: PhaseProgress, elapsedS: number): number {
+  if ((p.basis ?? "time") === "children" && (p.children_total ?? 0) > 0) {
+    return Math.min(1, (p.children_done ?? 0) / (p.children_total ?? 1));
+  }
+  const typical = Math.max(1, p.typical_s ?? 30);
+  const liveSeconds = (p.in_step_s ?? 0) + Math.max(0, elapsedS);
+  return Math.min(0.97, 1 - Math.exp(-liveSeconds / typical));
+}
+
+export default function SdlcProgress({
+  step,
+  phase,
+  reduced,
+  showCaption = true,
+}: {
+  step?: string;
+  phase?: PhaseProgress | null;
+  reduced?: boolean | null;
+  showCaption?: boolean;
+}) {
+  const steps = WORKFLOW_STEPS_ORDERED;
+  const curIdx = steps.findIndex((s) => s.id === step);
+  const tokens = phase?.tokens_since_step ?? 0;
+  const basis = phase?.basis ?? "time";
+  const tokFrac = Math.max(0, Math.min(1, tokens / 500_000));
+  const seed = Math.max(0, Math.min(1, phase?.pct ?? 0));
+
+  // Overall task progress toward DONE: completed steps + the current phase's
+  // fraction, over all 8 steps. Only nears 100% as the whole task completes —
+  // never because one step ran long.
+  const overallSeed = curIdx >= 0 ? (curIdx + seed) / steps.length : seed;
+  const fill = useMotionValue(seed);
+  const widthPct = useTransform(fill, (v) => `${(v * 100).toFixed(3)}%`);
+  const [liveLabel, setLiveLabel] = useState(overallSeed * 100);
+  const [liveInStep, setLiveInStep] = useState(phase?.in_step_s ?? 0);
+  // "active" = token spend on this step rose recently (the real work signal).
+  // Flat tokens + a ticking clock = idle/stuck; rising tokens = progressing.
+  const [active, setActive] = useState(false);
+  const prevTokens = useRef(tokens);
+  const lastGrowAt = useRef(-1e9);
+
+  // Re-anchor the extrapolation clock on each fresh server value, and note
+  // when the token count grew (so we can show active vs idle honestly).
+  const anchor = useRef({ t0: 0 });
+  useEffect(() => {
+    anchor.current.t0 = performance.now();
+    if (tokens > prevTokens.current) lastGrowAt.current = performance.now();
+    prevTokens.current = tokens;
+  }, [phase, tokens]);
+
+  const lastPctAt = useRef(0);
+  const lastClockAt = useRef(0);
+  // The frame loop ALWAYS runs (it carries information — the live % + timer —
+  // not just decoration); only the shimmer/easing below are gated on reduced.
+  useAnimationFrame((t) => {
+    if (!phase || curIdx < 0) return;
+    const elapsedS = (performance.now() - anchor.current.t0) / 1000;
+    const wf = liveFraction(phase, elapsedS); // within the current phase (0..0.97)
+    fill.set(wf); // the current SEGMENT fills by its own phase fraction
+    if (t - lastPctAt.current > 120) {
+      lastPctAt.current = t;
+      // headline = OVERALL task progress, so it only nears 100% as the whole
+      // task completes — not because the current step ran long.
+      setLiveLabel(((curIdx + wf) / steps.length) * 100);
+    }
+    if (t - lastClockAt.current > 500) {
+      lastClockAt.current = t;
+      setLiveInStep((phase.in_step_s ?? 0) + elapsedS);
+      // active if tokens grew within the importer's cadence window (~90s).
+      setActive(tokens > 0 && performance.now() - lastGrowAt.current < 90_000);
+    }
+  });
+
+  return (
+    <div className="w-full">
+      <div className="flex items-stretch gap-[3px] h-2.5">
+        {steps.map((s, i) => {
+          const isGate = s.type === "gate";
+          const done = curIdx >= 0 && i < curIdx;
+          const current = i === curIdx;
+          const base = "relative flex-1 rounded-full overflow-hidden";
+          if (done) {
+            return (
+              <div
+                key={s.id}
+                className={base}
+                title={stepLabel(s.id)}
+                style={{ background: "var(--accent-emerald-bg)", boxShadow: "inset 0 0 0 1px var(--accent-emerald-ring)" }}
+              />
+            );
+          }
+          if (current) {
+            return (
+              <div key={s.id} className={base} title={stepLabel(s.id)} style={{ background: "var(--surface-3)" }}>
+                <motion.div
+                  className="absolute inset-y-0 left-0 rounded-full"
+                  style={{ width: widthPct, background: "var(--accent-teal-bg)", boxShadow: "inset 0 0 0 1px var(--accent-teal-ring)" }}
+                />
+                {!reduced && active && (
+                  <motion.div
+                    className="absolute inset-y-0 left-0 w-1/2 pointer-events-none"
+                    style={{ background: "linear-gradient(90deg, transparent, rgba(255,255,255,0.35), transparent)" }}
+                    initial={{ x: "-100%" }}
+                    animate={{ x: "260%" }}
+                    transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+                  />
+                )}
+              </div>
+            );
+          }
+          return (
+            <div
+              key={s.id}
+              className={base}
+              title={stepLabel(s.id)}
+              style={{ background: "var(--surface-2)", opacity: isGate ? 0.45 : 0.7 }}
+            />
+          );
+        })}
+      </div>
+
+      {showCaption && curIdx >= 0 && (
+        <>
+          <div className="mt-1 flex items-center justify-between text-[10px] font-mono text-[color:var(--text-muted)]">
+            <span className="uppercase tracking-wider truncate">
+              {stepLabel(steps[curIdx].id)} · {liveLabel.toFixed(2)}%
+              {basis === "children" && phase?.children_total ? ` · ${phase.children_done}/${phase.children_total}` : ""}
+            </span>
+            <span className="flex items-center gap-1.5 shrink-0 tabular-nums">
+              <motion.span
+                className="inline-block h-1.5 w-1.5 rounded-full"
+                style={{ background: active ? "var(--accent-emerald-fg)" : "var(--text-muted)" }}
+                animate={!reduced && active ? { opacity: [1, 0.25, 1] } : { opacity: active ? 1 : 0.4 }}
+                transition={!reduced && active ? { duration: 1.2, repeat: Infinity, ease: "easeInOut" } : { duration: 0.2 }}
+              />
+              <span>{fmtClock(liveInStep)}</span>
+              <span className="opacity-70">· {fmtTokens(tokens)} tok</span>
+              <span className={active ? "" : "opacity-60"}>· {active ? "active" : "idle"}</span>
+            </span>
+          </div>
+          {tokens > 0 && (
+            <div className="mt-0.5 h-[2px] w-full rounded-full overflow-hidden" style={{ background: "var(--surface-2)" }}>
+              <motion.div
+                className="h-full rounded-full"
+                style={{ background: "var(--accent-amber-bg)", opacity: 0.7 }}
+                initial={false}
+                animate={{ width: `${tokFrac * 100}%` }}
+                transition={{ duration: reduced ? 0 : 0.24 }}
+              />
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/index.css
+++ b/services/prism-service/prism_service/web/src/index.css
@@ -108,3 +108,19 @@ body {
 }
 
 @theme inline { --spacing: calc(0.25rem * var(--theme-spacing-mul, 1)); }
+
+/* Reduced-motion reset (task a5e0d9f5). Belt-and-braces alongside the
+   per-component useReducedMotion() guards: when the OS asks for reduced
+   motion, collapse all animation/transition/scroll-smoothing globally so
+   nothing travels or wobbles regardless of which surface authored it.
+   GPU props (transform/opacity) still apply their END state instantly. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/services/prism-service/prism_service/web/src/lib/motion.ts
+++ b/services/prism-service/prism_service/web/src/lib/motion.ts
@@ -1,0 +1,53 @@
+// Shared motion vocabulary for the PRISM SPA (task a5e0d9f5).
+//
+// Motion as STRUCTURE, not decoration: calm, purposeful, GPU-only
+// (transform/opacity), color exclusively via --accent-*/--surface-*/--text-*
+// tokens. One vocabulary so every surface tweens with the same feel.
+//
+// Zero new dependencies — these are plain objects consumed by motion@12
+// (imported from "motion/react" at the call sites).
+
+import type { Transition, Variants } from "motion/react";
+
+// Cubic-bezier easings. EASE_OUT (expo-out) decelerates INTO place — the
+// default for anything entering. EASE_IN accelerates OUT — for exits.
+export const EASE_OUT = [0.16, 1, 0.3, 1] as const;
+export const EASE_IN = [0.4, 0, 1, 1] as const;
+
+// Durations (seconds). Exits are FASTER than entrances so leaving feels
+// crisp and arriving feels settled.
+export const DUR = { enter: 0.24, exit: 0.16, chip: 0.2 } as const;
+
+// Critically-damped spring (bounce < 0.1) for layout / reorder FLIP — no
+// wobble, which would read as "toy". Used for board card reorder + the
+// child-task checkbox tick.
+export const SPRING_SNAPPY: Transition = {
+  type: "spring",
+  stiffness: 460,
+  damping: 38,
+  mass: 1,
+};
+
+// Stagger cap: 0.04s per item, capped at 12 so a long column never exceeds
+// ~0.5s of cascade.
+export function staggerDelay(i: number): number {
+  return Math.min(i, 12) * 0.04;
+}
+
+// Card-enter variants for stacked Card stagger on a page mount. The reduced
+// variant collapses to opacity-only (no translate) so reduced-motion users
+// still get a gentle fade without travel.
+export function cardEnter(i: number, reduced: boolean): Variants {
+  return {
+    initial: reduced ? { opacity: 0 } : { opacity: 0, y: 8 },
+    animate: {
+      opacity: 1,
+      y: 0,
+      transition: {
+        duration: reduced ? 0 : DUR.enter,
+        ease: EASE_OUT,
+        delay: reduced ? 0 : staggerDelay(i),
+      },
+    },
+  };
+}

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -218,7 +218,7 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
       {/* Real-time SDLC phase progress — bar fills the current step from the
           server phase_progress estimate (time / children / token effort). */}
       <div className="mt-2 pt-2.5 border-t border-[color:var(--border-default)]/60">
-        <SdlcProgress step={task.workflow_step} phase={task.phase_progress} reduced={reduced} />
+        <SdlcProgress step={task.workflow_step} phase={task.phase_progress} status={task.status} reduced={reduced} />
       </div>
     </button>
   );

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -7,6 +7,8 @@ import {
   stepLabel, gateLabel, WORKFLOW_STEPS_ORDERED,
 } from "@/lib/workflowChips";
 import { relativeTime } from "@/lib/relativeTime";
+import { useReducedMotion } from "motion/react";
+import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
 
 type ManagedTask = {
   id: string;
@@ -21,6 +23,7 @@ type ManagedTask = {
   created_at?: string;
   updated_at?: string;
   tags?: string[];
+  phase_progress?: PhaseProgress | null;
 };
 
 type State = {
@@ -52,6 +55,7 @@ const STATUS_TONE: Record<string, PillTone> = {
 export default function ConductorPage() {
   const [project] = useProject();
   const navigate = useNavigate();
+  const reduced = useReducedMotion();
   const [data, setData] = useState<State | null>(null);
 
   const load = useCallback(() => {
@@ -133,7 +137,7 @@ export default function ConductorPage() {
                   ) : (
                     <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">
                       {tasksHere.map((t) => (
-                        <TaskTile key={t.id} task={t} onClick={() =>
+                        <TaskTile key={t.id} task={t} reduced={reduced} onClick={() =>
                           navigate(`/tasks/${t.id}`, { state: { from: "/conductor" } })
                         } />
                       ))}
@@ -165,7 +169,7 @@ export default function ConductorPage() {
 //   - owner: {assigned_agent or 'unassigned'}
 //   - up to 3 tag chips
 // ---------------------------------------------------------------------------
-function TaskTile({ task, onClick }: { task: ManagedTask; onClick: () => void }) {
+function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: boolean | null; onClick: () => void }) {
   const status = (task.status ?? "").toLowerCase();
   const statusTone: PillTone = STATUS_TONE[status] ?? "slate";
   const gate = task.gate_state ?? "none";
@@ -211,6 +215,11 @@ function TaskTile({ task, onClick }: { task: ManagedTask; onClick: () => void })
           ))}
         </div>
       )}
+      {/* Real-time SDLC phase progress — bar fills the current step from the
+          server phase_progress estimate (time / children / token effort). */}
+      <div className="mt-2 pt-2.5 border-t border-[color:var(--border-default)]/60">
+        <SdlcProgress step={task.workflow_step} phase={task.phase_progress} reduced={reduced} />
+      </div>
     </button>
   );
 }

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -8,7 +8,8 @@ import {
   stepChipClass, gateChipClass, gateLabel, stepLabel,
 } from "@/lib/workflowChips";
 import PlanView from "@/components/plan/PlanView";
-import { EASE_OUT, DUR, staggerDelay } from "@/lib/motion";
+import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import { EASE_OUT, DUR, SPRING_SNAPPY, staggerDelay } from "@/lib/motion";
 
 // Same status → tone map as TasksPage so the detail-page status chip
 // matches the kanban column header it came from.
@@ -56,6 +57,7 @@ type Task = {
   stop_if?: string[];
   plan_doc?: string;
   plan_diagram?: string;
+  phase_progress?: PhaseProgress | null;
 };
 
 // Slim shape for the child-task list — only what the row renders.
@@ -99,6 +101,44 @@ function Stagger({ i, reduced, children }: { i: number; reduced: boolean | null;
     >
       {children}
     </motion.div>
+  );
+}
+
+// Animated checkbox for the child-task checklist — empty square when pending,
+// emerald fill + spring-tick check when the child is done (feeds the
+// current-segment sub-step fill server-side via children_done/total).
+function Checkbox({ done, reduced }: { done: boolean; reduced: boolean | null }) {
+  return (
+    <span
+      className="inline-flex items-center justify-center h-4 w-4 rounded shrink-0"
+      style={{
+        background: done ? "var(--accent-emerald-bg)" : "var(--surface-3)",
+        boxShadow: `inset 0 0 0 1px var(--accent-${done ? "emerald" : "slate"}-ring)`,
+      }}
+    >
+      <AnimatePresence>
+        {done && (
+          <motion.svg
+            key="tick"
+            viewBox="0 0 16 16"
+            className="h-3 w-3"
+            initial={reduced ? { opacity: 0 } : { scale: 0, opacity: 0 }}
+            animate={reduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={reduced ? { duration: 0 } : SPRING_SNAPPY}
+          >
+            <path
+              d="M3.5 8.5l3 3 6-6.5"
+              fill="none"
+              stroke="var(--accent-emerald-fg)"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </motion.svg>
+        )}
+      </AnimatePresence>
+    </span>
   );
 }
 
@@ -151,10 +191,12 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[] }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null }>(
         `/api/tasks/${id}?project=${project}`,
       );
-      setTask(d.task);
+      // phase_progress rides at the TOP LEVEL of the response (not nested in
+      // task) — merge it onto the task so the SDLC bar reads task.phase_progress.
+      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
       setError(null);
@@ -171,7 +213,9 @@ export default function TaskDetailPage() {
     }
   }, [id, project]);
 
-  useEffect(() => { load(); }, [load]);
+  // Poll every 5s so the SDLC progress bar, child checklist, and token-effort
+  // label update in real-time as the conductor advances the task.
+  useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
   useEffect(() => {
     if (!notice) return;
@@ -335,6 +379,9 @@ export default function TaskDetailPage() {
         <Stagger i={0} reduced={reduced}>
         <Card>
           <SectionLabel>Conductor</SectionLabel>
+          <div className="mt-3 mb-1">
+            <SdlcProgress step={task.workflow_step} phase={task.phase_progress} reduced={reduced} />
+          </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-3 text-[12px] mt-2 items-start">
             <div>
               <div className="opacity-50 mb-1">step</div>
@@ -470,7 +517,10 @@ export default function TaskDetailPage() {
                   onClick={() => c.id && navigate(`/tasks/${c.id}`, { state: { from: `/tasks/${id}` } })}
                   className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors flex items-center justify-between gap-3"
                 >
-                  <span className="text-sm font-medium">{c.title ?? c.id}</span>
+                  <span className="flex items-center gap-3 min-w-0">
+                    <Checkbox done={(c.status ?? "") === "done"} reduced={reduced} />
+                    <span className="text-sm font-medium truncate">{c.title ?? c.id}</span>
+                  </span>
                   <span className="flex items-center gap-2 shrink-0">
                     {typeof c.priority !== "undefined" && (
                       <span className="text-[10px] opacity-50 font-mono">p{c.priority}</span>

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -142,6 +142,52 @@ function Checkbox({ done, reduced }: { done: boolean; reduced: boolean | null })
   );
 }
 
+// Progressive disclosure for long, receipt-style text (gate validation,
+// completion proof): a one-line summary by default; click ▸ to expand the full
+// text into a bordered, scrollable panel. No walls of raw text inline.
+function oneLine(s: string, n = 96): string {
+  const f = s.replace(/\s+/g, " ").trim();
+  return f.length > n ? f.slice(0, n) + "…" : f;
+}
+
+function Disclosure({ summary, children, reduced }: { summary: string; children: React.ReactNode; reduced: boolean | null }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 text-left w-full group"
+        title={open ? "collapse" : "expand"}
+      >
+        <span
+          className="text-[color:var(--text-muted)] shrink-0 transition-transform duration-150"
+          style={{ transform: open ? "rotate(90deg)" : "none" }}
+        >
+          ▸
+        </span>
+        <span className="text-[12px] leading-snug opacity-80 group-hover:opacity-100 truncate">
+          {open ? "Hide details" : summary}
+        </span>
+      </button>
+      <AnimatePresence initial={false}>
+        {open && (
+          <motion.div
+            initial={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+            animate={reduced ? { opacity: 1 } : { opacity: 1, height: "auto" }}
+            exit={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+            transition={{ duration: reduced ? 0 : DUR.enter, ease: EASE_OUT }}
+            className="overflow-hidden"
+          >
+            <div className="mt-2 text-[12px] leading-relaxed opacity-90 whitespace-pre-wrap rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] p-3 max-h-[340px] overflow-y-auto">
+              {children}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
 const STATUS_CYCLE: Record<string, string[]> = {
   pending: ["in_progress", "blocked", "done"],
   in_progress: ["done", "blocked", "pending"],
@@ -402,7 +448,7 @@ export default function TaskDetailPage() {
                   : "reason"}
               </div>
               {task.gate_reason
-                ? <div className="text-[12px] leading-snug opacity-90">{task.gate_reason}</div>
+                ? <Disclosure summary={oneLine(task.gate_reason)} reduced={reduced}>{task.gate_reason}</Disclosure>
                 : <span className="opacity-50">-</span>}
             </div>
           </div>
@@ -457,7 +503,7 @@ export default function TaskDetailPage() {
             <div>
               <div className="opacity-50 mb-1 text-[11px] uppercase tracking-wider">completion proof</div>
               {task.completion_proof
-                ? <div className="leading-relaxed opacity-90">{task.completion_proof}</div>
+                ? <Disclosure summary={oneLine(task.completion_proof)} reduced={reduced}>{task.completion_proof}</Disclosure>
                 : <div className="text-amber-300/90 text-[12px]">⚠ not yet recorded — green_gate will flag this</div>}
             </div>
           </div>

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, SectionLabel, Empty, toneFromLabel, type PillTone } from "@/components/ui";
@@ -7,6 +8,7 @@ import {
   stepChipClass, gateChipClass, gateLabel, stepLabel,
 } from "@/lib/workflowChips";
 import PlanView from "@/components/plan/PlanView";
+import { EASE_OUT, DUR, staggerDelay } from "@/lib/motion";
 
 // Same status → tone map as TasksPage so the detail-page status chip
 // matches the kanban column header it came from.
@@ -85,6 +87,21 @@ type SessionRow = {
   skills_invoked?: number;
 };
 
+// Staggered Card-stack wrapper: each card fades + rises into place with a
+// capped per-index delay, so the detail page assembles top-to-bottom on mount
+// instead of snapping in all at once. Collapses to opacity-only when reduced.
+function Stagger({ i, reduced, children }: { i: number; reduced: boolean | null; children: React.ReactNode }) {
+  return (
+    <motion.div
+      initial={reduced ? { opacity: 0 } : { opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: reduced ? 0 : DUR.enter, ease: EASE_OUT, delay: reduced ? 0 : staggerDelay(i) }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
 const STATUS_CYCLE: Record<string, string[]> = {
   pending: ["in_progress", "blocked", "done"],
   in_progress: ["done", "blocked", "pending"],
@@ -114,6 +131,22 @@ export default function TaskDetailPage() {
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Reduced-motion guard for the staggered Card stack, toast, and status flash.
+  const reduced = useReducedMotion();
+  // Status-chip flash: keyed on the task.status VALUE change (NOT the click).
+  // The setStatus handler does a PATCH + reload round-trip, so the value only
+  // changes after the server confirms — this effect fires off that confirmed
+  // change, decoupled from the optimistic click.
+  const prevStatus = useRef<string | undefined>(undefined);
+  const [statusFlash, setStatusFlash] = useState(0);
+  const taskStatusValue = task?.status;
+  useEffect(() => {
+    if (taskStatusValue === undefined) return;
+    if (prevStatus.current !== undefined && prevStatus.current !== taskStatusValue) {
+      setStatusFlash((n) => n + 1);
+    }
+    prevStatus.current = taskStatusValue;
+  }, [taskStatusValue]);
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -202,18 +235,33 @@ export default function TaskDetailPage() {
         ← {backLabel}
       </button>
 
-      {notice && (
-        <div className="fixed bottom-6 right-6 z-40 max-w-[420px] rounded-md border border-[color:var(--midground-base)]/20 bg-[color:var(--background-base)]/95 backdrop-blur-sm shadow-lg px-4 py-3 text-[12px]">
-          {notice}
-        </div>
-      )}
+      <AnimatePresence>
+        {notice && (
+          <motion.div
+            key="notice"
+            initial={reduced ? { opacity: 0 } : { opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={reduced ? { opacity: 0 } : { opacity: 0, y: 12 }}
+            transition={{ duration: reduced ? 0 : DUR.enter, ease: EASE_OUT }}
+            className="fixed bottom-6 right-6 z-40 max-w-[420px] rounded-md border border-[color:var(--midground-base)]/20 bg-[color:var(--background-base)]/95 backdrop-blur-sm shadow-lg px-4 py-3 text-[12px]"
+          >
+            {notice}
+          </motion.div>
+        )}
+      </AnimatePresence>
 
       <div className="flex items-baseline justify-between gap-4">
         <div>
           <h1 className="font-serif text-3xl tracking-tight">{task.title ?? "Untitled task"}</h1>
           <div className="flex items-center gap-2 mt-2 flex-wrap">
-            <span
-              className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded"
+            <motion.span
+              // Flash on the confirmed task.status value change (statusFlash
+              // bumps off the load() round-trip, not the optimistic click).
+              key={`status-${statusFlash}`}
+              initial={reduced ? false : { scale: 1 }}
+              animate={reduced ? {} : { scale: [1, 1.12, 1] }}
+              transition={{ duration: reduced ? 0 : DUR.chip, ease: EASE_OUT }}
+              className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded inline-block"
               style={{
                 background: `var(--accent-${statusTone}-bg)`,
                 color: `var(--accent-${statusTone}-fg)`,
@@ -221,7 +269,7 @@ export default function TaskDetailPage() {
               }}
             >
               {taskStatus}
-            </span>
+            </motion.span>
             {typeof task.priority !== "undefined" && (
               <span
                 className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded"
@@ -284,6 +332,7 @@ export default function TaskDetailPage() {
       )}
 
       {conductorOn && (
+        <Stagger i={0} reduced={reduced}>
         <Card>
           <SectionLabel>Conductor</SectionLabel>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-3 text-[12px] mt-2 items-start">
@@ -311,16 +360,20 @@ export default function TaskDetailPage() {
             </div>
           </div>
         </Card>
+        </Stagger>
       )}
 
       {(task.plan_doc || task.plan_diagram) ? (
+        <Stagger i={1} reduced={reduced}>
         <Card>
           <SectionLabel>Plan</SectionLabel>
           <div className="mt-2">
             <PlanView diagram={task.plan_diagram} doc={task.plan_doc} />
           </div>
         </Card>
+        </Stagger>
       ) : (
+        <Stagger i={1} reduced={reduced}>
         <Card>
           <SectionLabel>Description</SectionLabel>
           {task.description ? (
@@ -331,6 +384,7 @@ export default function TaskDetailPage() {
             <Empty>No description.</Empty>
           )}
         </Card>
+        </Stagger>
       )}
 
       {(task.oracle || task.proof_type || task.completion_proof) && (

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -142,50 +142,12 @@ function Checkbox({ done, reduced }: { done: boolean; reduced: boolean | null })
   );
 }
 
-// Progressive disclosure for long, receipt-style text (gate validation,
-// completion proof): a one-line summary by default; click ▸ to expand the full
-// text into a bordered, scrollable panel. No walls of raw text inline.
+// Long receipt-style text (gate validation, completion proof) is NOT shown
+// inline or in a collapse — clicking the summary row navigates to a DEDICATED
+// screen (TaskTextPage at /tasks/:id/:section). oneLine builds that summary.
 function oneLine(s: string, n = 96): string {
   const f = s.replace(/\s+/g, " ").trim();
   return f.length > n ? f.slice(0, n) + "…" : f;
-}
-
-function Disclosure({ summary, children, reduced }: { summary: string; children: React.ReactNode; reduced: boolean | null }) {
-  const [open, setOpen] = useState(false);
-  return (
-    <div>
-      <button
-        onClick={() => setOpen((o) => !o)}
-        className="flex items-center gap-1.5 text-left w-full group"
-        title={open ? "collapse" : "expand"}
-      >
-        <span
-          className="text-[color:var(--text-muted)] shrink-0 transition-transform duration-150"
-          style={{ transform: open ? "rotate(90deg)" : "none" }}
-        >
-          ▸
-        </span>
-        <span className="text-[12px] leading-snug opacity-80 group-hover:opacity-100 truncate">
-          {open ? "Hide details" : summary}
-        </span>
-      </button>
-      <AnimatePresence initial={false}>
-        {open && (
-          <motion.div
-            initial={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
-            animate={reduced ? { opacity: 1 } : { opacity: 1, height: "auto" }}
-            exit={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
-            transition={{ duration: reduced ? 0 : DUR.enter, ease: EASE_OUT }}
-            className="overflow-hidden"
-          >
-            <div className="mt-2 text-[12px] leading-relaxed opacity-90 whitespace-pre-wrap rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] p-3 max-h-[340px] overflow-y-auto">
-              {children}
-            </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  );
 }
 
 const STATUS_CYCLE: Record<string, string[]> = {
@@ -448,7 +410,13 @@ export default function TaskDetailPage() {
                   : "reason"}
               </div>
               {task.gate_reason
-                ? <Disclosure summary={oneLine(task.gate_reason)} reduced={reduced}>{task.gate_reason}</Disclosure>
+                ? <button
+                    onClick={() => navigate(`/tasks/${id}/validation`, { state: { from: `/tasks/${id}` } })}
+                    className="flex items-center gap-1.5 text-left w-full group"
+                  >
+                    <span className="text-[12px] leading-snug opacity-80 group-hover:opacity-100 truncate">{oneLine(task.gate_reason)}</span>
+                    <span className="opacity-50 group-hover:opacity-100 shrink-0">→</span>
+                  </button>
                 : <span className="opacity-50">-</span>}
             </div>
           </div>
@@ -503,7 +471,13 @@ export default function TaskDetailPage() {
             <div>
               <div className="opacity-50 mb-1 text-[11px] uppercase tracking-wider">completion proof</div>
               {task.completion_proof
-                ? <Disclosure summary={oneLine(task.completion_proof)} reduced={reduced}>{task.completion_proof}</Disclosure>
+                ? <button
+                    onClick={() => navigate(`/tasks/${id}/proof`, { state: { from: `/tasks/${id}` } })}
+                    className="flex items-center gap-1.5 text-left w-full group"
+                  >
+                    <span className="leading-relaxed opacity-80 group-hover:opacity-100 truncate">{oneLine(task.completion_proof)}</span>
+                    <span className="opacity-50 group-hover:opacity-100 shrink-0">→</span>
+                  </button>
                 : <div className="text-amber-300/90 text-[12px]">⚠ not yet recorded — green_gate will flag this</div>}
             </div>
           </div>

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -380,7 +380,7 @@ export default function TaskDetailPage() {
         <Card>
           <SectionLabel>Conductor</SectionLabel>
           <div className="mt-3 mb-1">
-            <SdlcProgress step={task.workflow_step} phase={task.phase_progress} reduced={reduced} />
+            <SdlcProgress step={task.workflow_step} phase={task.phase_progress} status={task.status} reduced={reduced} />
           </div>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-3 text-[12px] mt-2 items-start">
             <div>

--- a/services/prism-service/prism_service/web/src/pages/TaskTextPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskTextPage.tsx
@@ -6,6 +6,7 @@ import { useParams, useNavigate, useLocation } from "react-router-dom";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, Empty } from "@/components/ui";
+import EvidenceView from "@/components/EvidenceView";
 
 type Task = {
   id?: string;
@@ -63,7 +64,7 @@ export default function TaskTextPage() {
         ) : !meta ? (
           <Empty>Unknown section.</Empty>
         ) : text ? (
-          <pre className="whitespace-pre-wrap text-[13px] leading-relaxed opacity-90 font-sans">{text}</pre>
+          <EvidenceView text={text} />
         ) : (
           <Empty>Nothing recorded.</Empty>
         )}

--- a/services/prism-service/prism_service/web/src/pages/TaskTextPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskTextPage.tsx
@@ -1,0 +1,73 @@
+// Dedicated screen for a single long task artifact (gate validation evidence,
+// completion proof, description). Reached by clicking the summary row on the
+// task detail — each artifact gets its OWN screen + URL, not an inline collapse.
+import { useEffect, useState } from "react";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
+import { api } from "@/lib/api";
+import { useProject } from "@/lib/project";
+import { Page, Card, Empty } from "@/components/ui";
+
+type Task = {
+  id?: string;
+  title?: string;
+  gate_reason?: string;
+  completion_proof?: string;
+  description?: string;
+  workflow_step?: string;
+  gate_state?: string;
+};
+
+const SECTIONS: Record<string, { label: string; field: keyof Task }> = {
+  validation: { label: "Gate validation", field: "gate_reason" },
+  proof: { label: "Completion proof", field: "completion_proof" },
+  description: { label: "Description", field: "description" },
+};
+
+export default function TaskTextPage() {
+  const { id = "", section = "" } = useParams<{ id: string; section: string }>();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [project] = useProject();
+  const [task, setTask] = useState<Task | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const back = (location.state as { from?: string } | null)?.from || `/tasks/${id}`;
+  const meta = SECTIONS[section];
+
+  useEffect(() => {
+    if (!id) return;
+    api
+      .get<{ task: Task }>(`/api/tasks/${id}?project=${project}`)
+      .then((d) => setTask(d.task))
+      .catch((e) => setError((e as Error).message ?? "task not found"));
+  }, [id, project]);
+
+  const text = task && meta ? (task[meta.field] as string | undefined) : undefined;
+
+  return (
+    <Page>
+      <button
+        onClick={() => navigate(back)}
+        className="text-[11px] uppercase tracking-wider opacity-60 hover:opacity-100 self-start"
+      >
+        ← back to task
+      </button>
+      <div>
+        <h1 className="font-serif text-2xl tracking-tight">{meta?.label ?? "Detail"}</h1>
+        {task?.title && <div className="text-[12px] opacity-60 mt-1 truncate">{task.title}</div>}
+      </div>
+      <Card>
+        {error ? (
+          <Empty>{error}</Empty>
+        ) : !task ? (
+          <Empty>Loading…</Empty>
+        ) : !meta ? (
+          <Empty>Unknown section.</Empty>
+        ) : text ? (
+          <pre className="whitespace-pre-wrap text-[13px] leading-relaxed opacity-90 font-sans">{text}</pre>
+        ) : (
+          <Empty>Nothing recorded.</Empty>
+        )}
+      </Card>
+    </Page>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, SectionLabel, Empty, Kpi, toneFromLabel, type PillTone } from "@/components/ui";
 import {
   stepChipClass, gateChipClass, gateLabel, stepLabel,
 } from "@/lib/workflowChips";
+import { EASE_OUT, EASE_IN, DUR, SPRING_SNAPPY } from "@/lib/motion";
 
 type Task = {
   id?: string;
@@ -57,6 +59,9 @@ function priorityTone(p: number | string | undefined): PillTone {
 export default function TasksPage() {
   const [project] = useProject();
   const navigate = useNavigate();
+  // Board motion respects the OS reduced-motion preference: when set, cards
+  // fade/snap with no travel or FLIP reorder. Guards every motion below.
+  const reduced = useReducedMotion();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [next, setNext] = useState<Task | null>(null);
 
@@ -122,14 +127,36 @@ export default function TasksPage() {
                 <div className="text-xs opacity-40 text-center py-6">empty</div>
               ) : (
                 <div className="space-y-2">
+                  <AnimatePresence initial={false}>
                   {items.map((t) => {
                     const pTone = priorityTone(t.priority);
                     const step = t.workflow_step ?? "";
                     const gate = t.gate_state ?? "none";
                     const conductorOn = step !== "" || gate !== "none";
                     return (
-                      <button
+                      <motion.div
+                        // Stable layoutId on the TASK ID (never the array
+                        // index) so FLIP recognises the same card across the
+                        // 5s poll — animating cross-column reorder instead of
+                        // a hard cut. transform/opacity only (GPU).
                         key={t.id}
+                        layout={reduced ? false : true}
+                        layoutId={t.id}
+                        initial={reduced ? { opacity: 0 } : { opacity: 0, y: 8 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={reduced ? { opacity: 0 } : { opacity: 0, scale: 0.97 }}
+                        transition={
+                          reduced
+                            ? { duration: 0 }
+                            : {
+                                layout: SPRING_SNAPPY,
+                                opacity: { duration: DUR.enter, ease: EASE_OUT },
+                                y: { duration: DUR.enter, ease: EASE_OUT },
+                                scale: { duration: DUR.exit, ease: EASE_IN },
+                              }
+                        }
+                      >
+                      <button
                         onClick={() => t.id && navigate(`/tasks/${t.id}`, { state: { from: "/tasks" } })}
                         className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors cursor-pointer"
                       >
@@ -152,20 +179,38 @@ export default function TasksPage() {
                         {conductorOn && (
                           <div className="flex items-center gap-1.5 mt-2 flex-wrap">
                             {step && (
-                              <span
-                                className={stepChipClass(step)}
-                                title={`conductor step: ${step}`}
-                              >
-                                {stepLabel(step)}
-                              </span>
+                              // Cross-fade the step chip's --accent tone when
+                              // the SDLC step advances. Keyed on the step value
+                              // so AnimatePresence swaps in the new tone with a
+                              // subtle scale pulse drawing the eye to the change.
+                              <AnimatePresence mode="wait" initial={false}>
+                                <motion.span
+                                  key={step}
+                                  className={stepChipClass(step)}
+                                  title={`conductor step: ${step}`}
+                                  initial={reduced ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+                                  animate={reduced ? { opacity: 1 } : { opacity: 1, scale: [1, 1.04, 1] }}
+                                  exit={{ opacity: 0 }}
+                                  transition={{ duration: reduced ? 0 : DUR.chip, ease: EASE_OUT }}
+                                >
+                                  {stepLabel(step)}
+                                </motion.span>
+                              </AnimatePresence>
                             )}
                             {gate !== "none" && (
-                              <span
-                                className={gateChipClass(gate as any)}
-                                title={t.gate_reason || `gate ${gate}`}
-                              >
-                                gate {gateLabel(gate as any)}
-                              </span>
+                              <AnimatePresence mode="wait" initial={false}>
+                                <motion.span
+                                  key={gate}
+                                  className={gateChipClass(gate as any)}
+                                  title={t.gate_reason || `gate ${gate}`}
+                                  initial={reduced ? { opacity: 0 } : { opacity: 0, scale: 0.96 }}
+                                  animate={reduced ? { opacity: 1 } : { opacity: 1, scale: [1, 1.04, 1] }}
+                                  exit={{ opacity: 0 }}
+                                  transition={{ duration: reduced ? 0 : DUR.chip, ease: EASE_OUT }}
+                                >
+                                  gate {gateLabel(gate as any)}
+                                </motion.span>
+                              </AnimatePresence>
                             )}
                           </div>
                         )}
@@ -203,8 +248,10 @@ export default function TasksPage() {
                           })}
                         </div>
                       </button>
+                      </motion.div>
                     );
                   })}
+                  </AnimatePresence>
                 </div>
               )}
             </Card>

--- a/services/prism-service/tests/integration/test_phase_progress_seam.py
+++ b/services/prism-service/tests/integration/test_phase_progress_seam.py
@@ -1,0 +1,194 @@
+"""RED scaffold — phase_progress field for the animated SDLC progress bar
+(task a5e0d9f5 — Animate Conductor Tasks in the PRISM Web UI).
+
+The segmented SDLC progress bar (ConductorPage tiles + TaskDetailPage header)
+needs a server-computed `phase_progress` blend so the current-segment fill can
+tween smoothly between 5s polls instead of snapping at each step advance. This
+field is NET-NEW: today nothing computes it and neither API payload carries it.
+
+These pin the REAL user-facing seams end-to-end (not a service method in
+isolation — that exact gap has shipped false-greens):
+
+  Seam A (compute) — ConductorService.phase_progress(task_id) returns the
+    documented shape {pct, basis, in_step_s, typical_s, children_done,
+    children_total, tokens_since_step}.
+  Seam B (baseline pct) — with no child tasks, pct = min(0.95, in_step_s /
+    typical_s) from MEDIAN step history, basis='time', and the 0.95 ceiling
+    holds even when in_step_s far exceeds typical_s.
+  Seam C (children override) — when child tasks exist (parent_id == task),
+    pct is the exact children_done/children_total ratio and basis='children',
+    OVERRIDING the time baseline.
+  Seam D (conductor /state API) — GET /api/conductor/state managed_tasks
+    entries each carry a phase_progress object with pct (reachable through the
+    REAL router, not just the method).
+  Seam E (task detail API) — GET /api/tasks/{id} returns phase_progress on a
+    conductor-managed task object.
+
+ALL FAIL today: ConductorService has no phase_progress method, managed_tasks()
+entries lack the key, and neither API route surfaces it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+_SHAPE_KEYS = {
+    "pct", "basis", "in_step_s", "typical_s",
+    "children_done", "children_total", "tokens_since_step",
+}
+
+
+def _services(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"),
+        enable_engine=False,
+        task_svc=task_svc,
+    )
+    return task_svc, cond
+
+
+def _managed(task_svc, cond, title="animate"):
+    """Create a task and walk it onto the workflow so managed_tasks() sees it."""
+    t = task_svc.create(title=title)
+    cond.advance_task(t.id)  # '' -> step 0, workflow_step now non-empty
+    return task_svc.get(t.id)
+
+
+# ----------------------------------------------------------------------
+# Seam A — the method exists and returns the documented shape
+# ----------------------------------------------------------------------
+
+def test_phase_progress_returns_documented_shape(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    t = _managed(task_svc, cond)
+    assert hasattr(cond, "phase_progress"), \
+        "ConductorService must expose phase_progress(task_id)"
+    pp = cond.phase_progress(t.id)
+    assert isinstance(pp, dict)
+    assert _SHAPE_KEYS.issubset(pp.keys()), \
+        f"phase_progress shape missing keys: {_SHAPE_KEYS - set(pp.keys())}"
+    assert 0.0 <= pp["pct"] <= 1.0
+
+
+# ----------------------------------------------------------------------
+# Seam B — time baseline pct = min(0.95, in_step_s / typical_s)
+# ----------------------------------------------------------------------
+
+def test_phase_progress_time_basis_caps_at_0_95(tmp_path):
+    """With no children, pct is the time ratio capped at 0.95 — even when the
+    task has dwelt far longer than the typical step duration."""
+    task_svc, cond = _services(tmp_path)
+    t = _managed(task_svc, cond)
+    pp = cond.phase_progress(t.id)
+    assert pp["basis"] == "time", "no-children progress must be time-based"
+    assert pp["children_total"] == 0
+    assert pp["pct"] <= 0.95, "time-basis pct must never exceed the 0.95 ceiling"
+    # in_step_s comes off the last advance row, so it is a real (>=0) duration.
+    assert pp["in_step_s"] >= 0.0
+    assert pp["typical_s"] > 0.0, "typical_s must fall back to a positive default"
+
+
+# ----------------------------------------------------------------------
+# Seam C — child tasks OVERRIDE the time baseline with an exact ratio
+# ----------------------------------------------------------------------
+
+def test_phase_progress_children_override_time_basis(tmp_path):
+    """When parent_id == this task, pct is the exact done/total child ratio
+    and basis flips to 'children', overriding the time baseline."""
+    task_svc, cond = _services(tmp_path)
+    parent = _managed(task_svc, cond, title="parent")
+
+    c1 = task_svc.create(title="child-1")
+    c2 = task_svc.create(title="child-2")
+    c3 = task_svc.create(title="child-3")
+    for c in (c1, c2, c3):
+        task_svc.update(c.id, parent_id=parent.id)
+    task_svc.update(c1.id, status="done")
+
+    pp = cond.phase_progress(parent.id)
+    assert pp["basis"] == "children", \
+        "child tasks must override the time baseline"
+    assert pp["children_total"] == 3
+    assert pp["children_done"] == 1
+    assert pp["pct"] == pytest.approx(1 / 3, abs=1e-6), \
+        "pct must be the exact children_done/children_total ratio"
+
+
+# ----------------------------------------------------------------------
+# Seam D — conductor /state API surfaces phase_progress per managed task
+# ----------------------------------------------------------------------
+
+def _isolated_ctx(tmp_path, monkeypatch):
+    """Bind the API routers' get_project to a context whose task_svc and
+    conductor_svc share one tasks.db (the real wiring)."""
+    task_svc, cond = _services(tmp_path)
+
+    class _Ctx:
+        task_svc = None
+        conductor_svc = None
+
+    ctx = _Ctx()
+    ctx.task_svc = task_svc
+    ctx.conductor_svc = cond
+    return ctx, task_svc, cond
+
+
+def test_conductor_state_api_carries_phase_progress(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import conductor as conductor_api
+
+    ctx, task_svc, cond = _isolated_ctx(tmp_path, monkeypatch)
+    _managed(task_svc, cond, title="board tile")
+
+    monkeypatch.setattr(conductor_api, "get_project", lambda p: ctx)
+    app = FastAPI()
+    app.include_router(conductor_api.router, prefix="/api/conductor")
+    client = TestClient(app)
+
+    r = client.get("/api/conductor/state")
+    assert r.status_code == 200, r.text
+    managed = r.json()["managed_tasks"]
+    assert managed, "the managed task must appear on the conductor /state payload"
+    tile = managed[0]
+    assert "phase_progress" in tile, \
+        "each managed_tasks entry must carry a phase_progress object"
+    assert "pct" in tile["phase_progress"]
+
+
+# ----------------------------------------------------------------------
+# Seam E — task detail API surfaces phase_progress on the task object
+# ----------------------------------------------------------------------
+
+def test_task_detail_api_carries_phase_progress(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import tasks as tasks_api
+
+    ctx, task_svc, cond = _isolated_ctx(tmp_path, monkeypatch)
+    t = _managed(task_svc, cond, title="detail header")
+
+    monkeypatch.setattr(tasks_api, "get_project", lambda p: ctx)
+    app = FastAPI()
+    app.include_router(tasks_api.router, prefix="/api/tasks")
+    client = TestClient(app)
+
+    r = client.get(f"/api/tasks/{t.id}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "phase_progress" in body, \
+        "GET /api/tasks/{id} must surface phase_progress for the detail header bar"
+    assert "pct" in body["phase_progress"]

--- a/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
+++ b/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
@@ -150,10 +150,11 @@ def test_index_css_appends_prefers_reduced_motion_reset_after_line_110():
 
 
 # ---------------------------------------------------------------------------
-# Version patch-bump 6.2.30 -> 6.2.31
+# Version bump -> 6.3.0 (minor: animations + real-time phase progress feature;
+# rolls up the never-shipped 6.2.31)
 # ---------------------------------------------------------------------------
 
-def test_prism_version_patch_bumped_to_6_2_31():
+def test_prism_version_bumped_to_6_3_0():
     from prism_service.__version__ import PRISM_VERSION
-    assert PRISM_VERSION == "6.2.31", \
-        "PRISM_VERSION must be patch-bumped from 6.2.30 to 6.2.31 in the same commit"
+    assert PRISM_VERSION == "6.3.0", \
+        "PRISM_VERSION must be bumped to 6.3.0 for the conductor-animation feature"

--- a/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
+++ b/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
@@ -1,0 +1,159 @@
+"""UI contract tests for "Animate Conductor Tasks in the PRISM Web UI"
+(task a5e0d9f5 — board motion + click-through transitions).
+
+The PRISM SPA has no JS test runner, so the UI-FIRST motion acceptance
+criteria are pinned by asserting the ACTUAL web source (TSX/CSS) — the same
+pattern as tests/unit/test_explore_narrative_ui.py and the other *_ui.py
+contracts. These assert the real seams: the motion library is imported AND
+applied to the rendered elements (not merely available in node_modules),
+layoutId is keyed on the stable task id (never an array index), the route
+swap is wrapped + keyed, reduced-motion infra exists in BOTH a hook usage and
+a global CSS reset, and the version is patch-bumped.
+
+ALL of these FAIL today (the source has zero motion wiring, index.css is
+exactly 110 lines with no reduced-motion block, version is 6.2.30). They go
+green only when the animation work is wired into the live components.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SRC = _HERE.parent.parent.parent / "prism_service" / "web" / "src"
+_TASKS = _SRC / "pages" / "TasksPage.tsx"
+_DETAIL = _SRC / "pages" / "TaskDetailPage.tsx"
+_APP = _SRC / "App.tsx"
+_CSS = _SRC / "index.css"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Board (TasksPage) — entrance / exit / cross-column reorder motion
+# ---------------------------------------------------------------------------
+
+def test_tasks_page_imports_motion_from_react_subpath():
+    src = _read(_TASKS)
+    # Zero-new-dependency: the already-installed motion@12 via motion/react.
+    assert 'from "motion/react"' in src, \
+        "TasksPage must import the motion primitives from the motion/react subpath"
+    assert "AnimatePresence" in src
+    assert "motion." in src or "motion(" in src, \
+        "TasksPage must render a motion element, not just import the lib"
+
+
+def test_tasks_board_cards_use_layout_and_stable_layoutid():
+    src = _read(_TASKS)
+    # FLIP reorder motion across the 5s poll requires layout + a STABLE
+    # layoutId. The id must be the task id (t.id), never the array index.
+    assert "layout" in src, "board cards must opt into layout (FLIP) animation"
+    assert "layoutId={t.id}" in src, \
+        "layoutId must be the stable task id t.id (never an array index)"
+    # Guard against the classic false-green: layoutId keyed on the map index.
+    assert "layoutId={i}" not in src and "layoutId={index}" not in src, \
+        "layoutId must not be an array index"
+
+
+def test_tasks_board_card_list_wrapped_in_animatepresence():
+    src = _read(_TASKS)
+    # Entrance + exit motion as tasks appear/leave the poll snapshot needs the
+    # per-column card list under <AnimatePresence>.
+    assert "<AnimatePresence" in src, \
+        "the per-column card list must be wrapped in AnimatePresence for enter/exit"
+
+
+def test_tasks_chip_crossfade_preserves_literal_gate_prefix_and_guard():
+    src = _read(_TASKS)
+    # The chip cross-fade must NOT regress the load-bearing literal "gate "
+    # prefix at the call site, and must stay guarded by conductor-engaged state.
+    assert "gate " in src, "the literal 'gate ' prefix must be preserved at the call site"
+    assert "conductorOn" in src or "conductorEngaged" in src, \
+        "step/gate chips must remain guarded by conductor-engaged state"
+
+
+# ---------------------------------------------------------------------------
+# App.tsx — route-swap transition into TaskDetailPage
+# ---------------------------------------------------------------------------
+
+def test_app_routes_wrapped_in_animatepresence_keyed_on_pathname():
+    src = _read(_APP)
+    assert 'from "motion/react"' in src, "App must import motion/react"
+    assert 'AnimatePresence mode="wait"' in src, \
+        "the <Routes> must be wrapped in <AnimatePresence mode=\"wait\">"
+    assert "location.pathname" in src, \
+        "the route-swap transition must be keyed on location.pathname"
+
+
+def test_app_preserves_navigate_redirects_and_scroll_container():
+    src = _read(_APP)
+    # Wrapping the router must not break the two replace-redirects or the single
+    # flex-1 overflow-y-auto scroll container.
+    assert 'Navigate to="/brain" replace' in src
+    assert src.count('Navigate to="/brain" replace') == 2, \
+        "both /explore and /graph replace-redirects to /brain must survive"
+    assert "flex-1 overflow-y-auto" in src, "the page scroll container must survive"
+
+
+# ---------------------------------------------------------------------------
+# TaskDetailPage — Card stagger, toast in/out, status flash
+# ---------------------------------------------------------------------------
+
+def test_detail_page_imports_motion_and_staggers_cards():
+    src = _read(_DETAIL)
+    assert 'from "motion/react"' in src, "TaskDetailPage must import motion/react"
+    assert "motion." in src or "motion(" in src, \
+        "the Card stack must mount as motion elements to stagger"
+
+
+def test_detail_toast_animates_in_and_out():
+    src = _read(_DETAIL)
+    # The fixed notice toast (was a bare `notice && <div>`) must animate via
+    # AnimatePresence so it slides/fades in and out instead of hard-cutting.
+    assert "<AnimatePresence" in src, "the notice toast must be under AnimatePresence"
+    assert "notice" in src
+
+
+def test_detail_status_chip_flash_decoupled_from_patch_roundtrip():
+    src = _read(_DETAIL)
+    # The status chip flash must key on the task.status VALUE change (an effect
+    # / animation keyed on task.status), NOT fire inside the setStatus click
+    # handler — otherwise it's coupled to the PATCH+reload round-trip.
+    assert "task.status" in src
+    assert "useReducedMotion" in src, \
+        "the flash must respect reduced motion (shared infra)"
+
+
+# ---------------------------------------------------------------------------
+# Reduced-motion infrastructure — hook guard + global CSS reset
+# ---------------------------------------------------------------------------
+
+def test_reduced_motion_hook_used_on_board_and_detail():
+    tasks = _read(_TASKS)
+    detail = _read(_DETAIL)
+    assert "useReducedMotion" in tasks, "board motion must be guarded by useReducedMotion()"
+    assert "useReducedMotion" in detail, "detail motion must be guarded by useReducedMotion()"
+
+
+def test_index_css_appends_prefers_reduced_motion_reset_after_line_110():
+    src = _read(_CSS)
+    lines = src.splitlines()
+    # The reset is NEW and appended AFTER the existing 110-line file.
+    assert len(lines) > 110, "a reduced-motion block must be appended after line 110"
+    assert "prefers-reduced-motion: reduce" in src, \
+        "a global @media (prefers-reduced-motion: reduce) reset must exist"
+    tail = "\n".join(lines[110:])
+    assert "prefers-reduced-motion: reduce" in tail, \
+        "the reduced-motion reset must be appended AFTER the original line 110"
+
+
+# ---------------------------------------------------------------------------
+# Version patch-bump 6.2.30 -> 6.2.31
+# ---------------------------------------------------------------------------
+
+def test_prism_version_patch_bumped_to_6_2_31():
+    from prism_service.__version__ import PRISM_VERSION
+    assert PRISM_VERSION == "6.2.31", \
+        "PRISM_VERSION must be patch-bumped from 6.2.30 to 6.2.31 in the same commit"


### PR DESCRIPTION
## Summary
Motion + real-time phase progress for the PRISM conductor/task UI (task `a5e0d9f5`, driven through the conductor SDLC — green gate passed on 689-green + live verification).

**Animation layer** (zero new deps — `motion@12`):
- `lib/motion.ts` vocabulary (EASE_OUT/EASE_IN, DUR enter>exit, SPRING_SNAPPY bounce<0.1, capped stagger).
- Board `AnimatePresence` + `motion.div layout/layoutId` reorder + step/gate chip cross-fade.
- Route transitions via `AnimatePresence mode="wait"`; `index.css` `prefers-reduced-motion` reset + `useReducedMotion()` guards throughout.

**Real-time phase progress**:
- New `ConductorService.phase_progress()` → `{pct, basis, in_step_s, typical_s, children_done, children_total, tokens_since_step}` (time baseline w/ 0.95 cap, children-done override, real linked-session token sum), on `/api/conductor/state` + `/api/tasks/{id}`.
- `SdlcProgress`: segmented 8-step bar (done solid / current live-extrapolated fill + shimmer / future muted) on conductor tiles (~2× height) and the task-detail header; live `mm:ss` in-step timer; status pill reflects **real task status** (in progress / done / blocked) — not a guessed activity ping.
- Child-task checkbox checklist with spring-tick.

**Readable artifacts** (per progressive-disclosure = dedicated screens, not collapse):
- Validation + completion proof click through to a dedicated `TaskTextPage` (`/tasks/:id/:section`); `EvidenceView` renders the receipt-style blob as structured rows (teal `code` chips, toned labels, emerald/amber/rose result tokens) in the `/understand` palette — no `<pre>` wall.

**Also fixed**: `claude_transcripts` guarded the optional `claude_memory` import that was silently killing ALL session/token import.

## Tests / gates
- `pytest tests/unit` → **637 passed**; full `tests/` → **689 passed** (workflow verify). `tsc -b` + `npm run build` clean.
- Live-verified on the dev daemon (:8888, 6.3.0): bar + ticking timer + tokens, click-through screens, reduced-motion, redirects + scroll preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)