### PR TITLE
chore: implement-workflow pre-flight guard + self-heal doctrine + clock lint

### DIFF
--- a/.claude/workflows/implement.js
+++ b/.claude/workflows/implement.js
@@ -77,12 +77,25 @@ const CONVENTIONS = [
   '- If the change is user-visible, patch-bump PRISM_VERSION in the same commit.',
 ].join('\n')
 
+// SELF-HEAL doctrine (implement-workflow reliability). Injected into every step
+// agent's preamble so a failed step / genuine gate-reject / runtime error
+// triggers a knowledge-ladder climb instead of a dead halt. NOTE: the RESEARCH
+// rung is WebSearch/WebFetch today; Context7 MCP (clean library docs) is a
+// not-yet-wired follow-up.
+const SELF_HEAL = [
+  'SELF-HEAL DOCTRINE — when a step fails, a gate GENUINELY rejects (NOT the verifier-blind case above), or a tool/runtime error fires, climb the ladder before giving up:',
+  '1. PRISM-FIRST: brain_search + memory_recall for a known resolution. PRISM is the knowledge AND time authority — it server-stamps run timestamps; never reach for a client clock.',
+  '2. RESEARCH: if PRISM has no answer, research best practices via WebSearch/WebFetch and cite sources.',
+  '3. APPLY the smallest fix.',
+  '4. RECORD: memory_store(type="failure", with file:line + the fix) so PRISM HAS THE ANSWER next time — failures become memories.',
+].join('\n')
+
 const dryNote = DRY
   ? '\n\nDRY-RUN MODE: Do NOT write files, do NOT run conductor_advance/conductor_gate/task_update, do NOT mutate anything. Only gather context and report exactly what you WOULD do. Treat the conductor transition as simulated and report the to_step you would expect.'
   : ''
 
 function preamble(role) {
-  return `${PRISM_TOOLS}\n\nYou are acting as the PRISM "${role}" persona inside the conductor SDLC.\n\n${KNOWLEDGE}\n\n${CONVENTIONS}${dryNote}`
+  return `${PRISM_TOOLS}\n\nYou are acting as the PRISM "${role}" persona inside the conductor SDLC.\n\n${KNOWLEDGE}\n\n${CONVENTIONS}\n\n${SELF_HEAL}${dryNote}`
 }
 
 // ── Agent-run telemetry emitter (task f4498190) ─────────────────────────
@@ -170,6 +183,30 @@ const STEP_SCHEMA = {
     halt_reason: { type: 'string', description: 'set ONLY if the step failed or a gate rejected; empty otherwise' },
   },
 }
+
+// ── Phase: Pre-flight (fail fast) ───────────────────────────────────────
+// AC1: assert the run can even succeed BEFORE the drive — turns 7-min-to-fail
+// runs into ~5-second fails with one actionable line. Workflow scripts have no
+// fs/process access, so the checks run inside the first agent (read-only bash).
+const PREFLIGHT_SCHEMA = {
+  type: 'object',
+  required: ['ok', 'sane_branch', 'datenow_clean', 'daemon_ok', 'halt_reason'],
+  properties: {
+    ok: { type: 'boolean' },
+    sane_branch: { type: 'boolean' },
+    datenow_clean: { type: 'boolean' },
+    daemon_ok: { type: 'boolean' },
+    halt_reason: { type: 'string', description: 'ONE actionable remediation line if ok=false; empty otherwise' },
+  },
+}
+phase('Pre-flight')
+const preflight = await agent(
+  `${PRISM_TOOLS}\n\nPRE-FLIGHT GUARD — run these READ-ONLY checks from E:/.prism and fail FAST. Use 127.0.0.1, NEVER localhost (gitbash resolves localhost->::1 while the daemon binds IPv4 — a silent-zero trap that has burned whole runs).\n\n1. SANE BRANCH: after \`git -C E:/.prism fetch -q origin main\`, read \`git -C E:/.prism rev-parse --abbrev-ref HEAD\` and \`git -C E:/.prism rev-list --count HEAD..origin/main\`. sane_branch=false if the current branch is BEHIND origin/main by >0 (the stale-branch trap — the drive would build on stale code). main or an even/ahead feature branch is fine.\n2. CLOCK-CLEAN: \`git -C E:/.prism grep -nE 'Date[.]now|new[[:space:]]*Date[(]' -- .claude/workflows/*.js\`. datenow_clean=false on ANY match — PRISM is the time authority (it server-stamps run timestamps); a workflow script must never use a client clock (unavailable in the sandbox; breaks resume/cache; PRISM memory mx-9945f2).\n3. DAEMON/CONDUCTOR REACHABLE: \`curl -s -m5 -o /dev/null -w '%{http_code}' http://127.0.0.1:8888/api/version\` must be 200 — the conductor cannot record transitions (or stamp time) against a dead daemon.${DRY ? ' (DRY-RUN: treat a dead daemon as non-fatal.)' : ''}\n\nSet ok=true ONLY if sane_branch AND datenow_clean${DRY ? '' : ' AND daemon_ok'}. If ok=false, halt_reason = ONE actionable line, e.g. "branch <b> is N behind origin/main — rebase or branch fresh off main", "client clock in <file>:<line> — PRISM server-stamps time, remove it (mx-9945f2)", or "daemon down on :8888 — start dev (prism-dev) before driving".`,
+  { label: 'pre-flight', phase: 'Pre-flight', schema: PREFLIGHT_SCHEMA })
+if (!preflight.ok) {
+  throw new Error(`PRE-FLIGHT HALT — ${preflight.halt_reason || 'a pre-flight check failed'} [sane_branch=${preflight.sane_branch} clock_clean=${preflight.datenow_clean} daemon_ok=${preflight.daemon_ok}]`)
+}
+log(`Pre-flight OK — branch sane, workflow scripts clock-clean (PRISM owns time)${DRY ? '' : ', daemon reachable'}.`)
 
 // ── Phase: Locate ───────────────────────────────────────────────────────
 phase('Locate')

--- a/services/prism-service/tests/unit/test_workflow_scripts_no_datenow.py
+++ b/services/prism-service/tests/unit/test_workflow_scripts_no_datenow.py
@@ -1,0 +1,40 @@
+"""Lint: workflow scripts must not use a client clock (Date.now / new Date()).
+
+PRISM is the time authority — run timestamps are server-stamped on ingest
+(see .claude/workflows/implement.js: "Timing is stamped server-side ... workflow
+scripts forbid client clocks"). Client clocks are also unavailable in the
+workflow sandbox and would break resume/caching. See PRISM memory mx-9945f2
+(workflow-scripts-forbid-date-now).
+
+This lint scans .claude/workflows/*.js and fails on any real usage; comment
+lines (// or *) are allowed so the ban can be documented.
+"""
+import re
+from pathlib import Path
+
+WORKFLOWS_DIR = Path(__file__).resolve().parents[4] / ".claude" / "workflows"
+FORBIDDEN = re.compile(r"Date\.now|new\s+Date\s*\(")
+
+
+def _is_comment(line: str) -> bool:
+    s = line.lstrip()
+    return s.startswith("//") or s.startswith("*") or s.startswith("/*")
+
+
+def test_no_client_clocks_in_workflow_scripts():
+    if not WORKFLOWS_DIR.is_dir():
+        return  # no workflows dir in this checkout — nothing to lint
+    scripts = sorted(WORKFLOWS_DIR.glob("*.js"))
+    assert scripts, f"expected workflow scripts under {WORKFLOWS_DIR}"
+    offenders = []
+    for js in scripts:
+        for i, line in enumerate(js.read_text(encoding="utf-8").splitlines(), 1):
+            if _is_comment(line):
+                continue
+            if FORBIDDEN.search(line):
+                offenders.append(f"{js.name}:{i}: {line.strip()}")
+    assert not offenders, (
+        "workflow scripts must not use a client clock (Date.now / new Date()); "
+        "PRISM server-stamps run timestamps (mx-9945f2). Offenders:\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
Hardens the implement workflow tooling (not a product change — no version bump).

- **AC1** pre-flight guard (first agent): sane-branch / clock-clean / daemon reachable on `127.0.0.1` → fail-fast one-line remediation instead of 7-min-to-fail runs.
- **AC2** lint `tests/unit/test_workflow_scripts_no_datenow.py` forbids `Date.now`/`new Date()` in `.claude/workflows/*.js` — PRISM server-stamps run timestamps (mx-9945f2).
- **AC3** self-heal doctrine in every step preamble: PRISM-first → research → apply → `memory_store` the fix.
- **AC4** Context7 MCP research rung: follow-up (not yet wired).

Lint green; `node --check implement.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)