### PR TITLE
feat(v6.3.2): conductor animated SDLC tiles — cleanup + live token effort

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.1"
+PRISM_VERSION = "6.3.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.2: Conductor tiles now show LIVE token effort instead of 0 tok. Two "
+    "bugs fixed: (1) phase_progress only read the post-hoc session_outcomes "
+    "table, which is empty for an in-progress task — it now also sums "
+    "output_tokens straight off the on-disk transcript JSONL (parent + nested "
+    "workflow-subagent transcripts) and takes the max, so a running session "
+    "shows a real, growing number. New claude_transcripts.live_tokens_for_session "
+    "(mtime/size cached so the 5s poll never re-reads unchanged transcripts) + "
+    "current_session_id. (2) conductor_advance/conductor_gate fell back to the "
+    "MCP request_id when no session_id was passed — a phantom that maps to no "
+    "transcript and no token row, so every workflow-driven task linked dead "
+    "sessions. New _resolve_link_session_id() resolves the real active "
+    "transcript session, keeping request_id only as last resort. "
     "v6.3.1: Clean up /conductor for the animated SDLC tiles. Swimlane rows "
     "open from py-3 to py-4 and the lane->tile auto-fill grid widens "
     "(minmax 220px->250px) + opens (gap-2->gap-3) so each tile's embedded "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.0"
+PRISM_VERSION = "6.3.1"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.1: Clean up /conductor for the animated SDLC tiles. Swimlane rows "
+    "open from py-3 to py-4 and the lane->tile auto-fill grid widens "
+    "(minmax 220px->250px) + opens (gap-2->gap-3) so each tile's embedded "
+    "~2x-height SdlcProgress bar reads uncluttered. TaskTile gains a coherent "
+    "hierarchy: an explicit 'SDLC' SectionLabel on the progress block plus "
+    "click-to-expand progressive disclosure of gate_reason (local expand "
+    "state, not tooltip-only). SdlcProgress current-step fill now tweens "
+    "SMOOTHLY between the 5s polls via useSpring (suppressed when reduced), "
+    "instead of a hard segFill.set jump; reduced stays threaded "
+    "page->TaskTile->SdlcProgress. UI-only. "
     "v6.3.0: Animate conductor tasks + real-time SDLC phase progress. New "
     "web/src/lib/motion.ts motion vocabulary (EASE_OUT/EASE_IN, DUR enter>exit, "
     "SPRING_SNAPPY bounce<0.1, capped 0.04s stagger); board AnimatePresence + "

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -1516,6 +1516,29 @@ def _json(obj: Any) -> str:
     return json.dumps(_serialise(obj), indent=2, default=str)
 
 
+def _resolve_link_session_id() -> str:
+    """Fallback session id to stamp into task_sessions when a conductor
+    advance/gate omits one. Prefers the REAL active transcript session for
+    the request's project (so the link maps to actual token data); falls
+    back to the MCP request handle only when no transcript can be found —
+    that preserves the "always stamp something" guarantee without making a
+    phantom id the default (which left conductor tiles stuck at 0 tok)."""
+    from prism_service.mcp.request_context import get_request_context
+    ctx = get_request_context()
+    try:
+        from prism_service.services.claude_transcripts import (
+            _project_source_path, current_session_id,
+        )
+        src = _project_source_path(ctx.project_id)
+        if src:
+            real = current_session_id(src)
+            if real:
+                return real
+    except Exception:
+        pass
+    return ctx.request_id
+
+
 # ---------------------------------------------------------------------------
 # Self-documenting guide (returned by prism_guide tool)
 # ---------------------------------------------------------------------------
@@ -3367,15 +3390,11 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
         if name == "conductor_advance":
             task_id = arguments["id"]
             # Session capture: prefer the caller-threaded session_id (the human
-            # driving session a workflow passes as SID); else fall back to the
-            # MCP request handle so a conductor drive ALWAYS stamps a
-            # task_sessions row — mirrors task_link_session. Without this, a
-            # drive that omits session_id leaves the task with 0 linked
-            # sessions (the ed7292bd symptom).
-            _sid = arguments.get("session_id")
-            if not _sid:
-                from prism_service.mcp.request_context import get_request_context
-                _sid = get_request_context().request_id
+            # driving session a workflow passes as SID); else resolve the REAL
+            # active transcript session so the linked id maps to actual token
+            # data. The MCP request handle is the last-resort stamp only — on
+            # its own it links a phantom (no transcript, no tokens → 0 tok).
+            _sid = arguments.get("session_id") or _resolve_link_session_id()
             result = conductor_svc.advance_task(
                 task_id,
                 validation=arguments.get("validation"),
@@ -3387,15 +3406,10 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "conductor_gate":
             task_id = arguments["id"]
-            # Same session-capture fallback as conductor_advance. conductor_gate
-            # does not even expose session_id in its schema, so before this the
-            # gate transition NEVER linked a session — the request-handle
-            # fallback ensures a terminal gate (green_gate close-out) records
-            # the session that resolved it.
-            _sid = arguments.get("session_id")
-            if not _sid:
-                from prism_service.mcp.request_context import get_request_context
-                _sid = get_request_context().request_id
+            # Same session-capture fallback as conductor_advance — resolve the
+            # real active transcript session (not the phantom request handle) so
+            # the terminal gate links a session that carries token data.
+            _sid = arguments.get("session_id") or _resolve_link_session_id()
             result = conductor_svc.gate_decide(
                 task_id,
                 arguments["action"],

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -572,3 +572,115 @@ def _project_source_path(project_id: str) -> str:
         return (state.get("source_path") or "").strip()
     except Exception:
         return ""
+
+
+# ---------------------------------------------------------------------------
+# LIVE token read (conductor SDLC bar). The post-hoc `session_outcomes` table
+# is only written when the importer sees a session — so an IN-PROGRESS task
+# always reads 0 tok there. These helpers sum `output_tokens` straight off the
+# transcript JSONL on disk, in real time, including the workflow-subagent
+# transcripts filed under <slug>/<session-uuid>/ (they carry the parent
+# sessionId, so their spend belongs to the same session). Keyed by (mtime,size)
+# so the 5s conductor poll never re-reads an unchanged multi-MB transcript.
+# ---------------------------------------------------------------------------
+
+# path -> (mtime, size, output_tokens)
+_TOKEN_CACHE: dict[str, tuple[float, int, int]] = {}
+
+
+def _sum_output_tokens(path: Path) -> int:
+    """Sum assistant `output_tokens` across one transcript JSONL. Cached on
+    (mtime, size) so unchanged files cost nothing on repeat polls."""
+    try:
+        st = path.stat()
+    except OSError:
+        return 0
+    key = str(path)
+    cached = _TOKEN_CACHE.get(key)
+    if cached and cached[0] == st.st_mtime and cached[1] == st.st_size:
+        return cached[2]
+    total = 0
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            usage = (evt.get("message") or {}).get("usage") or {}
+            if usage:
+                total += int(usage.get("output_tokens") or 0)
+    except OSError:
+        return cached[2] if cached else 0
+    _TOKEN_CACHE[key] = (st.st_mtime, st.st_size, total)
+    return total
+
+
+def _session_id_of(path: Path) -> str:
+    """Read just the first `sessionId` from a transcript, '' if none."""
+    try:
+        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                evt = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            sid = evt.get("sessionId") or evt.get("session_id")
+            if sid:
+                return str(sid)
+    except OSError:
+        pass
+    return ""
+
+
+def live_tokens_for_session(
+    session_id: str, project_path: str, claude_home: Path | None = None,
+) -> int:
+    """Sum live `output_tokens` for `session_id` across its on-disk transcript
+    AND any workflow-subagent transcripts nested under <slug>/<session_id>/.
+    Returns 0 when nothing is found (caller falls back to session_outcomes)."""
+    if not session_id or not project_path:
+        return 0
+    claude_home = claude_home or resolve_claude_home()
+    projects_dir = claude_home / "projects"
+    if not projects_dir.is_dir():
+        return 0
+    total = 0
+    seen: set[Path] = set()
+    for sub in projects_dir.iterdir():
+        if not sub.is_dir() or not slug_matches(sub.name, project_path):
+            continue
+        main = sub / f"{session_id}.jsonl"
+        if main.is_file() and main not in seen:
+            total += _sum_output_tokens(main)
+            seen.add(main)
+        # Subagent transcripts (workflow agents) live under the session dir
+        # and carry the parent sessionId — their spend is part of this session.
+        sess_dir = sub / session_id
+        if sess_dir.is_dir():
+            for f in sess_dir.rglob("*.jsonl"):
+                if f not in seen:
+                    total += _sum_output_tokens(f)
+                    seen.add(f)
+    return total
+
+
+def current_session_id(
+    project_path: str, claude_home: Path | None = None,
+) -> str:
+    """Best-effort id of the project's ACTIVE Claude session — the sessionId
+    of the most-recently-modified matching transcript. Used as the conductor
+    link fallback so we stamp a REAL, resolvable session instead of the MCP
+    request handle (which maps to no transcript and no token data)."""
+    if not project_path:
+        return ""
+    claude_home = claude_home or resolve_claude_home()
+    paths = transcripts_for(claude_home, project_path)
+    if not paths:
+        return ""
+    newest = max(paths, key=lambda p: p.stat().st_mtime)
+    return _session_id_of(newest) or newest.stem

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1521,6 +1521,24 @@ class ConductorService:
     # snapping at each advance.
     _TYPICAL_S_FALLBACK = 900.0  # 15 min — positive default when no history
 
+    def _project_source_path(self) -> str:
+        """Resolve this project's source tree from the scores.db location
+        (.../projects/<project_id>/scores.db) so phase_progress can read the
+        live transcript on disk. Cached; '' when not in folder mode."""
+        cached = getattr(self, "_src_path_cache", None)
+        if cached is not None:
+            return cached
+        src = ""
+        try:
+            from pathlib import Path
+            from prism_service.services.claude_transcripts import _project_source_path
+            project_id = Path(self._scores_db).parent.name
+            src = _project_source_path(project_id) or ""
+        except Exception:
+            src = ""
+        self._src_path_cache = src
+        return src
+
     @staticmethod
     def _parse_iso(ts: str) -> Optional[float]:
         """ISO-8601 timestamp -> epoch seconds; None if unparseable."""
@@ -1618,16 +1636,31 @@ class ConductorService:
             pct = min(0.95, ratio)
             basis = "time"
 
-        # Real token effort: sum tokens across the sessions linked to this task
-        # (the importer populates sessions.tokens_used). Per-message timestamps
-        # aren't imported, so this is task-TOTAL spend, not a per-step slice —
-        # but it's a real, growing number the bar surfaces as "N tok".
+        # Real token effort, summed across the sessions linked to this task.
+        # session_outcomes.tokens_used is only written once a session is
+        # imported (post-hoc), so an IN-PROGRESS task reads 0 there — we also
+        # read the LIVE transcript on disk and take the larger of the two, so
+        # a running session ("seeing ourselves") shows a real, growing number.
         tokens = 0
         if self._task_svc is not None:
             try:
+                source_path = self._project_source_path()
+                live_fn = None
+                if source_path:
+                    from prism_service.services.claude_transcripts import (
+                        live_tokens_for_session as live_fn,
+                    )
                 for s in self._task_svc.sessions_for_task(task_id):
+                    sid = s.get("session_id") if isinstance(s, dict) else getattr(s, "session_id", "")
                     used = s.get("tokens_used") if isinstance(s, dict) else getattr(s, "tokens_used", 0)
-                    tokens += int(used or 0)
+                    outcome_tok = int(used or 0)
+                    live_tok = 0
+                    if live_fn and sid:
+                        try:
+                            live_tok = int(live_fn(sid, source_path) or 0)
+                        except Exception:
+                            live_tok = 0
+                    tokens += max(outcome_tok, live_tok)
             except Exception:
                 tokens = 0
 

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -7,6 +7,9 @@
 // task is actively in progress. Completed steps solid (emerald); future muted.
 import { useEffect, useRef, useState } from "react";
 import { motion, useMotionValue, useTransform, useAnimationFrame } from "motion/react";
+// useSpring tweens the current-step fill between 5s polls; its config keys off
+// `reduced` so prefers-reduced-motion collapses the tween (see segSpring below).
+import { useSpring } from "motion/react";
 import { WORKFLOW_STEPS_ORDERED, stepLabel } from "@/lib/workflowChips";
 
 export type PhaseProgress = {
@@ -77,8 +80,15 @@ export default function SdlcProgress({
   const [liveLabel, setLiveLabel] = useState(overallSeed * 100);
   const [liveInStep, setLiveInStep] = useState(phase?.in_step_s ?? 0);
   // current-SEGMENT fill (within the active step) drives just that segment.
+  // The animation frame writes the raw live fraction to `segFill`; a spring
+  // tweens the DISPLAYED value smoothly between the 5s poll snapshots instead
+  // of hard-jumping. Under prefers-reduced-motion the spring collapses to a
+  // stiff, damping-pinned pass-through so the bar tracks without easing.
   const segFill = useMotionValue(seed);
-  const segWidth = useTransform(segFill, (v) => `${(v * 100).toFixed(3)}%`);
+  const segSpring = useSpring(segFill, reduced
+    ? { stiffness: 1000, damping: 100, restDelta: 0.001 }
+    : { stiffness: 90, damping: 22, restDelta: 0.0005 });
+  const segWidth = useTransform(segSpring, (v) => `${(Math.max(0, Math.min(1, v)) * 100).toFixed(3)}%`);
 
   const anchor = useRef({ t0: 0 });
   useEffect(() => {

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -114,7 +114,7 @@ export default function ConductorPage() {
             return (
               <div
                 key={s.id}
-                className="grid grid-cols-[14rem_1fr] gap-4 items-center py-3"
+                className="grid grid-cols-[14rem_1fr] gap-4 items-center py-4"
               >
                 <div className="flex items-center gap-2">
                   <span
@@ -135,7 +135,7 @@ export default function ConductorPage() {
                   {tasksHere.length === 0 ? (
                     <span className="text-[11px] opacity-30 italic">empty</span>
                   ) : (
-                    <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">
+                    <div className="grid grid-cols-[repeat(auto-fill,minmax(250px,1fr))] gap-3">
                       {tasksHere.map((t) => (
                         <TaskTile key={t.id} task={t} reduced={reduced} onClick={() =>
                           navigate(`/tasks/${t.id}`, { state: { from: "/conductor" } })
@@ -181,12 +181,17 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
   const shortId = task.id.slice(0, 8);
   const owner = task.assigned_agent || "unassigned";
   const tags = (task.tags ?? []).slice(0, 3);
-  const title = `${task.title}\nid: ${task.id}${showGate ? `\ngate: ${gateLabel(gate as any)}${task.gate_reason ? "\n" + task.gate_reason : ""}` : ""}`;
+  const gateReason = task.gate_reason?.trim() || "";
+  const [showReason, setShowReason] = useState(false);
+  const title = `${task.title}\nid: ${task.id}`;
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onClick(); } }}
       title={title}
-      className="text-left rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)] p-3 flex flex-col gap-1.5 transition-colors"
+      className="text-left rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] hover:border-[color:var(--border-strong)] p-3 flex flex-col gap-1.5 transition-colors cursor-pointer"
     >
       <div className="text-[13px] leading-snug font-medium line-clamp-2 text-[color:var(--text-primary)]">
         {task.title}
@@ -197,6 +202,22 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
           <TileBadge tone={gateTone}>{gateLabel(gate as any)}</TileBadge>
         )}
       </div>
+      {gateReason && (
+        <div className="text-[11px] text-[color:var(--text-muted)]">
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); setShowReason((v) => !v); }}
+            className="font-mono uppercase tracking-wider text-[10px] opacity-70 hover:opacity-100 transition-opacity"
+          >
+            {showReason ? "▾" : "▸"} gate reason
+          </button>
+          {showReason && (
+            <p className="mt-1 leading-snug text-[color:var(--text-secondary)] whitespace-pre-wrap break-words">
+              {gateReason}
+            </p>
+          )}
+        </div>
+      )}
       <div className="text-[11px] font-mono text-[color:var(--text-muted)]">
         p{priority} · {age} · id {shortId}
       </div>
@@ -216,11 +237,14 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
         </div>
       )}
       {/* Real-time SDLC phase progress — bar fills the current step from the
-          server phase_progress estimate (time / children / token effort). */}
-      <div className="mt-2 pt-2.5 border-t border-[color:var(--border-default)]/60">
+          server phase_progress estimate (time / children / token effort).
+          Its own labelled section so the progress reads at a glance instead of
+          competing with the meta/owner lines above it. */}
+      <div className="mt-auto pt-2.5 border-t border-[color:var(--border-default)]/60 flex flex-col gap-1.5">
+        <span className="text-[9px] uppercase tracking-[0.12em] font-mono text-[color:var(--text-muted)] opacity-70">SDLC</span>
         <SdlcProgress step={task.workflow_step} phase={task.phase_progress} status={task.status} reduced={reduced} />
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/services/prism-service/tests/integration/test_conductor_live_tokens.py
+++ b/services/prism-service/tests/integration/test_conductor_live_tokens.py
@@ -1,0 +1,138 @@
+"""Regression — conductor tiles must show LIVE token effort, not 0 tok
+(v6.3.1).
+
+Two bugs left the SDLC progress bar stuck at "0 tok" for any in-progress task:
+
+  Bug 1 (sourcing) — phase_progress only read the post-hoc session_outcomes
+    table, which is empty until a session is imported. An IN-PROGRESS task
+    therefore always read 0. Fix: also sum output_tokens off the live
+    transcript JSONL on disk (parent + nested workflow-subagent transcripts)
+    and take the max.
+  Bug 2 (linking) — conductor_advance/gate fell back to the MCP request_id
+    when no session_id was passed; that phantom maps to no transcript and no
+    token row, so workflow-driven tasks linked dead sessions. Fix:
+    current_session_id() resolves the real active transcript session.
+
+These pin the disk-read seam end-to-end with a fabricated ~/.claude tree.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _write_jsonl(path: Path, session_id: str, out_tokens: list[int]) -> None:
+    """Emit a minimal transcript: one assistant event per output-token count."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for n in out_tokens:
+        lines.append(json.dumps({
+            "sessionId": session_id,
+            "message": {"role": "assistant", "usage": {"output_tokens": n}},
+        }))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _fake_tree(tmp_path: Path):
+    """Build claude_home/projects/<slug>/ with a parent transcript + one nested
+    workflow-subagent transcript. Returns (claude_home, source_path, sess)."""
+    from prism_service.services.claude_transcripts import path_to_slug
+
+    source_path = str(tmp_path / "src" / "proj")
+    claude_home = tmp_path / "claude"
+    slug = path_to_slug(source_path)
+    proj = claude_home / "projects" / slug
+    sess = "11111111-2222-3333-4444-555555555555"
+    _write_jsonl(proj / f"{sess}.jsonl", sess, [100, 200])  # parent = 300
+    # subagent transcript nested under the session dir carries the parent id
+    _write_jsonl(
+        proj / sess / "subagents" / "wf_x" / "agent-abc.jsonl", sess, [50, 75],
+    )  # subagent = 125
+    return claude_home, source_path, sess
+
+
+# ----------------------------------------------------------------------
+# Bug 1 — live transcript token read (parent + subagents), with cache
+# ----------------------------------------------------------------------
+
+def test_live_tokens_sums_parent_and_subagent_transcripts(tmp_path):
+    from prism_service.services import claude_transcripts as ct
+
+    claude_home, source_path, sess = _fake_tree(tmp_path)
+    total = ct.live_tokens_for_session(sess, source_path, claude_home=claude_home)
+    assert total == 425, f"expected 300 parent + 125 subagent = 425, got {total}"
+
+
+def test_live_tokens_zero_for_unknown_session(tmp_path):
+    from prism_service.services import claude_transcripts as ct
+
+    claude_home, source_path, _ = _fake_tree(tmp_path)
+    # A phantom id (the old request_id symptom) resolves to no transcript.
+    assert ct.live_tokens_for_session(
+        "deadbeef" * 4, source_path, claude_home=claude_home,
+    ) == 0
+
+
+# ----------------------------------------------------------------------
+# Bug 2 — current_session_id resolves the real active transcript session
+# ----------------------------------------------------------------------
+
+def test_current_session_id_returns_real_session(tmp_path):
+    from prism_service.services import claude_transcripts as ct
+
+    claude_home, source_path, sess = _fake_tree(tmp_path)
+    assert ct.current_session_id(source_path, claude_home=claude_home) == sess
+
+
+# ----------------------------------------------------------------------
+# End-to-end — phase_progress reports live tokens with NO outcomes row
+# (the exact in-progress state that previously read 0 tok)
+# ----------------------------------------------------------------------
+
+def test_phase_progress_live_tokens_without_outcomes_row(tmp_path, monkeypatch):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+    from prism_service.services import claude_transcripts as ct
+
+    import sqlite3
+
+    claude_home, source_path, sess = _fake_tree(tmp_path)
+    scores_db = str(tmp_path / "scores.db")
+    # session_outcomes is normally created by brain_engine; materialize it
+    # EMPTY here to mirror an in-progress session the importer hasn't written
+    # a row for yet (the exact 0-tok scenario this fix targets).
+    conn = sqlite3.connect(scores_db)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS session_outcomes ("
+        "session_id TEXT PRIMARY KEY, duration_s INTEGER, tokens_used INTEGER, "
+        "files_read INTEGER, files_modified INTEGER, skills_invoked INTEGER, "
+        "timestamp TEXT)"
+    )
+    conn.commit()
+    conn.close()
+    task_svc = TaskService(str(tmp_path / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    # Source path normally comes off understand_state; pin it for the test.
+    monkeypatch.setattr(cond, "_project_source_path", lambda: source_path)
+    monkeypatch.setattr(
+        ct, "resolve_claude_home", lambda: claude_home,
+    )
+
+    t = task_svc.create(title="in-progress, no outcome row")
+    cond.advance_task(t.id)
+    # Link the REAL session — but DO NOT write a session_outcomes row, mirroring
+    # an in-progress task the importer hasn't seen yet.
+    task_svc.link_session(t.id, sess)
+
+    pp = cond.phase_progress(t.id)
+    assert pp["tokens_since_step"] == 425, (
+        "in-progress task must report live transcript tokens (425) even with "
+        f"no session_outcomes row; got {pp['tokens_since_step']}"
+    )

--- a/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
+++ b/services/prism-service/tests/unit/test_animate_conductor_tasks_ui.py
@@ -155,6 +155,11 @@ def test_index_css_appends_prefers_reduced_motion_reset_after_line_110():
 # ---------------------------------------------------------------------------
 
 def test_prism_version_bumped_to_6_3_0():
+    # The animation feature shipped AT 6.3.0; assert a floor (>= 6.3.0) rather
+    # than exact equality so later patch bumps (e.g. the 6.3.1 /conductor
+    # cleanup) don't regress this guard. Exact-version `==` asserts are an
+    # anti-pattern — they break on every legitimate patch.
     from prism_service.__version__ import PRISM_VERSION
-    assert PRISM_VERSION == "6.3.0", \
-        "PRISM_VERSION must be bumped to 6.3.0 for the conductor-animation feature"
+    parts = tuple(int(x) for x in PRISM_VERSION.split("."))
+    assert parts >= (6, 3, 0), \
+        "PRISM_VERSION must be >= 6.3.0 for the conductor-animation feature"

--- a/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
+++ b/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
@@ -1,0 +1,151 @@
+"""UI contract tests for "Clean up /conductor page to support the new
+animated SDLC tasks" (task fde3c08e).
+
+The PRISM SPA has NO JS test runner, so UI-FIRST acceptance criteria are
+pinned by asserting the ACTUAL web source (TSX) — the same pattern as
+tests/unit/test_animate_conductor_tasks_ui.py and test_explore_narrative_ui.py.
+
+These assert the REAL seams the cleanup must land on the LIVE components:
+the swimlane lane/tile spacing actually opens up now that each tile embeds
+the ~2x-height animated SdlcProgress bar; the TaskTile information hierarchy
+gains an explicit progress-section label so it reads at a glance; gate-reason
+receipt text becomes click-to-expand (progressive disclosure) instead of a
+tooltip-only / inline wall; the current-step fill tweens SMOOTHLY between the
+5s polls via a spring (not a hard jump) AND that tween is suppressed under
+reduced-motion; and the version is patch-bumped.
+
+ALL of these FAIL against the current source (lanes are py-3, the tile grid
+is minmax(220px) gap-2, the progress section has no label, gate_reason lives
+only in the button `title` tooltip, SdlcProgress hard-sets segFill with no
+spring, and PRISM_VERSION is 6.3.0). They go green only when the cleanup is
+wired into ConductorPage.tsx + SdlcProgress.tsx.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SRC = _HERE.parent.parent.parent / "prism_service" / "web" / "src"
+_CONDUCTOR = _SRC / "pages" / "ConductorPage.tsx"
+_PROGRESS = _SRC / "components" / "conductor" / "SdlcProgress.tsx"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Lane / tile spacing opens up for the embedded animated progress bar
+# ---------------------------------------------------------------------------
+
+def test_swimlane_rows_get_more_vertical_breathing_room():
+    src = _read(_CONDUCTOR)
+    # The lane row is currently cramped at py-3; with the ~2x progress bar in
+    # each tile the lanes must open up. Pin a larger vertical lane rhythm.
+    assert "py-3\n" not in src and "py-3\"" not in src, \
+        "swimlane rows must no longer use the cramped py-3 vertical padding"
+    assert ("py-4" in src or "py-5" in src), \
+        "swimlane rows must adopt a roomier vertical padding (py-4/py-5)"
+
+
+def test_tile_autofill_grid_widens_and_gaps_for_progress_bar():
+    src = _read(_CONDUCTOR)
+    # 220px tiles are too narrow once the multi-segment SDLC bar + caption sit
+    # inside; widen the auto-fill min and open the inter-tile gap.
+    assert "minmax(220px" not in src, \
+        "tile auto-fill min must widen past 220px for the progress bar"
+    assert ("minmax(240px" in src or "minmax(250px" in src
+            or "minmax(260px" in src), \
+        "tile auto-fill min must widen to >=240px"
+    # The tile grid gap was gap-2; open it so tiles don't feel cluttered.
+    assert "minmax(" in src
+    grid_line = next(ln for ln in src.splitlines() if "auto-fill,minmax(" in ln)
+    assert "gap-2" not in grid_line, \
+        "the tile auto-fill grid must open past gap-2"
+    assert "gap-3" in grid_line or "gap-4" in grid_line, \
+        "the tile auto-fill grid must use gap-3/gap-4"
+
+
+# ---------------------------------------------------------------------------
+# TaskTile information hierarchy: the SDLC progress block reads as its own
+# labelled section, not an unmarked strip competing with the meta lines.
+# ---------------------------------------------------------------------------
+
+def test_tile_progress_section_has_an_explicit_label():
+    src = _read(_CONDUCTOR)
+    # Scope to the TaskTile function so the page-level "SDLC swimlanes"
+    # SectionLabel can't satisfy this. The tile progress block is currently
+    # just a top-bordered <div> with no rendered label, so it competes with
+    # the owner/meta lines. Render an at-a-glance label as a JSX text node.
+    tile = src[src.index("function TaskTile"):]
+    assert (">SDLC<" in tile or ">SDLC " in tile or ">SDLC\n" in tile
+            or "SDLC progress<" in tile or "progress</" in tile.lower()), \
+        "the TaskTile progress section must RENDER an explicit 'SDLC'/" \
+        "'progress' label (JSX text node, not just a comment) so the " \
+        "information hierarchy reads at a glance"
+
+
+# ---------------------------------------------------------------------------
+# Progressive disclosure: gate-reason receipt text becomes click-to-expand,
+# not a tooltip-only string / inline wall.
+# ---------------------------------------------------------------------------
+
+def test_gate_reason_is_progressive_disclosure_not_tooltip_only():
+    src = _read(_CONDUCTOR)
+    # Today gate_reason rides only inside the button `title` tooltip string.
+    # Surface it as a real click-to-expand disclosure in the tile.
+    assert "gate_reason" in src, "the tile must read task.gate_reason"
+    # The TaskTile function (today) has no local expand state and no
+    # <details> element — gate_reason only rides in the button `title`
+    # tooltip. Require a genuine in-tile click-to-expand disclosure.
+    assert ("<details" in src or "<summary" in src or "setExpanded" in src
+            or "showReason" in src or "setShowReason" in src), \
+        "gate_reason detail must be a click-to-expand disclosure (details/" \
+        "summary or a local expand state in the tile), not tooltip-only"
+
+
+# ---------------------------------------------------------------------------
+# Current-step fill tweens SMOOTHLY between the 5s polls (spring), and the
+# tween is suppressed under reduced-motion.
+# ---------------------------------------------------------------------------
+
+def test_segment_fill_tweens_smoothly_via_spring():
+    src = _read(_PROGRESS)
+    # The current-step fill must ease between poll snapshots instead of hard
+    # jumping; pin a motion spring/tween on the segment fill.
+    assert "useSpring" in src, \
+        "the current-step fill must tween via useSpring between 5s polls"
+
+
+def test_segment_tween_is_suppressed_under_reduced_motion():
+    src = _read(_PROGRESS)
+    # The spring/tween that drives the segment fill must collapse when the
+    # caller threads reduced=true (reduced-motion honored end-to-end).
+    assert "useSpring" in src
+    spring_idx = src.index("useSpring")
+    window = src[spring_idx: spring_idx + 240]
+    assert "reduced" in window, \
+        "the segment-fill spring must reference `reduced` so the tween is " \
+        "suppressed under prefers-reduced-motion"
+
+
+# ---------------------------------------------------------------------------
+# Reduced-motion stays threaded page -> tile -> SdlcProgress (regression guard)
+# ---------------------------------------------------------------------------
+
+def test_reduced_motion_stays_threaded_end_to_end():
+    src = _read(_CONDUCTOR)
+    assert "useReducedMotion" in src, "page must read useReducedMotion()"
+    assert "reduced={reduced}" in src, \
+        "reduced must stay threaded page -> TaskTile -> SdlcProgress"
+
+
+# ---------------------------------------------------------------------------
+# Version patch-bump 6.3.0 -> 6.3.1
+# ---------------------------------------------------------------------------
+
+def test_prism_version_patch_bumped_from_6_3_0():
+    from prism_service.__version__ import PRISM_VERSION
+    assert PRISM_VERSION == "6.3.1", \
+        "PRISM_VERSION must be patch-bumped to 6.3.1 for the /conductor cleanup"

--- a/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
+++ b/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
@@ -142,10 +142,13 @@ def test_reduced_motion_stays_threaded_end_to_end():
 
 
 # ---------------------------------------------------------------------------
-# Version patch-bump 6.3.0 -> 6.3.1
+# Version patch-bump — the /conductor cleanup landed in 6.3.1; the live-token
+# fix consolidated onto the same branch as 6.3.2. Assert a >= 6.3.1 floor so
+# the bump is verified without re-breaking on every subsequent patch.
 # ---------------------------------------------------------------------------
 
 def test_prism_version_patch_bumped_from_6_3_0():
     from prism_service.__version__ import PRISM_VERSION
-    assert PRISM_VERSION == "6.3.1", \
-        "PRISM_VERSION must be patch-bumped to 6.3.1 for the /conductor cleanup"
+    parts = tuple(int(x) for x in PRISM_VERSION.split("."))
+    assert parts >= (6, 3, 1), \
+        f"PRISM_VERSION must be >= 6.3.1 for the /conductor cleanup; got {PRISM_VERSION}"


### PR DESCRIPTION
Two consolidated commits for the **conductor animated SDLC tasks** workstream.

## v6.3.1 — UI cleanup (`feat/animate-conductor-tasks` follow-up)
Roomier swimlane rows (py-3→py-4) and a wider/looser lane→tile grid (minmax 220→250px, gap-2→gap-3) so each tile's embedded ~2x-height `SdlcProgress` bar reads uncluttered. `TaskTile` gains a coherent hierarchy: explicit `SDLC` SectionLabel on the progress block + click-to-expand progressive disclosure of `gate_reason`. `SdlcProgress` current-step fill now tweens smoothly between the 5s polls via `useSpring` (suppressed under reduced-motion); `reduced` stays threaded page→TaskTile→SdlcProgress. UI-only.

## v6.3.2 — live token effort (fixes "0 tok")
Conductor tiles showed `0 tok` for actively-running tasks. Two root causes:

1. **Sourcing** — `phase_progress` only read the post-hoc `session_outcomes` table, empty until a session is imported → an in-progress task structurally always read 0. Now also sums `output_tokens` straight off the live transcript JSONL on disk (parent + nested workflow-subagent transcripts) and takes the max. New `claude_transcripts.live_tokens_for_session()` (mtime/size-cached so the 5s poll never re-reads unchanged transcripts) + `current_session_id()`.
2. **Linking** — `conductor_advance`/`conductor_gate` fell back to the MCP `request_id` when no `session_id` was passed — a phantom that maps to no transcript and no token row, so workflow-driven tasks linked dead sessions. New `_resolve_link_session_id()` resolves the real active transcript session; `request_id` stays last-resort only.

## Tests
- New `tests/integration/test_conductor_live_tokens.py` (4): live read sums parent+subagent transcripts, phantom id → 0, `current_session_id` resolves the real session, and e2e `phase_progress` reports live tokens with NO `session_outcomes` row.
- Relaxed the 6.3.1 version-pin unit test to a `>= 6.3.1` floor.

## Verification (live, against the running dev daemon)
- tsc clean, unit suite green (646), SPA build clean.
- `/api/conductor/state` `tokens_since_step`: `0 → 252,801` (live, growing).
- Screenshot: tile renders `REVIEW PREVIOUS NOTES · 12.13% · 6:02 · 287k tok · pending`.
- Link audit: advance with no session_id linked the real session, not a phantom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)