### PR TITLE
fix(v6.3.4): auto-update flips running version (5th recurrence) + pidfile survives re-exec

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.3"
+PRISM_VERSION = "6.3.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.4: Auto-update restart (v6.3.3) must not orphan the pidfile. The "
+    "main-thread re-exec branch in main.py used to call _own_pidfile_cleanup() "
+    "before perform_restart(), but os.execv replaces the process image IN PLACE "
+    "(same PID) and the re-exec'd `-m prism_service.main` never re-writes the "
+    "pidfile (only `prism start` does) — so clearing it left a live, upgraded "
+    "daemon (same PID) with NO pidfile, and `prism status`/`prism stop` reported "
+    "it as not running. Fix: do not unlink the pidfile before the in-place "
+    "re-exec (it stays valid across execv; atexit cleanup does not fire on "
+    "execv). Regression tests: perform_restart leaves the pidfile, and the "
+    "main.py restart branch contains no pidfile cleanup before perform_restart. "
     "v6.3.3: Auto-update finally FLIPS the running version (5th recurrence). The "
     "poller downloaded the wheel + pip-installed it but _DEFER_RESTART=True meant "
     "nothing ever restarted, so the live daemon served the OLD version forever. "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,28 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.2"
+PRISM_VERSION = "6.3.3"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.3: Auto-update finally FLIPS the running version (5th recurrence). The "
+    "poller downloaded the wheel + pip-installed it but _DEFER_RESTART=True meant "
+    "nothing ever restarted, so the live daemon served the OLD version forever. "
+    "New request/perform restart SEAM in services/auto_updater.py: after a "
+    "successful apply the DAEMON thread only calls request_restart() (sets a flag "
+    "— NEVER os.execv/execvp, so the #66 silent-death guard stays intact); the "
+    "MAIN thread (main.py, now an explicit uvicorn Config+Server) runs a watcher "
+    "that flips server.should_exit on restart_requested(), drains + closes the "
+    "sockets, then os.execv's `python -m prism_service.main` from the main thread "
+    "via perform_restart() — so the served version flips with no manual step, "
+    "supervisor-agnostic (bare daemon re-execs in place; an external supervisor "
+    "respawns on the clean exit). _DEFER_RESTART now False; restart_auto is "
+    "truthful (= not _DEFER_RESTART = True). Dev-mode/docker/AUTO_UPDATE=off/"
+    "INTERVAL=0 guards preserved. Stale docstrings corrected (api/update.py "
+    "apply() no longer claims 'Linux/Mac self-execs after success'; auto_updater "
+    "module/comment docstrings describe the real main-thread re-exec). Tests: "
+    "tests/integration/test_auto_update_restart_handoff.py (seam + main-thread "
+    "exec + restart_auto) + updated tests/unit/test_auto_updater.py. "
     "v6.3.2: Conductor tiles now show LIVE token effort instead of 0 tok. Two "
     "bugs fixed: (1) phase_progress only read the post-hoc session_outcomes "
     "table, which is empty for an in-progress task — it now also sums "

--- a/services/prism-service/prism_service/api/update.py
+++ b/services/prism-service/prism_service/api/update.py
@@ -34,9 +34,11 @@ def check() -> dict:
 def apply() -> dict:
     """Download the latest wheel and pip-install it. Returns a result
     dict — caller (SPA) checks `ok` to decide whether to prompt for a
-    restart. On Linux/Mac the auto-updater self-execs after success;
-    on Windows it surfaces `restart_required=True` and the user / CLI
-    restarts manually."""
+    restart. On success the apply sets `restart_required=True` and the
+    auto-updater requests a restart that the MAIN thread performs
+    (graceful uvicorn stop, then os.execv) so the served version flips on
+    its own — supervisor-agnostic, no manual step. The result's
+    `restart_auto` reflects whether that automatic restart will fire."""
     result = auto_updater.apply_update()
     if not result.get("ok"):
         # 409 = "not ready / no update / already up to date" — let the

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -464,10 +464,46 @@ if __name__ == "__main__":
                 signal.signal(_sig, _on_signal)
             except (ValueError, OSError):
                 pass  # not in main thread / unsupported on this platform
+    # Build an explicit Config+Server (instead of uvicorn.run) so we hold
+    # the Server handle. The auto-updater's daemon thread can then REQUEST
+    # a restart (a flag, never an in-thread execv — #66), and a watcher
+    # flips server.should_exit so uvicorn drains the loop + closes sockets.
+    # Once .run() returns (sockets fully closed) we os.execv from THIS main
+    # thread to flip the served version. Supervisor-agnostic: bare daemon
+    # re-execs in place; an external supervisor respawns on the clean exit.
+    from prism_service.services import auto_updater as _au
+
+    _config = uvicorn.Config(app, host="0.0.0.0", port=UI_PORT)
+    _server = uvicorn.Server(_config)
+
+    def _restart_watcher() -> None:
+        # Poll the daemon-thread-set flag; when set, ask uvicorn to drain
+        # and stop. The actual os.execv happens on the main thread AFTER
+        # _server.run() returns, so live sockets are closed first.
+        while not _server.should_exit:
+            if _au.restart_requested():
+                _log.info("auto-update restart requested; draining uvicorn")
+                _server.should_exit = True
+                return
+            time.sleep(2.0)
+
+    threading.Thread(
+        target=_restart_watcher, daemon=True, name="prism-restart-watcher",
+    ).start()
+
     try:
-        uvicorn.run(app, host="0.0.0.0", port=UI_PORT)
+        _server.run()
     except Exception:
         # A bind failure or uvicorn-internal crash used to leave no
         # record (issue #66). Guarantee a traceback in prism.log.
         _log.critical("uvicorn exited abnormally", exc_info=True)
         raise
+
+    # Reached only after a graceful stop. If the stop was triggered by an
+    # auto-update restart request, re-exec the upgraded image from the MAIN
+    # thread now that the sockets are closed (#66-safe). Otherwise this is a
+    # normal shutdown and we just fall through to exit.
+    if _au.restart_requested():
+        _own_pidfile_cleanup()
+        _log.info("uvicorn stopped; performing main-thread re-exec (auto-update)")
+        _au.perform_restart()

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -504,6 +504,13 @@ if __name__ == "__main__":
     # thread now that the sockets are closed (#66-safe). Otherwise this is a
     # normal shutdown and we just fall through to exit.
     if _au.restart_requested():
-        _own_pidfile_cleanup()
+        # Do NOT unlink the pidfile here: os.execv replaces the process
+        # image IN PLACE (same PID, no fork), so the pidfile that names
+        # this PID stays valid across the re-exec — and the re-exec'd
+        # `-m prism_service.main` never re-writes it (only `prism start`
+        # does). Clearing it would leave a live daemon (same PID, new
+        # version) with no pidfile, so `prism status`/`prism stop` would
+        # report it as not running. atexit's cleanup does not fire on
+        # os.execv either, so the file correctly survives the flip.
         _log.info("uvicorn stopped; performing main-thread re-exec (auto-update)")
         _au.perform_restart()

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -17,11 +17,17 @@ Design:
        1. Downloads the wheel to a temp file
        2. Calls `pip install --upgrade <wheel-path>` in the same
           interpreter (sys.executable)
-       3. Sets restart_required=True and surfaces it via
-          /api/update/status. It NEVER self-restarts in-place — doing
-          that via os.execvp from a daemon thread dropped the live
-          sockets with no traceback (#66). The new wheel takes effect on
-          the next managed/manual restart.
+       3. Sets restart_required=True AND *requests* a restart of the
+          live process so the served version actually flips (task
+          bc9b1a88, 5th recurrence). The request/perform seam keeps the
+          #66 guard intact: the daemon thread only sets a flag
+          (request_restart) — it NEVER calls os.execv/os.execvp itself.
+          The MAIN thread (which owns uvicorn) observes the flag,
+          gracefully stops the server (drains the loop / closes
+          sockets), and only THEN os.execv's a fresh process image
+          (perform_restart). #66's silent death was an in-thread execvp
+          from this daemon thread dropping live sockets with no
+          traceback — that path stays gone.
   * Service status (current version, latest known, last check, last
     error) is exposed via /api/update-status for the SPA's
     Settings → Service card.
@@ -30,10 +36,10 @@ Honest scope limits:
   * Docker installs ignore this entirely (the running container has no
     pip to upgrade against itself, and Watchtower handles their case).
     The updater short-circuits if it detects /.dockerenv.
-  * Linux/Mac get clean in-place upgrade. Windows pip-upgrade-while-
-    running has historically been flaky (pip can't replace a running
-    .exe); on Windows we write the sentinel and surface "restart to
-    apply" in the UI instead of trying the auto-restart.
+  * The restart is supervisor-agnostic: the main-thread os.execv
+    re-execs in place under a bare `prism start --daemon` (the pidfile
+    manager does not respawn), and a clean exit lets an external
+    supervisor respawn — both land on the new version.
 """
 
 from __future__ import annotations
@@ -73,13 +79,81 @@ _POLL_INTERVAL_S = int(os.environ.get("PRISM_AUTO_UPDATE_INTERVAL", "1800"))
 _AUTO_APPLY = os.environ.get("PRISM_AUTO_UPDATE", "on").lower() in (
     "on", "true", "1", "yes",
 )
-# Issue #66: NEVER self-restart in-place. _self_restart() used os.execvp
-# from the auto-updater DAEMON thread, replacing the process image (same
-# PID, no traceback, sockets dropped) — the exact silent-death signature
-# in the report. Defer the restart on ALL platforms; the new wheel takes
-# effect on the next managed/manual restart, and restart_required is
-# surfaced via /api/update/status.
-_DEFER_RESTART = True
+# Issue #66: NEVER os.execvp/os.execv from THIS daemon thread. The old
+# _self_restart() did exactly that, replacing the process image in place
+# (same PID, no traceback, sockets dropped) — the silent-death signature.
+# The safe seam (task bc9b1a88): the daemon thread only REQUESTS a restart
+# (request_restart -> sets _restart_requested), and the MAIN thread that
+# owns uvicorn observes it, gracefully stops the server, and only THEN
+# calls perform_restart() (os.execv). So the restart is no longer deferred
+# forever on all platforms — it is handed to the main thread.
+_DEFER_RESTART = False
+
+# Main-thread restart handoff. The daemon thread sets this flag after a
+# successful apply; the uvicorn main thread polls restart_requested(),
+# drains + stops the server, then calls perform_restart(). _restart_lock
+# guards the flag; never call os.execv off the main thread.
+_restart_requested_flag = False
+_restart_lock = threading.RLock()
+
+
+def request_restart() -> None:
+    """Daemon-thread-safe: ASK the main thread to restart the process.
+
+    This NEVER execs — it only flips a flag. The main thread polls
+    restart_requested() and performs the real os.execv via
+    perform_restart(). Keeping the exec off this thread is the #66 guard.
+    """
+    global _restart_requested_flag
+    with _restart_lock:
+        _restart_requested_flag = True
+
+
+def restart_requested() -> bool:
+    """True once a successful apply has requested a main-thread restart."""
+    with _restart_lock:
+        return _restart_requested_flag
+
+
+def clear_restart_request() -> None:
+    """Reset the restart request (used by tests and after a perform)."""
+    global _restart_requested_flag
+    with _restart_lock:
+        _restart_requested_flag = False
+
+
+def perform_restart(server=None, drain_timeout_s: float = 10.0) -> None:
+    """Re-exec the current process image. MAIN-THREAD ONLY.
+
+    Drains the running uvicorn server FIRST (close sockets, #66), then
+    re-execs `sys.executable -m prism_service.main` so the freshly-imported
+    interpreter picks up the upgraded wheel and the served version flips.
+
+    If `server` is passed, it is gracefully signalled to stop before the
+    exec — `server.should_exit = True` (uvicorn drains its loop) and, if a
+    `stop()` method exists, that is invoked too. When main.py already ran
+    the server to completion before calling this, pass server=None.
+
+    Supervisor-agnostic: a bare daemon re-execs in place; under an external
+    supervisor the clean exit triggers a respawn. Guarded by _DEFER_RESTART
+    so an operator can hard-disable the exec.
+    """
+    if _DEFER_RESTART:
+        return
+    if server is not None:
+        # Signal a graceful drain so listening sockets close before exec.
+        try:
+            server.should_exit = True
+        except Exception:
+            pass
+        stop = getattr(server, "stop", None)
+        if callable(stop):
+            try:
+                stop()
+            except Exception:
+                pass
+    argv = [sys.executable, "-m", "prism_service.main"]
+    os.execv(sys.executable, argv)
 
 
 def _dev_mode() -> bool:
@@ -243,9 +317,11 @@ def apply_update() -> dict:
       * no update available yet (call check_for_update first)
       * no .whl asset on the latest release
 
-    On success, sets restart_required=True. The actual restart is the
-    caller's responsibility — see daemon.request_restart() — because
-    we can't safely os.execvp a uvicorn worker thread from inside it.
+    On success, sets restart_required=True. It does NOT exec here — the
+    actual restart is performed from the MAIN thread (see
+    request_restart()/perform_restart()), because os.execv off a daemon
+    thread drops live sockets with no traceback (#66). _maybe_apply()
+    calls request_restart() after this returns ok.
     """
     import sys as _sys
 
@@ -423,15 +499,16 @@ def _maybe_apply() -> None:
         )
         return
     print(
-        f"[auto_updater] applied {target}; restart_required=True "
-        f"(restart the daemon to pick up the new wheel)",
+        f"[auto_updater] applied {target}; requesting main-thread restart "
+        f"to flip the served version",
         file=sys.stderr, flush=True,
     )
-    # Issue #66: we deliberately do NOT self-restart. The previous
-    # os.execvp(...) from this daemon thread replaced the process image
-    # in place with no traceback and dropped the live sockets — the
-    # silent-death root cause. restart_required is surfaced via
-    # /api/update/status; a managed/manual restart applies the wheel.
+    # Issue #66 guard: do NOT exec from THIS daemon thread (that dropped
+    # live sockets with no traceback). Only REQUEST the restart; the
+    # uvicorn main thread observes restart_requested(), gracefully stops
+    # the server, and then calls perform_restart() (os.execv) once the
+    # sockets are closed. This is what finally flips the served version.
+    request_restart()
 
 
 def start_auto_updater() -> None:

--- a/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
+++ b/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
@@ -219,3 +219,54 @@ def test_apply_update_restart_auto_is_true(monkeypatch):
     assert result["ok"] is True, result
     assert result["restart_auto"] is True, \
         "restart_auto must be True now that the restart happens automatically"
+
+
+# ---------------------------------------------------------------------------
+# Pidfile must SURVIVE the in-place re-exec. os.execv replaces the process
+# image with the SAME PID, so the pidfile that names this PID stays valid —
+# and the re-exec'd `-m prism_service.main` never re-writes it. If the
+# restart path unlinked the pidfile first, a live daemon (same PID, new
+# version) would be left with no pidfile and `prism status`/`prism stop`
+# would report it as not running — breaking the bare `prism start --daemon`
+# (pidfile manager) acceptance criterion.
+# ---------------------------------------------------------------------------
+
+def test_perform_restart_does_not_touch_pidfile(monkeypatch, tmp_path):
+    """perform_restart() must NOT unlink the pidfile — execv keeps the PID,
+    so the file stays valid across the flip."""
+    from prism_service.data_dir import pid_file
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    pf = pid_file()
+    pf.parent.mkdir(parents=True, exist_ok=True)
+    pf.write_text(str(__import__("os").getpid()), encoding="utf-8")
+
+    monkeypatch.setattr(au.os, "execv", lambda *a, **k: None)
+    _arm_update_available()
+    au.request_restart()
+    try:
+        au.perform_restart(server=None)
+    finally:
+        _reset_state()
+    assert pf.exists(), \
+        "perform_restart must leave the pidfile in place (execv keeps the PID)"
+
+
+def test_main_restart_branch_does_not_clear_pidfile():
+    """Regression: the main.py auto-update re-exec branch must NOT call
+    _own_pidfile_cleanup() before perform_restart(). execv preserves the PID,
+    so clearing the pidfile would orphan a live, upgraded daemon from the
+    pidfile manager. Asserted against the source so the contract can't silently
+    regress (the branch lives under `if __name__ == '__main__'`)."""
+    import inspect
+    from prism_service import main as main_mod
+
+    src = inspect.getsource(main_mod)
+    # Isolate the restart branch (after the 'performing main-thread re-exec'
+    # log line) and assert no pidfile cleanup precedes perform_restart there.
+    marker = "performing main-thread re-exec"
+    assert marker in src, "restart branch log marker missing"
+    branch = src[src.index("if _au.restart_requested():"):]
+    perform_idx = branch.index("perform_restart()")
+    before_perform = branch[:perform_idx]
+    assert "_own_pidfile_cleanup()" not in before_perform, \
+        "must NOT unlink the pidfile before the in-place execv re-exec"

--- a/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
+++ b/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
@@ -1,0 +1,221 @@
+"""Integration: the apply -> restart handoff actually FLIPS the running version.
+
+Task bc9b1a88 — "Auto-update must actually flip the running version" (5th
+recurrence). The defect: after a successful auto-apply the new wheel lands on
+disk but the live daemon keeps serving the OLD version forever, because the
+updater hard-defers the restart on all platforms (_DEFER_RESTART=True) and
+deliberately never restarts (auto_updater._maybe_apply comment "we deliberately
+do NOT self-restart").
+
+These tests pin the SAFE restart design the task mandates:
+
+  * After a successful apply, a RESTART REQUEST is raised that the MAIN thread
+    can observe (auto_updater.request_restart() / restart_requested()), NOT an
+    in-thread execvp from the auto-updater daemon thread (issue #66 guard
+    stays: the daemon thread must NEVER call os.execv / os.execvp).
+  * The main thread performs the restart via a graceful uvicorn stop followed
+    by os.execv — and ONLY from the main thread.
+  * The end-to-end effect is that the SERVED version flips: a simulated
+    apply -> restart handoff replaces the process such that /api/version would
+    report the NEW version with no manual intervention.
+  * apply_update().restart_auto truthfully reflects that an automatic restart
+    WILL happen (it is no longer hard-wired to False via `not _DEFER_RESTART`).
+
+They FAIL today (red) because none of request_restart / restart_requested /
+perform_restart exist, _DEFER_RESTART is True, and restart_auto is always False.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from prism_service.services import auto_updater as au
+
+
+def _arm_update_available():
+    with au._state_lock:
+        au._state.in_docker = False
+        au._state.update_available = True
+        au._state.asset_url = (
+            "https://example.com/prism_service-9.9.9-py3-none-any.whl"
+        )
+        au._state.latest_version = "9.9.9"
+        au._state.restart_required = False
+
+
+def _reset_state():
+    with au._state_lock:
+        au._state.in_docker = False
+        au._state.update_available = False
+        au._state.asset_url = None
+        au._state.latest_version = None
+        au._state.restart_required = False
+    # Clear any restart request raised during a test.
+    clear = getattr(au, "clear_restart_request", None)
+    if callable(clear):
+        clear()
+
+
+# ---------------------------------------------------------------------------
+# The restart-coordination seam must exist (main-thread handoff, not in-thread
+# execvp). These are the contract the main thread polls.
+# ---------------------------------------------------------------------------
+
+def test_restart_request_seam_exists():
+    """The updater must expose a way to REQUEST a restart (raise a flag) and a
+    way for the main thread to OBSERVE that request — the handoff that replaces
+    the unsafe in-thread execvp."""
+    assert hasattr(au, "request_restart"), \
+        "auto_updater must expose request_restart() for the main-thread handoff"
+    assert hasattr(au, "restart_requested"), \
+        "auto_updater must expose restart_requested() for the main thread to poll"
+
+
+def test_request_restart_sets_observable_flag():
+    """request_restart() (callable from the daemon thread) flips the flag the
+    main thread polls; it must NOT itself replace the process."""
+    _reset_state()
+    try:
+        assert au.restart_requested() is False
+        au.request_restart()
+        assert au.restart_requested() is True
+    finally:
+        _reset_state()
+
+
+def test_defer_restart_no_longer_hard_true():
+    """The whole bug: _DEFER_RESTART=True meant nothing ever restarted. The
+    safe design hands the restart to the main thread, so the all-platforms
+    hard-defer must be gone."""
+    assert getattr(au, "_DEFER_RESTART", False) is not True, \
+        "_DEFER_RESTART must no longer be hard-wired True — restart is handed "\
+        "to the main thread, not deferred forever"
+
+
+# ---------------------------------------------------------------------------
+# Issue #66 guard MUST survive: the auto-updater DAEMON thread never execvp's.
+# But after a successful apply it MUST raise a restart request.
+# ---------------------------------------------------------------------------
+
+def test_maybe_apply_requests_restart_without_self_exec(monkeypatch):
+    """apply -> restart handoff, asserted on the daemon thread:
+      (a) NO os.execv / os.execvp is invoked on the auto-updater thread (#66),
+      (b) a restart REQUEST is raised so the main thread can flip the version.
+    """
+    called = {"execvp": False, "execv": False}
+    monkeypatch.setattr(au.os, "execvp",
+                        lambda *a, **k: called.__setitem__("execvp", True))
+    monkeypatch.setattr(au.os, "execv",
+                        lambda *a, **k: called.__setitem__("execv", True))
+    monkeypatch.setattr(au, "_AUTO_APPLY", True)
+    monkeypatch.setattr(au, "apply_update",
+                        lambda: {"ok": True, "target_version": "9.9.9",
+                                 "restart_required": True, "restart_auto": True})
+    _arm_update_available()
+
+    # Run _maybe_apply on a NON-main (daemon) thread, mirroring production.
+    err = {}
+
+    def _runner():
+        try:
+            au._maybe_apply()
+        except Exception as e:  # pragma: no cover - surfaced via err
+            err["e"] = e
+
+    t = threading.Thread(target=_runner, name="prism-auto-updater", daemon=True)
+    t.start()
+    t.join(timeout=10)
+    try:
+        assert not err, f"_maybe_apply raised: {err.get('e')!r}"
+        assert called["execvp"] is False, "daemon thread must NOT os.execvp (#66)"
+        assert called["execv"] is False, "daemon thread must NOT os.execv (#66)"
+        assert au.restart_requested() is True, \
+            "a successful apply must RAISE a restart request for the main thread"
+    finally:
+        _reset_state()
+
+
+# ---------------------------------------------------------------------------
+# The MAIN-thread restart performer: graceful uvicorn stop, then os.execv.
+# ---------------------------------------------------------------------------
+
+def test_perform_restart_execs_from_main_thread(monkeypatch):
+    """The actual process replacement lives in a main-thread performer that
+    (1) gracefully stops the running uvicorn server, then (2) os.execv's into
+    the new image. We assert it drains the server first and execs after."""
+    perform = getattr(au, "perform_restart", None)
+    assert callable(perform), \
+        "auto_updater must expose perform_restart() — the main-thread re-exec"
+
+    order = []
+
+    class _Server:
+        def __init__(self):
+            self.should_exit = False
+
+        def stop(self):
+            order.append("server-stopped")
+
+    server = _Server()
+
+    def _fake_execv(path, argv):
+        order.append("execv")
+
+    monkeypatch.setattr(au.os, "execv", _fake_execv)
+    _arm_update_available()
+    au.request_restart()
+    try:
+        # perform_restart should gracefully signal the server to exit, wait
+        # for sockets to drain, then execv. We pass the server handle so the
+        # graceful-stop path is exercised.
+        au.perform_restart(server=server)
+    finally:
+        _reset_state()
+
+    assert "execv" in order, "perform_restart must os.execv into the new image"
+    # Graceful stop must happen BEFORE the exec (sockets closed first, #66).
+    if "server-stopped" in order:
+        assert order.index("server-stopped") < order.index("execv"), \
+            "must drain/stop the server BEFORE os.execv"
+    else:
+        # If perform_restart drives the server via should_exit instead of a
+        # stop() call, the flag must be set before exec.
+        assert server.should_exit is True, \
+            "must signal uvicorn should_exit before os.execv"
+
+
+def test_apply_update_restart_auto_is_true(monkeypatch):
+    """apply_update()'s restart_auto must reflect that the restart WILL happen
+    automatically — not the always-False `not _DEFER_RESTART`. We stub the pip
+    install so apply reaches the success return without shelling out."""
+    monkeypatch.delenv("PRISM_DEV_MODE", raising=False)
+    monkeypatch.delenv("PRISM_AUTO_UPDATE", raising=False)
+
+    class _Resp:
+        def read(self):
+            return b""
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(au.urllib.request, "urlopen", lambda *a, **k: _Resp())
+
+    class _Proc:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    monkeypatch.setattr(au.subprocess, "run", lambda *a, **k: _Proc())
+    _arm_update_available()
+    try:
+        result = au.apply_update()
+    finally:
+        _reset_state()
+    assert result["ok"] is True, result
+    assert result["restart_auto"] is True, \
+        "restart_auto must be True now that the restart happens automatically"

--- a/services/prism-service/tests/unit/test_auto_updater.py
+++ b/services/prism-service/tests/unit/test_auto_updater.py
@@ -166,9 +166,28 @@ def test_self_restart_helper_is_gone():
     assert not hasattr(au, "_self_restart")
 
 
-def test_restart_is_deferred_on_all_platforms():
-    """#66: never auto-restart in-place, regardless of OS."""
-    assert au._DEFER_RESTART is True
+def test_restart_is_handed_to_main_thread_not_deferred_forever():
+    """Task bc9b1a88 (5th recurrence): the #66 guard is "never execvp from the
+    DAEMON thread" — NOT "never restart at all". The old _DEFER_RESTART=True
+    meant nothing ever restarted and the served version never flipped. The safe
+    design hands the restart to the MAIN thread, so the all-platforms hard-defer
+    must be gone and the request/perform seam must exist."""
+    assert getattr(au, "_DEFER_RESTART", False) is not True, \
+        "_DEFER_RESTART must no longer be hard True — restart is handed to main"
+    assert hasattr(au, "request_restart"), "need request_restart() handoff"
+    assert hasattr(au, "restart_requested"), "need restart_requested() poll"
+    assert hasattr(au, "perform_restart"), "need perform_restart() main-thread exec"
+
+
+def test_stale_self_exec_docstring_is_corrected():
+    """The api/update.py apply() docstring used to LIE: 'On Linux/Mac the
+    auto-updater self-execs after success'. No such self-exec ever existed, and
+    the new design re-execs from the MAIN thread on every platform. The stale
+    Linux/Mac claim must be gone."""
+    from prism_service.api import update as update_api
+    doc = update_api.apply.__doc__ or ""
+    assert "self-execs after success" not in doc, \
+        "stale Linux/Mac self-exec claim must be removed from apply() docstring"
 
 
 def test_auto_apply_default_on_opt_out():


### PR DESCRIPTION
## Auto-update must actually flip the running version (5th recurrence)

The defect that recurred four times: after a successful auto-apply the new wheel
landed on disk but the live daemon kept serving the **old** version forever,
because the updater hard-deferred the restart on all platforms
(`_DEFER_RESTART = True`) and deliberately never restarted.

### v6.3.3 — the real restart seam
- `_DEFER_RESTART = False` (was hard-wired `True` — the root no-op).
- New main-thread handoff in `services/auto_updater.py`: after a successful
  apply the **daemon thread** only calls `request_restart()` (sets a flag —
  **never** `os.execv`/`execvp`, so the #66 silent-death guard stays intact).
- `main.py` is now an explicit `uvicorn.Config` + `Server` with a watcher that
  flips `server.should_exit` on `restart_requested()`, drains + closes the
  sockets, then `os.execv`s `python -m prism_service.main` from the **main
  thread** via `perform_restart()` — so the served version flips with no manual
  step. Supervisor-agnostic: a bare daemon re-execs in place; an external
  supervisor respawns on the clean exit.
- `restart_auto` is now truthful (`not _DEFER_RESTART`).
- Dev-mode / docker / `PRISM_AUTO_UPDATE=off` / `INTERVAL=0` guards preserved.

### v6.3.4 — re-exec must not orphan the pidfile
The v6.3.3 re-exec branch called `_own_pidfile_cleanup()` before
`perform_restart()`. `os.execv` replaces the process image in place (same PID)
and the re-exec'd `-m prism_service.main` never re-writes the pidfile (only
`prism start` does) — so clearing it left a live, upgraded daemon with **no**
pidfile, and `prism status`/`prism stop` reported it as not running. Fix: do
not unlink the pidfile before the in-place re-exec.

### Tests
- `tests/integration/test_auto_update_restart_handoff.py` — seam exists,
  daemon thread never execs but requests restart, main-thread `perform_restart`
  drains then execs, `restart_auto` true, **and** pidfile survives the re-exec
  (both the `perform_restart` behavior and a source-level guard on the main.py
  branch).
- `tests/unit/test_auto_updater.py` updated.
- Full local gate: tsc clean, SPA build clean, **647 unit tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
