### PR TITLE
fix(v6.3.13): task-detail Timeline per-turn token pills render for all tasks

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.12"
+PRISM_VERSION = "6.3.13"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.13: task-detail Timeline per-turn token pills now actually render. "
+    "Root cause: TaskService.history() returns TaskHistory DATACLASSES, but "
+    "_attach_turn_tokens assumed dicts (h.get / h[...] / isinstance dict) so it "
+    "AttributeError'd on the first row and the swallow-all except hid it — "
+    "per-turn attribution had never reached the JSON. get_task now converts "
+    "history rows to dicts before attribution. AND the pills now show for ALL "
+    "tasks, not just ones with a written task↔session link: api/tasks "
+    "_attach_turn_tokens falls back to wall-clock attribution across the "
+    "project's on-disk transcripts (new claude_transcripts."
+    "project_token_events_in_window) when a task has no usable linked-session "
+    "events — the work is on disk regardless of the link. Fallback is bounded "
+    "to the task's turn span and idle-clamped at 600s (the burn-graph "
+    "threshold) so a long-parked task's closing turn can't vacuum up the spend "
+    "other tasks burned during the gap; linked-session events stay "
+    "authoritative (no clamp). "
     "v6.3.12: Phase 4 of epic 4fd1e6b4 — fold the genuinely wall-clock memory "
     "duties into ONE maintenance/heartbeat clock. New "
     "services/maintenance_clock.py: a single daemon thread iterates every "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -1,5 +1,6 @@
 """Tasks API — kanban list, detail, transitions, history."""
 
+import dataclasses
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -31,6 +32,7 @@ def _attach_turn_tokens(history: list, sessions: list, project: str) -> None:
         from prism_service.services.claude_transcripts import (
             _project_source_path,
             live_token_events_for_session,
+            project_token_events_in_window,
         )
 
         src = _project_source_path(project)
@@ -55,6 +57,15 @@ def _attach_turn_tokens(history: list, sessions: list, project: str) -> None:
             sid = s.get("session_id") if isinstance(s, dict) else getattr(s, "session_id", "")
             if sid:
                 events.extend(live_token_events_for_session(sid, src))
+        fallback = False
+        if not events:
+            # No authoritative linked-session spend (the task↔session link was
+            # never written, or the linked id maps to no transcript). Fall back
+            # to wall-clock attribution across the project's transcripts so the
+            # timeline still shows real per-turn tokens — the work is on disk
+            # regardless of the link. Bounded to the task's turn span.
+            events = project_token_events_in_window(src, bounds[0][0], bounds[-1][0])
+            fallback = True
         if not events:
             return
 
@@ -62,10 +73,18 @@ def _attach_turn_tokens(history: list, sessions: list, project: str) -> None:
 
         edges = [b[0] for b in bounds]
         sums = [0] * len(history)
+        # Fallback attribution gets an idle clamp: a turn that closed a long
+        # gap (the task was parked, not worked) must not vacuum up the spend
+        # other tasks burned during that gap. 600s mirrors the conductor
+        # burn-graph's idle/skew threshold. Linked-session events are this
+        # task's own spend, so they skip the clamp.
+        IDLE_CLAMP_S = 600.0
         for ev_ts, tok in events:
             # window (edges[k-1], edges[k]] -> the turn that closed it (bounds[k]).
             k = bisect.bisect_left(edges, ev_ts)
             if 1 <= k < len(bounds):
+                if fallback and (edges[k] - ev_ts) > IDLE_CLAMP_S:
+                    continue
                 sums[bounds[k][1]] += tok
         for i, h in enumerate(history):
             if sums[i] > 0 and isinstance(h, dict):
@@ -90,12 +109,21 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
     t = svc.get(task_id)
     if not t:
         raise HTTPException(404, "task not found")
+    # history() yields TaskHistory dataclasses — convert to plain dicts here so
+    # _attach_turn_tokens can read timestamps and stamp `turn_tokens` (a
+    # dataclass has no .get/__setitem__, and a setattr'd non-field attribute
+    # would be dropped by jsonable_encoder's asdict). This is why per-turn
+    # token pills never surfaced before — the attach silently AttributeError'd.
+    history = [
+        dataclasses.asdict(h) if dataclasses.is_dataclass(h) else dict(h)
+        for h in svc.history(task_id)
+    ]
     # `sessions` rides the EXISTING task-detail route (no parallel
     # top-level route) — the linked Claude sessions JOINed with their
     # session_outcomes metrics. Empty list when nothing is linked.
     out = {
         "task": t,
-        "history": svc.history(task_id),
+        "history": history,
         "sessions": svc.sessions_for_task(task_id),
     }
     # Attribute per-turn token spend (output_tokens bucketed into each turn's

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -769,6 +769,42 @@ def live_token_events_for_session(
     return out
 
 
+def project_token_events_in_window(
+    project_path: str, since: float, until: float,
+    claude_home: Path | None = None,
+) -> list[tuple[float, int]]:
+    """Per-turn (epoch_s, output_tokens) across ALL transcripts matching the
+    project whose events fall in [since, until], sorted ascending.
+
+    The task-timeline attribution fallback: a task that was never explicitly
+    link_session'd still has the work that produced its turns on disk, so we
+    bucket the project's transcript spend into the task's history window by
+    wall-clock. Files are pruned by mtime (a transcript last written before
+    `since` cannot hold in-window events) and per-file reads are cached on
+    (mtime,size) via _token_events. Best-effort: when two tasks were worked in
+    the SAME window their spend can't be told apart, so this only fills the gap
+    when no authoritative linked-session events exist. [] when none match."""
+    if not project_path or until <= since:
+        return []
+    claude_home = claude_home or resolve_claude_home()
+    projects_dir = claude_home / "projects"
+    if not projects_dir.is_dir():
+        return []
+    out: list[tuple[float, int]] = []
+    for sub in projects_dir.iterdir():
+        if not sub.is_dir() or not slug_matches(sub.name, project_path):
+            continue
+        for f in sub.rglob("*.jsonl"):
+            try:
+                if f.stat().st_mtime < since:
+                    continue
+            except OSError:
+                continue
+            out.extend((ep, tok) for ep, tok in _token_events(f) if since <= ep <= until)
+    out.sort(key=lambda e: e[0])
+    return out
+
+
 def live_token_turns_for_session(
     session_id: str, project_path: str, claude_home: Path | None = None,
     limit: int = 40,

--- a/services/prism-service/tests/integration/test_timeline_turn_tokens.py
+++ b/services/prism-service/tests/integration/test_timeline_turn_tokens.py
@@ -1,0 +1,122 @@
+"""Regression — task-detail Timeline per-turn token pills (v6.3.13).
+
+Two bugs left every task's timeline showing NO per-turn token pills:
+
+  Bug A (shape) — TaskService.history() yields TaskHistory DATACLASSES, but
+    api/tasks._attach_turn_tokens assumed dicts (h.get / h[...] / isinstance
+    dict). It AttributeError'd on the first row, the swallow-all except hid
+    it, and turn_tokens never reached the JSON. Fix: get_task converts history
+    rows to dicts before attribution.
+  Bug B (linkage) — attribution only ran off task_sessions, which is empty for
+    most tasks, so even with the shape fixed only link_session'd tasks showed
+    tokens. Fix: project_token_events_in_window time-window fallback, bounded
+    to the turn span and idle-clamped at 600s.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+# 2026-01-01T00:00:00Z .. as a fixed wall clock the test reasons about.
+_BASE = "2026-01-01T00:"
+
+
+def _iso(mm: int, ss: int) -> str:
+    return f"{_BASE}{mm:02d}:{ss:02d}+00:00"
+
+
+def _write_transcript(path: Path, sess: str, events: list[tuple[str, int]]) -> None:
+    """One assistant event per (iso_ts, output_tokens) pair."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        json.dumps({
+            "sessionId": sess,
+            "timestamp": ts,
+            "message": {"role": "assistant", "usage": {"output_tokens": tok}},
+        })
+        for ts, tok in events
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _fake_project(tmp_path: Path):
+    """claude_home/projects/<slug>/<sess>.jsonl with timestamped turns.
+
+    Events: C @00:00:30 (50), A @00:01:30 (100), B @00:29:50 (200).
+    Returns (claude_home, source_path)."""
+    from prism_service.services.claude_transcripts import path_to_slug
+
+    source_path = str(tmp_path / "src" / "proj")
+    claude_home = tmp_path / "claude"
+    slug = path_to_slug(source_path)
+    proj = claude_home / "projects" / slug
+    sess = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    _write_transcript(
+        proj / f"{sess}.jsonl", sess,
+        [(_iso(0, 30), 50), (_iso(1, 30), 100), (_iso(29, 50), 200)],
+    )
+    return claude_home, source_path
+
+
+def test_window_helper_returns_events_in_span(tmp_path, monkeypatch):
+    from prism_service.services import claude_transcripts as ct
+
+    claude_home, source_path = _fake_project(tmp_path)
+    monkeypatch.setattr(ct, "resolve_claude_home", lambda: claude_home)
+    from datetime import datetime
+
+    def ep(mm, ss):
+        return datetime.fromisoformat(_iso(mm, ss)).timestamp()
+
+    ev = ct.project_token_events_in_window(source_path, ep(0, 0), ep(30, 0))
+    assert sorted(t for _, t in ev) == [50, 100, 200]
+    # until <= since collapses to empty.
+    assert ct.project_token_events_in_window(source_path, ep(5, 0), ep(5, 0)) == []
+
+
+def _history():
+    """Dict rows (post-conversion shape) — created, in_progress, done."""
+    return [
+        {"id": 1, "action": "created", "timestamp": _iso(0, 0)},
+        {"id": 2, "action": "updated", "timestamp": _iso(1, 0)},
+        {"id": 3, "action": "updated", "timestamp": _iso(30, 0)},
+    ]
+
+
+def test_attach_buckets_with_idle_clamp(tmp_path, monkeypatch):
+    """Fallback attribution: event C (00:00:30) -> the in_progress turn (50);
+    event B (00:29:50, 10s before done) -> done (200); event A (00:01:30, ~28m
+    before done) is idle-clamped OUT. No linked sessions -> fallback path."""
+    from prism_service.services import claude_transcripts as ct
+    from prism_service.api import tasks as T
+
+    claude_home, source_path = _fake_project(tmp_path)
+    monkeypatch.setattr(ct, "resolve_claude_home", lambda: claude_home)
+    monkeypatch.setattr(ct, "_project_source_path", lambda _p: source_path)
+
+    rows = _history()
+    T._attach_turn_tokens(rows, sessions=[], project="proj")
+    assert rows[0].get("turn_tokens") is None      # created — nothing before it
+    assert rows[1].get("turn_tokens") == 50         # in_progress turn
+    assert rows[2].get("turn_tokens") == 200        # done; event A clamped out
+
+
+def test_attach_is_safe_on_dataclass_rows(monkeypatch):
+    """Documents Bug A: TaskHistory dataclasses have no .get/__setitem__, so
+    the attach must no-op (not raise) on them — which is exactly why get_task
+    converts to dicts first."""
+    from prism_service.api import tasks as T
+    from prism_service.services.task_service import TaskHistory
+
+    row = TaskHistory(id=1, task_id="t", actor="", action="created",
+                      details="", timestamp=_iso(0, 0))
+    # Must not raise even though rows are the wrong shape.
+    T._attach_turn_tokens([row, row], sessions=[], project="proj")
+    assert not hasattr(row, "turn_tokens")


### PR DESCRIPTION
## What

The task-detail **Timeline/history box** now shows per-turn **token pills** (`N tok`) for every task — previously they never appeared on any task.

## Root cause (two bugs)

1. **Shape:** `TaskService.history()` returns `TaskHistory` *dataclasses*, but `api/tasks._attach_turn_tokens` assumed dicts (`h.get` / `h[...]` / `isinstance(h, dict)`). It `AttributeError`'d on the first row, the swallow-all `except: pass` hid it, and `turn_tokens` never reached the JSON. → `get_task` now converts history rows to dicts before attribution.
2. **Linkage:** attribution only ran off `task_sessions`, which is empty for nearly every task. → new `claude_transcripts.project_token_events_in_window` buckets on-disk transcript token-events into a task's turn span as a fallback. Bounded to the turn span and **idle-clamped at 600s** (the conductor burn-graph threshold) so a long-parked task's closing turn can't vacuum up other tasks' concurrent spend. Linked-session events stay authoritative (no clamp).

## Verification (live daemon, not just tests)

| task | before | after |
|---|---|---|
| eb2029e2 | header-only fake 8.1k, no pills | `18.0k` / `72.3k` pills, ~90.3k total |
| 0bda3046 | nothing | 13 pills across SDLC turns |
| e644c9cf | nothing | `6.6k` / `89.2k` (clamp dropped a 3.3M phantom) |

479 transcripts / 41k events on disk back the attribution. New `tests/integration/test_timeline_turn_tokens.py` pins the dataclass→dict conversion + the idle clamp; **79 related tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)