### PR TITLE
feat(v6.3.14): collapse Background Activity to memory pipeline + maintenance clock (Phase 5, epic 4fd1e6b4)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,30 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.13"
+PRISM_VERSION = "6.3.14"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.14: Phase 5 of epic 4fd1e6b4 — COLLAPSE the Background Activity UI "
+    "for the memory concern into ~2 pipeline rows + 1 maintenance-clock row. "
+    "GET /api/consolidation/workers no longer emits the discrete "
+    "reflection_worker / memory_summary_worker rows; instead it emits a "
+    "kind=='pipeline' row (the event-driven learning pipeline) carrying live "
+    "EventBus metrics — events_per_min, queue_depth, last_event_ts, in_flight "
+    "— plus the latest per-pass consolidation receipt (extracted / deduped / "
+    "superseded / retired), and a kind=='clock' row (the Phase-4 maintenance "
+    "heartbeat) carrying interval_s / last_sweep / next_sweep. New EventBus "
+    "metrics in services/event_pool.py (rolling 60s emit window + last-event "
+    "stamp + ConsumerPool-bracketed in-flight counter) and a module-level "
+    "last/next-sweep stamp in services/maintenance_clock.py. SettingsPage "
+    "BackgroundWorkersPanel branches on row kind: PipelineRow renders the four "
+    "throughput readouts + a one-line consolidation receipt summary with "
+    "click-to-expand per-pass detail (progressive disclosure, Hermes "
+    "primitives, no <pre>/JSON.stringify); ClockRow renders interval / last "
+    "sweep / next sweep. Non-memory infra/brain workers stay listed "
+    "separately. Tests: tests/integration/"
+    "test_activity_collapse_pipelines_clock.py + "
+    "tests/unit/test_activity_pipelines_clock_ui.py (12 green). "
     "v6.3.13: task-detail Timeline per-turn token pills now actually render. "
     "Root cause: TaskService.history() returns TaskHistory DATACLASSES, but "
     "_attach_turn_tokens assumed dicts (h.get / h[...] / isinstance dict) so it "

--- a/services/prism-service/prism_service/api/consolidation.py
+++ b/services/prism-service/prism_service/api/consolidation.py
@@ -41,120 +41,28 @@ def overview(
 
 
 @router.get("/workers")
-def workers() -> dict:
-    """v6.0.9 — Honest snapshot of what's running vs what isn't. v6.0.18
-    splits the reflection_worker entry by PRISM_REFLECTION_WORKER env
-    state so the panel reports reality rather than a fixed 'NOT
-    RUNNING by design' string. v6.1.1 adds a `prompt` field on workers
-    that shell out to claude_cli, so the /settings/activity drilldown
-    can render the actual instructions that drive each one."""
-    from prism_service.services import reflection_worker
-    reflection_on = reflection_worker.is_enabled()
-    reflection_interval = int(
-        os.environ.get("PRISM_REFLECTION_WORKER_INTERVAL", "900")
-    )
-    if reflection_on:
-        reflection_entry = {
-            "id": "reflection_worker",
-            "label": "Reflection worker",
-            "running": True,
-            "cadence_s": reflection_interval,
-            "description": (
-                "Default ON (PRISM_REFLECTION_WORKER=off to opt out). "
-                "Picks the oldest real-signal pending "
-                "consolidation_candidate every "
-                f"{reflection_interval}s, dispatches the same headless "
-                "claude_cli path /api/consolidation/run-reflection uses, "
-                "and persists the verdict + minted memories."
-            ),
-            "prompt_kind": "dynamic",
-            "prompt": (
-                "Reflection prompts are assembled per-candidate from the "
-                "JanitorService brief. Preview the next one via "
-                "GET /api/consolidation/next-brief; the runner template "
-                "lives in services/reflection_runner.py."
-            ),
-        }
-    else:
-        reflection_entry = {
-            "id": "reflection_worker",
-            "label": "Reflection worker",
-            "running": False,
-            "cadence_s": 0,
-            "description": (
-                "OFF — set PRISM_REFLECTION_WORKER=on (and optionally "
-                "PRISM_REFLECTION_WORKER_INTERVAL, default 900s) to "
-                "drain pending briefs automatically. Until then, "
-                "/learning + /memory only fill when you click Reflect "
-                "on /consolidation or run /prism-reflect from a session."
-            ),
-            "prompt_kind": "none",
-        }
-    from prism_service.services import memory_summary_worker
-    memory_summary_enabled = memory_summary_worker.is_enabled()
-    memory_summary_entry = {
-        "id": memory_summary_worker.WORKER_ID,
-        "label": memory_summary_worker.WORKER_LABEL,
-        "running": memory_summary_enabled,
-        "cadence_s": (
-            int(os.environ.get("PRISM_MEMORY_SUMMARY_WORKER_INTERVAL", "300"))
-            if memory_summary_enabled else 0
-        ),
-        "description": (
-            "Fills ExpertiseEntry.summary on active memories that ship "
-            "without one — each sweep takes the oldest 3 (MAX_PER_CYCLE) "
-            "and runs claude -p to mint a one-sentence rephrase for the "
-            "MemoryPage tile face. Defaults ON, every 300s (v6.2.18, "
-            "raised from 60s to bound token use). Costs claude quota — "
-            "set PRISM_MEMORY_SUMMARY_WORKER=off to disable."
-            if memory_summary_enabled else
-            "OFF (PRISM_MEMORY_SUMMARY_WORKER=off). Set "
-            "PRISM_MEMORY_SUMMARY_WORKER=on to fill the summary field "
-            "on the MemoryPage tile face."
-        ),
-        "prompt_kind": "static",
-        "prompt": memory_summary_worker.SUMMARY_PROMPT_TEMPLATE,
-    }
-    # Phase 4 (epic 4fd1e6b4) — the five wall-clock memory duties
-    # (governance TTL+decay+dup, verify_staleness, forget, adaptive retune,
-    # quality-vs-git) are folded into ONE maintenance clock. This single entry
-    # REPLACES the prior separate governance_timer + adaptive_policy_worker
-    # (+ any VerifyStaleness/Forget per-op) rows.
-    from prism_service.services import maintenance_clock as mc
-    _cadences = mc.pass_cadences()
-    _enabled = mc.pass_enabled()
-    _on = [n for n in mc.PASS_ORDER if _enabled.get(n)]
-    _off = [n for n in mc.PASS_ORDER if not _enabled.get(n)]
+def workers(project: str = Query("default")) -> dict:
+    """Honest snapshot of what's running vs what isn't.
 
-    def _fmt_cadence(s: int) -> str:
-        if s % 3600 == 0:
-            return f"{s // 3600}h"
-        if s % 60 == 0:
-            return f"{s // 60}m"
-        return f"{s}s"
-
-    _per_pass = ", ".join(f"{n}~{_fmt_cadence(_cadences[n])}" for n in mc.PASS_ORDER)
-    maintenance_entry = {
-        "id": mc.WORKER_ID,
-        "label": mc.WORKER_LABEL,
-        "running": mc.is_enabled(),
-        "cadence_s": mc.heartbeat_interval_s(),
-        "description": (
-            "ONE heartbeat thread (folds the prior 4-5 separate memory "
-            "timers). Each tick iterates every project and runs, in sequence, "
-            "five memory passes — each behind its OWN cadence gate: "
-            f"{_per_pass}. Passes ON: {', '.join(_on) or 'none'}. "
-            f"Passes OFF (env-gated): {', '.join(_off) or 'none'}. Honors "
-            "PRISM_GOVERNANCE_INTERVAL / PRISM_QUALITY_INTERVAL / "
-            "PRISM_ADAPTIVE_POLICY_WORKER[_INTERVAL] / PRISM_<OP>_WORKER; "
-            "disable the whole fold with PRISM_MAINTENANCE_CLOCK=off."
-        ),
-        "prompt_kind": "none",
-    }
+    Phase 5 (epic 4fd1e6b4) COLLAPSES the memory concern. The discrete
+    reflection_worker + memory_summary_worker rows are gone; the memory
+    learning pipeline is now presented as:
+      - kind=="pipeline" rows — the event-driven learning pipeline (events
+        flow through the EventBus → ConsumerPool), reporting live throughput
+        (events_per_min), queue depth, last-event timestamp, and in-flight
+        count, plus a per-pass consolidation receipt for progressive
+        disclosure.
+      - kind=="clock"    row  — the single Phase-4 maintenance clock,
+        reporting interval / last sweep / next sweep.
+    Non-memory infra/brain workers (transcript importer, drift reindex,
+    understand drainer, trash sweeper, auto-updater) stay listed separately
+    as kind=="worker" rows. Each row carries a `kind` so the SPA panel can
+    branch its render."""
     return {
         "workers": [
             {
                 "id": "transcript_importer",
+                "kind": "worker",
                 "label": "Transcript importer",
                 "running": True,
                 "cadence_s": 60,
@@ -168,6 +76,7 @@ def workers() -> dict:
             },
             {
                 "id": "drift_timer",
+                "kind": "worker",
                 "label": "Brain drift reindex",
                 "running": True,
                 "cadence_s": 1800,
@@ -176,6 +85,7 @@ def workers() -> dict:
             },
             {
                 "id": "understand_drainer",
+                "kind": "worker",
                 "label": "Understand analyzer drainer",
                 "running": True,
                 "cadence_s": 0,
@@ -190,6 +100,7 @@ def workers() -> dict:
             },
             {
                 "id": "trash_sweeper",
+                "kind": "worker",
                 "label": "Trash sweeper",
                 "running": True,
                 "cadence_s": 30,
@@ -198,16 +109,124 @@ def workers() -> dict:
             },
             {
                 "id": "auto_updater",
+                "kind": "worker",
                 "label": "Auto-updater",
                 "running": True,
                 "cadence_s": 1800,
                 "description": "Polls GitHub Releases, applies newer wheel via pip.",
                 "prompt_kind": "none",
             },
-            reflection_entry,
-            memory_summary_entry,
-            maintenance_entry,
+            _event_pipeline_row(project),
+            _maintenance_clock_row(),
         ],
+    }
+
+
+def _event_pipeline_row(project: str) -> dict:
+    """The collapsed event-driven learning pipeline row (kind=='pipeline').
+
+    Sources live metrics off the process-singleton EventBus (event_pool):
+    throughput, queue depth, last-event timestamp, and in-flight count — the
+    four readouts that replace the discrete reflection_worker /
+    memory_summary_worker rows. Also carries the latest per-pass
+    consolidation receipt (extracted / deduped / superseded / retired) for
+    the panel's progressive-disclosure summary."""
+    from prism_service.services import event_pool as ep
+    bus = ep.get_bus()
+    return {
+        "id": "memory_learning_pipeline",
+        "kind": "pipeline",
+        "label": "Memory learning pipeline",
+        "running": ep.is_enabled(),
+        "cadence_s": ep._interval_s(),
+        "events_per_min": bus.events_per_min(),
+        "queue_depth": bus.queue_depth(),
+        "last_event_ts": bus.last_event_ts(),
+        "in_flight": bus.in_flight(),
+        "receipt": _latest_consolidation_receipt(project),
+        "description": (
+            "Event-driven learning: session.imported / memory.written / "
+            "memory.recalled+outcome flow through the in-process EventBus to "
+            "the budget-governed consumer pool — the single claude -p "
+            "chokepoint that replaced the old reflection + memory-summary "
+            "timers. Folds reflection + summary minting onto one pipeline."
+        ),
+    }
+
+
+def _latest_consolidation_receipt(project: str) -> dict | None:
+    """Last consolidation pass receipt for progressive disclosure: how many
+    memories the most recent reflection extracted / deduped / superseded /
+    retired. Reads the recent runs already surfaced by the consolidation
+    overview; returns None when there are no runs yet."""
+    try:
+        ctx = get_project(project)
+        scores_db = str(ctx._data_dir / "scores.db")
+        if not Path(scores_db).exists():
+            return None
+        runs = get_recent_runs(scores_db, limit=1)
+        if not runs:
+            return None
+        r = runs[0] or {}
+        payload = _json.loads(r.get("output_json") or "{}")
+        new_mem = payload.get("new_memories") or []
+        invalidated = payload.get("invalidate_memory_ids") or []
+        return {
+            "extracted": len(new_mem) if isinstance(new_mem, list)
+            else int(payload.get("extracted", 0) or 0),
+            "deduped": int(payload.get("deduped", 0) or 0),
+            "superseded": len(invalidated) if isinstance(invalidated, list)
+            else int(payload.get("superseded", 0) or 0),
+            "retired": int(payload.get("retired", 0) or 0),
+            "at": r.get("run_at"),
+        }
+    except Exception:
+        return None
+
+
+def _maintenance_clock_row() -> dict:
+    """The single Phase-4 maintenance clock row (kind=='clock').
+
+    The five wall-clock memory duties (governance TTL+decay+dup,
+    verify_staleness, forget, adaptive retune, quality-vs-git) are folded
+    into ONE heartbeat. Reports interval / last sweep / next sweep alongside
+    each pass's own cadence gate."""
+    from prism_service.services import maintenance_clock as mc
+    _cadences = mc.pass_cadences()
+    _enabled = mc.pass_enabled()
+    _on = [n for n in mc.PASS_ORDER if _enabled.get(n)]
+    _off = [n for n in mc.PASS_ORDER if not _enabled.get(n)]
+
+    def _fmt_cadence(s: int) -> str:
+        if s % 3600 == 0:
+            return f"{s // 3600}h"
+        if s % 60 == 0:
+            return f"{s // 60}m"
+        return f"{s}s"
+
+    _per_pass = ", ".join(f"{n}~{_fmt_cadence(_cadences[n])}" for n in mc.PASS_ORDER)
+    return {
+        "id": mc.WORKER_ID,
+        "kind": "clock",
+        "label": mc.WORKER_LABEL,
+        "running": mc.is_enabled(),
+        "cadence_s": mc.heartbeat_interval_s(),
+        "interval_s": mc.heartbeat_interval_s(),
+        "last_sweep": mc.last_sweep_ts(),
+        "next_sweep": mc.next_sweep_ts(),
+        "passes": {n: {"cadence_s": _cadences[n], "enabled": _enabled.get(n, False)}
+                   for n in mc.PASS_ORDER},
+        "description": (
+            "ONE heartbeat thread (folds the prior 4-5 separate memory "
+            "timers). Each tick iterates every project and runs, in sequence, "
+            "five memory passes — each behind its OWN cadence gate: "
+            f"{_per_pass}. Passes ON: {', '.join(_on) or 'none'}. "
+            f"Passes OFF (env-gated): {', '.join(_off) or 'none'}. Honors "
+            "PRISM_GOVERNANCE_INTERVAL / PRISM_QUALITY_INTERVAL / "
+            "PRISM_ADAPTIVE_POLICY_WORKER[_INTERVAL] / PRISM_<OP>_WORKER; "
+            "disable the whole fold with PRISM_MAINTENANCE_CLOCK=off."
+        ),
+        "prompt_kind": "none",
     }
 
 

--- a/services/prism-service/prism_service/services/event_pool.py
+++ b/services/prism-service/prism_service/services/event_pool.py
@@ -36,8 +36,9 @@ import queue
 import sys
 import threading
 import time
+from collections import deque
 from dataclasses import dataclass, field
-from typing import Callable, Optional
+from typing import Callable, Deque, Optional
 
 
 # --- Event types -----------------------------------------------------------
@@ -169,6 +170,16 @@ class EventBus:
         # free and never circuit-broken.
         self._inference_types: set[str] = set()
         self._lock = threading.Lock()
+        # --- Phase 5 (epic 4fd1e6b4): pipeline-row metrics --------------
+        # The Background Activity event-pipeline row reports throughput,
+        # last-event timestamp, and in-flight count. We keep a rolling
+        # window of emit timestamps (events/min = count in the last 60s),
+        # the most recent emit stamp, and a live in-flight counter the
+        # ConsumerPool bumps around each dispatch.
+        self._emit_ts: Deque[float] = deque(maxlen=4096)
+        self._last_event_ts: Optional[float] = None
+        self._in_flight = 0
+        self._metrics_lock = threading.Lock()
 
     def register_handler(
         self, event_type: str, handler: Handler, inference: bool = False
@@ -192,6 +203,10 @@ class EventBus:
 
     def emit(self, event: Event) -> None:
         """Enqueue and return at once. Backpressure-free by contract."""
+        now = time.time()
+        with self._metrics_lock:
+            self._emit_ts.append(now)
+            self._last_event_ts = now
         self._q.put(event)
 
     def requeue(self, event: Event) -> None:
@@ -211,6 +226,33 @@ class EventBus:
     def queue_depth(self) -> int:
         """Number of events waiting on the bus (pinned oracle name)."""
         return self._q.qsize()
+
+    # --- Phase 5 pipeline-row metrics --------------------------------------
+    def events_per_min(self) -> float:
+        """Throughput: events emitted in the trailing 60s. The pipeline row's
+        events/min readout. Zero until events start flowing."""
+        cutoff = time.time() - 60.0
+        with self._metrics_lock:
+            return float(sum(1 for t in self._emit_ts if t >= cutoff))
+
+    def last_event_ts(self) -> Optional[float]:
+        """Epoch seconds of the most recent emit, or None if no event has ever
+        flowed — drives the pipeline row's 'last event Xs ago' readout."""
+        with self._metrics_lock:
+            return self._last_event_ts
+
+    def in_flight(self) -> int:
+        """Events claimed off the bus but not yet finished dispatching. The
+        ConsumerPool brackets each dispatch with mark_in_flight/mark_done."""
+        with self._metrics_lock:
+            return self._in_flight
+
+    def mark_in_flight(self, delta: int = 1) -> None:
+        with self._metrics_lock:
+            self._in_flight = max(0, self._in_flight + delta)
+
+    def mark_done(self) -> None:
+        self.mark_in_flight(-1)
 
 
 # Process-wide singleton — the one bus emitters (Phase 2) attach to.
@@ -345,10 +387,13 @@ class ConsumerPool:
                 time.sleep(0.01)
                 continue
 
+            self._bus.mark_in_flight()
+
             def _work(ev: Event = event) -> None:
                 try:
                     self._run_handlers(ev)
                 finally:
+                    self._bus.mark_done()
                     self._sem.release()
 
             threading.Thread(
@@ -369,7 +414,11 @@ class ConsumerPool:
                 self._bus.requeue(event)
                 deferred.append(event)
                 continue
-            self._run_handlers(event)
+            self._bus.mark_in_flight()
+            try:
+                self._run_handlers(event)
+            finally:
+                self._bus.mark_done()
         return deferred
 
 

--- a/services/prism-service/prism_service/services/maintenance_clock.py
+++ b/services/prism-service/prism_service/services/maintenance_clock.py
@@ -39,6 +39,35 @@ def _now() -> float:
     return time.time()
 
 
+# --- Phase 5 (epic 4fd1e6b4): heartbeat observability ----------------------
+# The Background Activity clock row reports last sweep + next sweep. The loop
+# stamps this each tick; the API reads it (None until the first tick).
+_last_sweep_ts: float | None = None
+_last_sweep_lock = threading.Lock()
+
+
+def _stamp_sweep() -> None:
+    global _last_sweep_ts
+    with _last_sweep_lock:
+        _last_sweep_ts = time.time()
+
+
+def last_sweep_ts() -> float | None:
+    """Epoch seconds of the most recent heartbeat tick, or None if the clock
+    has not ticked yet."""
+    with _last_sweep_lock:
+        return _last_sweep_ts
+
+
+def next_sweep_ts() -> float | None:
+    """Projected epoch of the next tick: last sweep + the heartbeat interval.
+    None until the clock has ticked once."""
+    last = last_sweep_ts()
+    if last is None:
+        return None
+    return last + heartbeat_interval_s()
+
+
 def _log(msg: str) -> None:
     print(f"[{WORKER_ID}] {msg}", file=_sys.stderr, flush=True)
 
@@ -253,6 +282,7 @@ def _loop(interval_s: int, initial_delay_s: float) -> None:
     )
     while True:
         try:
+            _stamp_sweep()
             enabled = pass_enabled()
             adaptive_ran_this_tick = False
             for pid in get_all_projects():

--- a/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
@@ -32,7 +32,7 @@ const SECTION_META: Record<SectionId, { title: string; description: string }> = 
   },
   activity: {
     title: "Background activity",
-    description: "Live status of in-process background workers (transcript importer, drift reindex, understand drainer, governance, trash sweeper, auto-updater, opt-in reflection worker) and the analyzer queue across every project — what's running, what's in flight, what's pending or failed.",
+    description: "Live status of in-process background work: the event-driven memory learning pipeline (throughput, queue depth, in-flight) and the single maintenance clock (last/next sweep), plus the non-memory infra workers (transcript importer, drift reindex, understand drainer, trash sweeper, auto-updater) and the analyzer queue across every project.",
   },
   logs: {
     title: "Logs",
@@ -1487,12 +1487,36 @@ type ServiceInfo = {
   mcp_endpoint: string;
 };
 
+// Phase 5 (epic 4fd1e6b4): per-pass consolidation receipt — one-line summary
+// + click-to-expand detail (progressive disclosure, no raw JSON wall).
+type ConsolidationReceipt = {
+  extracted: number;
+  deduped: number;
+  superseded: number;
+  retired: number;
+  at?: string | null;
+};
+
 type Worker = {
   id: string;
+  // Phase 5: the memory concern collapses into a "pipeline" row (event
+  // throughput) + a "clock" row (maintenance heartbeat). Everything else is
+  // a plain "worker" row. The panel branches its render on this.
+  kind?: "worker" | "pipeline" | "clock";
   label: string;
   running: boolean;
   cadence_s: number;
   description: string;
+  // Pipeline-row readouts (kind === "pipeline").
+  events_per_min?: number;
+  queue_depth?: number;
+  last_event_ts?: number | null;
+  in_flight?: number;
+  receipt?: ConsolidationReceipt | null;
+  // Clock-row readouts (kind === "clock").
+  interval_s?: number;
+  last_sweep?: number | null;
+  next_sweep?: number | null;
   // v6.1.1 — workers that shell out to claude carry a prompt so the
   // drilldown can render the actual instructions driving them. Values:
   //   "static"   — `prompt` is the literal template the worker sends
@@ -1571,7 +1595,15 @@ function BackgroundWorkersPanel() {
         <Empty>No workers reported.</Empty>
       ) : (
       <ul className="divide-y divide-[color:var(--midground-base)]/10">
-      {workers.map((w) => <WorkerRow key={w.id} worker={w} />)}
+      {workers.map((w) =>
+        w.kind === "pipeline" ? (
+          <PipelineRow key={w.id} worker={w} now={now} />
+        ) : w.kind === "clock" ? (
+          <ClockRow key={w.id} worker={w} now={now} />
+        ) : (
+          <WorkerRow key={w.id} worker={w} />
+        )
+      )}
     </ul>
       )}
     </>
@@ -1638,11 +1670,153 @@ function WorkerRow({ worker }: { worker: Worker }) {
             {kind === "dynamic" && "prompt construction — assembled per-run"}
             {kind === "per_job" && "per-job prompts — see individual job rows below"}
           </div>
-          <pre className="whitespace-pre-wrap font-mono text-[12px] opacity-90">
+          <div className="whitespace-pre-wrap font-mono text-[12px] opacity-90">
             {worker.prompt || "(no prompt provided)"}
-          </pre>
+          </div>
         </div>
       )}
+    </li>
+  );
+}
+
+// Phase 5: shared bits for the collapsed pipeline + clock rows.
+function StatusDot({ running }: { running: boolean }) {
+  return (
+    <span
+      className={`mt-1.5 w-2 h-2 rounded-full shrink-0 ${
+        running
+          ? "bg-emerald-400 shadow-[0_0_6px_2px_rgba(52,211,153,0.4)]"
+          : "bg-rose-400 shadow-[0_0_6px_2px_rgba(251,113,133,0.4)]"
+      }`}
+      aria-label={running ? "running" : "not running"}
+    />
+  );
+}
+
+function Readout({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[16px] font-mono leading-none">{value}</span>
+      <span className="text-[10px] uppercase tracking-wider opacity-50 mt-1">{label}</span>
+    </div>
+  );
+}
+
+function agoLabel(ts: number | null | undefined, now: number): string {
+  if (!ts) return "never";
+  const secs = Math.max(0, Math.round(now / 1000 - ts));
+  if (secs < 60) return `${secs}s ago`;
+  if (secs < 3600) return `${Math.round(secs / 60)}m ago`;
+  return `${Math.round(secs / 3600)}h ago`;
+}
+
+function inLabel(ts: number | null | undefined, now: number): string {
+  if (!ts) return "—";
+  const secs = Math.round(ts - now / 1000);
+  if (secs <= 0) return "due now";
+  if (secs < 60) return `in ${secs}s`;
+  if (secs < 3600) return `in ${Math.round(secs / 60)}m`;
+  return `in ${Math.round(secs / 3600)}h`;
+}
+
+// Event-driven learning pipeline row — events/min, queue depth, last event,
+// in-flight count + a progressive-disclosure consolidation receipt.
+function PipelineRow({ worker, now }: { worker: Worker; now: number }) {
+  const [open, setOpen] = useState(false);
+  const r = worker.receipt ?? null;
+  const summary = r
+    ? `${r.extracted} extracted · ${r.deduped} deduped · ${r.superseded} superseded · ${r.retired} retired`
+    : "no consolidation passes yet";
+  return (
+    <li className="py-3 text-sm">
+      <div className="flex items-start gap-3">
+        <StatusDot running={worker.running} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium">{worker.label}</span>
+            <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-sky-500/15 text-sky-300/90">
+              pipeline
+            </span>
+            {!worker.running && (
+              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-rose-500/15 text-rose-300/90">
+                not running
+              </span>
+            )}
+          </div>
+          <div className="text-xs opacity-60 mt-0.5 leading-relaxed">{worker.description}</div>
+          <div className="mt-3 grid grid-cols-4 gap-4">
+            <Readout label="events/min" value={Math.round(worker.events_per_min ?? 0)} />
+            <Readout label="queue depth" value={worker.queue_depth ?? 0} />
+            <Readout label="last event" value={agoLabel(worker.last_event_ts, now)} />
+            <Readout label="in-flight" value={worker.in_flight ?? 0} />
+          </div>
+          {/* Progressive-disclosure consolidation receipt: one-line summary,
+              click to expand the per-pass detail. No raw JSON. */}
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="mt-3 w-full text-left flex items-center gap-2 text-[12px] rounded-md -mx-2 px-2 py-1 hover:bg-[color:var(--midground-base)]/[0.03] cursor-pointer"
+            aria-expanded={open}
+          >
+            <span className="text-[10px] uppercase tracking-wider opacity-50">last consolidation</span>
+            <span className="font-mono opacity-80 truncate">{summary}</span>
+            <span className="text-[10px] opacity-40 font-mono ml-auto">
+              {open ? "hide ▴" : "detail ▾"}
+            </span>
+          </button>
+          {open && r && (
+            <div className="mt-2 rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] p-3 grid grid-cols-4 gap-4">
+              <Readout label="extracted" value={r.extracted} />
+              <Readout label="deduped" value={r.deduped} />
+              <Readout label="superseded" value={r.superseded} />
+              <Readout label="retired" value={r.retired} />
+              {r.at && (
+                <div className="col-span-4 text-[11px] opacity-50 font-mono">
+                  ran {agoLabel(Date.parse(r.at) / 1000, now)}
+                </div>
+              )}
+            </div>
+          )}
+          {open && !r && (
+            <div className="mt-2 rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] p-3 text-[12px] opacity-60">
+              No consolidation pass has run yet — receipts appear here once the
+              pipeline mints or supersedes memories.
+            </div>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+// Maintenance-clock row — interval, last sweep, next sweep.
+function ClockRow({ worker, now }: { worker: Worker; now: number }) {
+  const interval = worker.interval_s ?? worker.cadence_s ?? 0;
+  const intervalLabel = interval < 60 ? `${interval}s` : `${Math.round(interval / 60)}m`;
+  return (
+    <li className="py-3 text-sm">
+      <div className="flex items-start gap-3">
+        <StatusDot running={worker.running} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium">{worker.label}</span>
+            <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-violet-500/15 text-violet-300/90">
+              clock
+            </span>
+            {!worker.running && (
+              <span className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded bg-rose-500/15 text-rose-300/90">
+                not running
+              </span>
+            )}
+          </div>
+          <div className="text-xs opacity-60 mt-0.5 leading-relaxed">{worker.description}</div>
+          <div className="mt-3 grid grid-cols-3 gap-4">
+            <Readout label="interval" value={intervalLabel} />
+            <Readout label="last sweep" value={agoLabel(worker.last_sweep, now)} />
+            <Readout label="next sweep" value={inLabel(worker.next_sweep, now)} />
+          </div>
+        </div>
+      </div>
     </li>
   );
 }

--- a/services/prism-service/tests/integration/test_activity_collapse_pipelines_clock.py
+++ b/services/prism-service/tests/integration/test_activity_collapse_pipelines_clock.py
@@ -1,0 +1,179 @@
+"""RED scaffold (integration) — Phase 5 (epic 4fd1e6b4, task 034fbd6c):
+collapse the Background Activity memory concern into ~2 pipeline rows +
+1 maintenance-clock row.
+
+Today GET /api/consolidation/workers (api/consolidation.py:43-211) still
+returns the pre-consolidation shape: discrete reflection_worker +
+memory_summary_worker rows plus a maintenance_clock row — the memory
+concern is spread across three+ discrete worker rows rather than presented
+as ~2 PIPELINE rows (event throughput) + 1 CLOCK row.
+
+These pin the REAL user-facing seams end-to-end (not a service method in
+isolation — that exact gap has shipped false-greens in this epic):
+
+  Seam A (EventBus metrics)   — event_pool.EventBus exposes the NEW metrics
+    the event pipeline row needs: events/min throughput, last-event
+    timestamp, in-flight count. Today only queue_depth() (event_pool.py:211)
+    exists.
+  Seam B (API emits pipeline rows) — GET /api/consolidation/workers, reached
+    through the REAL FastAPI dispatcher (TestClient(app)), emits at least one
+    row of kind=="pipeline" carrying events_per_min / queue_depth /
+    last_event_ts / in_flight, sourced from the live bus.
+  Seam C (API emits a clock row)   — the same endpoint emits a row of
+    kind=="clock" carrying interval_s / last_sweep / next_sweep, sourced
+    from maintenance_clock.
+  Seam D (memory concern collapsed) — the discrete memory worker rows
+    (reflection_worker, memory_summary_worker) NO LONGER appear as
+    standalone rows; the memory concern is represented by the pipeline +
+    clock rows instead.
+  Seam E (non-memory infra survives) — transcript_importer / drift_timer /
+    trash_sweeper / auto_updater / understand_drainer stay listed
+    separately (out of scope for the collapse).
+
+ALL FAIL today: EventBus has no throughput/last-event/in-flight metrics,
+the API emits no kind field / pipeline / clock rows, and it still lists
+reflection_worker + memory_summary_worker as discrete rows.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Seam A — EventBus exposes the NEW metrics the event pipeline row needs.
+# ---------------------------------------------------------------------------
+
+def test_event_bus_exposes_throughput_lastevent_inflight():
+    from prism_service.services import event_pool as ep
+
+    bus = ep.EventBus()
+
+    # events/min (rate) — a numeric throughput readout, not just queue_depth.
+    assert hasattr(bus, "events_per_min"), (
+        "EventBus must expose events_per_min() — the pipeline row reports "
+        "event throughput, which does not exist today (only queue_depth)"
+    )
+    rate = bus.events_per_min()
+    assert isinstance(rate, (int, float)) and rate >= 0
+
+    # last-event timestamp — None until an event flows, then a real epoch.
+    assert hasattr(bus, "last_event_ts"), (
+        "EventBus must expose last_event_ts() for the pipeline 'last event' "
+        "readout"
+    )
+    assert bus.last_event_ts() is None
+
+    # in-flight count — events claimed but not yet finished dispatching.
+    assert hasattr(bus, "in_flight"), (
+        "EventBus (or the pool) must expose in_flight() for the pipeline "
+        "'in-flight' readout"
+    )
+    assert isinstance(bus.in_flight(), int)
+
+
+def test_last_event_ts_advances_on_emit():
+    from prism_service.services import event_pool as ep
+
+    bus = ep.EventBus()
+    assert bus.last_event_ts() is None, "no events yet → no last-event stamp"
+    bus.emit(ep.Event(type=ep.MEMORY_WRITTEN, payload={}))
+    ts = bus.last_event_ts()
+    assert ts is not None and ts > 0, (
+        "emit() must stamp last_event_ts so the pipeline row can show "
+        "'last event Xs ago'"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seam B — the API emits a PIPELINE row through the real dispatcher.
+# ---------------------------------------------------------------------------
+
+def _workers():
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+
+    client = TestClient(app)
+    resp = client.get("/api/consolidation/workers")
+    assert resp.status_code == 200, resp.text
+    return resp.json().get("workers", [])
+
+
+def test_workers_api_emits_event_pipeline_row():
+    workers = _workers()
+    pipelines = [w for w in workers if w.get("kind") == "pipeline"]
+    assert pipelines, (
+        "/api/consolidation/workers must emit at least one kind=='pipeline' "
+        f"row for the event pipeline; got kinds="
+        f"{[w.get('kind') for w in workers]}"
+    )
+    pipe = pipelines[0]
+    # The four readouts the oracle requires on a pipeline row.
+    for field in ("events_per_min", "queue_depth", "last_event_ts", "in_flight"):
+        assert field in pipe, (
+            f"pipeline row missing '{field}' — needs event rate + queue depth "
+            f"+ last-event ts + in-flight count; got keys={sorted(pipe)}"
+        )
+    assert isinstance(pipe["queue_depth"], int)
+    assert isinstance(pipe["in_flight"], int)
+
+
+# ---------------------------------------------------------------------------
+# Seam C — the API emits a CLOCK row sourced from maintenance_clock.
+# ---------------------------------------------------------------------------
+
+def test_workers_api_emits_maintenance_clock_row():
+    workers = _workers()
+    clocks = [w for w in workers if w.get("kind") == "clock"]
+    assert clocks, (
+        "/api/consolidation/workers must emit a kind=='clock' row for the "
+        f"maintenance clock; got kinds={[w.get('kind') for w in workers]}"
+    )
+    clock = clocks[0]
+    for field in ("interval_s", "last_sweep", "next_sweep"):
+        assert field in clock, (
+            f"clock row missing '{field}' — must report interval + last sweep "
+            f"+ next sweep; got keys={sorted(clock)}"
+        )
+    assert isinstance(clock["interval_s"], int) and clock["interval_s"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Seam D — the discrete memory worker rows are COLLAPSED (gone).
+# ---------------------------------------------------------------------------
+
+def test_discrete_memory_worker_rows_are_collapsed():
+    workers = _workers()
+    ids = [w.get("id") for w in workers]
+    assert "reflection_worker" not in ids, (
+        f"reflection_worker must be folded into the event pipeline + clock "
+        f"rows, not listed as a discrete row; got ids={ids}"
+    )
+    assert "memory_summary_worker" not in ids and "memory_summary_entry" not in ids, (
+        f"memory_summary_worker must be folded into the pipeline/clock rows; "
+        f"got ids={ids}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Seam E — out-of-scope infra/brain workers remain listed separately.
+# ---------------------------------------------------------------------------
+
+def test_non_memory_infra_workers_survive():
+    ids = [w.get("id") for w in _workers()]
+    for survivor in (
+        "transcript_importer", "drift_timer", "trash_sweeper",
+        "auto_updater", "understand_drainer",
+    ):
+        assert survivor in ids, (
+            f"{survivor} is non-memory infra and must remain a separate row; "
+            f"got ids={ids}"
+        )

--- a/services/prism-service/tests/unit/test_activity_pipelines_clock_ui.py
+++ b/services/prism-service/tests/unit/test_activity_pipelines_clock_ui.py
@@ -1,0 +1,106 @@
+"""RED scaffold (UI contract) — Phase 5 (epic 4fd1e6b4, task 034fbd6c):
+SettingsPage BackgroundWorkersPanel must collapse the memory concern into
+~2 pipeline rows + 1 maintenance-clock row.
+
+The web app has no JS test runner, so the UI-FIRST acceptance criterion is
+pinned by asserting SettingsPage.tsx SOURCE. Today BackgroundWorkersPanel
+(:1513-1574) maps EVERY worker dict to one <WorkerRow> (:1574); it has no
+notion of a "pipeline" vs "clock" row and no per-pass consolidation receipt
+with progressive disclosure.
+
+Pinned here (FAIL today):
+  - The panel branches on the row `kind` ("pipeline" / "clock") and renders
+    dedicated markup for each — not a single WorkerRow per item.
+  - The event-pipeline render surfaces the four readouts: events/min,
+    queue depth, last event, in-flight.
+  - The clock render surfaces interval / last sweep / next sweep.
+  - The per-pass consolidation receipt (N extracted, M deduped, K superseded,
+    J retired) renders as a one-line summary with click-to-expand detail
+    (progressive disclosure) — never a <pre>/raw JSON wall.
+  - The section description no longer enumerates the now-collapsed discrete
+    memory workers (reflection worker / memory summary) as separate rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_WEB = (_HERE.parent.parent.parent / "prism_service" / "web" / "src"
+        / "pages" / "SettingsPage.tsx")
+
+
+def _src() -> str:
+    return _WEB.read_text(encoding="utf-8")
+
+
+def test_panel_branches_on_row_kind():
+    src = _src()
+    # The Worker type / panel must understand a row `kind` so pipeline and
+    # clock rows render differently from a plain worker row.
+    assert 'kind' in src and ('"pipeline"' in src or "'pipeline'" in src), (
+        "BackgroundWorkersPanel must branch on a row kind=='pipeline'; the "
+        "memory concern is no longer one-WorkerRow-per-worker"
+    )
+    assert '"clock"' in src or "'clock'" in src, (
+        "panel must render a dedicated clock row (kind=='clock')"
+    )
+
+
+def test_pipeline_row_surfaces_throughput_readouts():
+    src = _src()
+    # The four event-pipeline readouts the oracle requires.
+    assert "events_per_min" in src, "pipeline row must show events/min"
+    assert "queue_depth" in src, "pipeline row must show queue depth"
+    assert "last_event_ts" in src or "last event" in src.lower(), (
+        "pipeline row must show last-event timestamp"
+    )
+    assert "in_flight" in src, "pipeline row must show in-flight count"
+
+
+def test_clock_row_surfaces_sweep_readouts():
+    src = _src()
+    assert "next_sweep" in src, "clock row must show next sweep"
+    assert "last_sweep" in src, "clock row must show last sweep"
+    assert "interval_s" in src or "interval" in src.lower(), (
+        "clock row must show the heartbeat interval"
+    )
+
+
+def test_consolidation_receipt_progressive_disclosure():
+    src = _src()
+    # A per-pass receipt rendered as one-line summary + click-to-expand.
+    # The receipt fields the oracle names — extracted / deduped / superseded /
+    # retired — must be referenced, not dumped as raw JSON.
+    receipt_terms = ("extracted", "deduped", "superseded", "retired")
+    assert any(t in src for t in receipt_terms), (
+        "the consolidation receipt (extracted/deduped/superseded/retired) "
+        "must render in the panel"
+    )
+    # Progressive disclosure: a collapsible/expand affordance, like the
+    # existing WorkerRow drilldown (open/setOpen) — NOT a wall of text.
+    assert ("setOpen" in src or "summary" in src.lower()
+            or "expand" in src.lower()), (
+        "the receipt must be a one-line summary with click-to-expand detail "
+        "(progressive disclosure)"
+    )
+
+
+def test_no_raw_json_dump_for_receipt():
+    src = _src()
+    # Render structured via Hermes primitives — never <pre>JSON.stringify(...).
+    assert "JSON.stringify" not in src, (
+        "no JSON.stringify wall in the activity panel — render structured"
+    )
+    assert "<pre>" not in src, "no <pre> raw dump in the activity panel"
+
+
+def test_section_description_drops_collapsed_memory_workers():
+    src = _src()
+    # The activity section blurb still enumerates the now-collapsed discrete
+    # memory workers as separate rows; once collapsed it should describe the
+    # pipeline + clock model instead of "opt-in reflection worker".
+    assert "opt-in reflection worker" not in src, (
+        "section description must stop enumerating the discrete reflection "
+        "worker — it is folded into the event pipeline + clock rows"
+    )

--- a/services/prism-service/tests/unit/test_reflection_worker.py
+++ b/services/prism-service/tests/unit/test_reflection_worker.py
@@ -142,29 +142,33 @@ def test_run_once_dispatches_run_one_for_pending(monkeypatch, tmp_path):
     assert summary["errors"] == 0
 
 
-def test_workers_endpoint_reflects_env_state(monkeypatch):
-    """/api/consolidation/workers shows the reflection worker as
-    running/cadence. FIX 1a — DEFAULT ON: with the env var UNSET the
-    worker reports running=True; only =off flips it to running=False."""
+def test_workers_endpoint_collapses_reflection_into_pipeline():
+    """Phase 5 (epic 4fd1e6b4) COLLAPSED the memory concern. The discrete
+    reflection_worker / memory_summary_worker rows are RETIRED from
+    /api/consolidation/workers; the reflection duty now flows through the
+    event-driven learning pipeline (kind=='pipeline') and the wall-clock
+    duties through the single maintenance clock (kind=='clock'). This test
+    pins that new collapsed contract (it superseded the pre-consolidation
+    'reflection_worker row reflects PRISM_REFLECTION_WORKER env state' test)."""
     from prism_service.api.consolidation import workers
 
-    monkeypatch.setenv("PRISM_REFLECTION_WORKER", "on")
-    monkeypatch.setenv("PRISM_REFLECTION_WORKER_INTERVAL", "300")
     payload = workers()
-    rw_entry = [w for w in payload["workers"] if w["id"] == "reflection_worker"][0]
-    assert rw_entry["running"] is True
-    assert rw_entry["cadence_s"] == 300
+    ids = {w["id"] for w in payload["workers"]}
 
-    # Env UNSET -> still running (default ON).
-    monkeypatch.delenv("PRISM_REFLECTION_WORKER")
-    payload = workers()
-    rw_entry = [w for w in payload["workers"] if w["id"] == "reflection_worker"][0]
-    assert rw_entry["running"] is True, (
-        "reflection worker must default ON when the env var is unset"
+    # The discrete memory-worker rows are gone.
+    assert "reflection_worker" not in ids, (
+        "Phase 5 retired the discrete reflection_worker row — the reflection "
+        "duty is folded into the memory_learning_pipeline row."
     )
+    assert "memory_summary_worker" not in ids
 
-    # Explicit off -> not running.
-    monkeypatch.setenv("PRISM_REFLECTION_WORKER", "off")
-    payload = workers()
-    rw_entry = [w for w in payload["workers"] if w["id"] == "reflection_worker"][0]
-    assert rw_entry["running"] is False
+    # The memory concern is now a single pipeline row + a single clock row.
+    pipeline = [w for w in payload["workers"] if w.get("kind") == "pipeline"]
+    clock = [w for w in payload["workers"] if w.get("kind") == "clock"]
+    assert len(pipeline) == 1, "exactly one event-driven learning pipeline row"
+    assert len(clock) == 1, "exactly one maintenance-clock row"
+
+    # The pipeline row carries the four live throughput readouts.
+    p = pipeline[0]
+    for key in ("events_per_min", "queue_depth", "last_event_ts", "in_flight"):
+        assert key in p, f"pipeline row must expose {key}"


### PR DESCRIPTION
## What

`/settings/activity` now renders the memory/learning subsystem as **1 event-driven pipeline row + 1 maintenance-clock row** instead of discrete per-worker rows — the UI-FIRST deliverable that makes the event-driven consolidation (epic 4fd1e6b4) visible. Completes the epic (Phases 1–4: event bus + maintenance clock already merged).

## Changes

- **`event_pool.py`** — EventBus gains `events_per_min()` / `last_event_ts()` / `in_flight()` (only `queue_depth()` existed before).
- **`maintenance_clock.py`** — process-level last-tick accessor so the API can derive last/next sweep (per-pass `last_run` was ephemeral in-thread).
- **`api/consolidation.py`** — `/api/consolidation/workers` returns typed rows: `kind=pipeline` (memory_learning_pipeline w/ live metrics) + `kind=clock` (maintenance_clock w/ interval/last/next sweep), folding the discrete reflection_worker + memory_summary_worker rows; the 5 non-memory infra workers stay listed.
- **`SettingsPage.tsx`** — BackgroundWorkersPanel branches on row `kind`; pipeline + clock rows with PRISM design-system primitives (no `<pre>` JSON), human-formatted timestamps, and per-pass receipt via progressive disclosure.

## Verification (live daemon, not just tests)

- `GET /api/consolidation/workers` → 7 rows: 5 worker + 1 pipeline + 1 clock ✓
- `/settings/activity` renders "Memory learning pipeline" (events/min, queue depth, last event, in flight) + "Memory maintenance clock" (interval 5m, last sweep 50s ago, next sweep in 4m) ✓
- Phase 5 oracle tests: `test_activity_collapse_pipelines_clock.py` + `test_activity_pipelines_clock_ui.py` + retired stale `test_reflection_worker` contract — 18/18 pass; full suite 766 passed.

Driven through the conductor SDLC (red_gate + green_gate passed). `[conductor:034fbd6c]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)