### PR TITLE
feat(v6.3.15): harden release pipeline — autotag, phase-merge gate, UI green_gate

### DIFF
--- a/.claude/workflows/prototype.js
+++ b/.claude/workflows/prototype.js
@@ -135,6 +135,28 @@ const plan = await agent(
   `Synthesize a PRD-style plan for the feature "${feature}" using ONLY the evidence below — do not invent capabilities the evidence doesn't support. Where evidence is thin, put it in open_questions rather than asserting it.\n\nAlso emit TWO rich-render fields:\n- plan_diagram: a valid Mermaid diagram (sequenceDiagram for actor↔system journeys, or classDiagram/flowchart for structure) capturing the core flow of this change. Raw Mermaid source only — no code fences.\n- plan_doc: a markdown PROPOSED-CHANGE doc using ## headings and - bullets (proposed change, plan steps, open questions). No raw JSON, no <pre>.\n\nEVIDENCE:\n${evidence}`,
   { label: 'plan:synthesize', phase: 'Plan', schema: PLAN_SCHEMA })
 
+// ── Phase-merge gate doctrine (stacked-epic stranding fix, task 56458db1) ──
+// The implement workflow cuts EVERY task branch off origin/main, so a
+// stacked multi-phase epic's phase N+1 depends on un-merged phase N
+// substrate and hard-halts (memory project_implement_branches_off_main).
+// The phase router MUST therefore enforce a PHASE-MERGE GATE: when this
+// plan decomposes into sequential phases, register them with an explicit
+// dependency chain (phase N+1 depends_on phase N) and gate each launch so
+// phase N is MERGED TO MAIN — its [conductor:<id>] commit reachable from
+// origin/main — BEFORE phase N+1 launches. Phase N is also auto-tagged on
+// landing (autotag.yml, STRAND A), so the merge both unblocks the next
+// phase and publishes. PR #130's dependency-aware base in implement.js
+// (Locate path b) stays as the substrate SAFETY NET, not a replacement for
+// merging in order.
+const PHASE_MERGE_GATE_DOCTRINE =
+  'PHASE-MERGE GATE (multi-phase epics): if this plan is more than one '
+  + 'phase, register the phases as an ORDERED dependency chain — phase N+1 '
+  + 'carries dependencies=[<phase N task id>] (sequential, in order) so it '
+  + 'cannot launch until phase N is DONE. The merge gate: phase N must be '
+  + 'MERGED TO MAIN (its [conductor:<id>] commit reachable from origin/main, '
+  + 'auto-tagged by autotag.yml) BEFORE the next phase is launched. Do NOT '
+  + 'kick phase N+1 off bare main while phase N is still un-merged.'
+
 // ── Phase 5: Register + track via conductor (planning steps only) ──────
 phase('Track')
 const planJson = JSON.stringify(plan, null, 2)
@@ -143,7 +165,7 @@ const linkStep = SID
   : ''
 const advSid = SID ? `, session_id="${SID}"` : ''
 const tracking = await agent(
-  `You are registering this plan as a conductor-tracked task in PRISM, then walking it through the PLANNING portion of the SDLC state machine ONLY (stop before build).\n\nThe WORKFLOW_STEPS are: review_previous_notes → draft_story → verify_plan → write_failing_tests → red_gate → implement_tasks → verify_green_state → green_gate. Planning = the first three steps.\n\nLoad tools: ToolSearch("select:mcp__prism__task_create,mcp__prism__task_link_session,mcp__prism__conductor_advance,mcp__prism__conductor_gate").\n\nSteps:\n1. task_create with a clear title derived from the plan, the plan summary as description, assigned_agent="sm", tags=["phase-router","prototype","planning"], AND persist the rich plan by passing plan_diagram=<the plan.plan_diagram Mermaid source> and plan_doc=<the plan.plan_doc markdown> so PRISM renders the plan as a document (diagram on top, proposed change below). If task_create does not carry them, call task_update(id, plan_diagram=..., plan_doc=...) immediately after. Capture the returned task id.${linkStep}\n2. conductor_advance(id${advSid}) to move from review_previous_notes -> draft_story.\n3. The draft_story gate validation is "story_complete" (manual-only). Call conductor_gate(id, action="approve", override=true, reason="PRD synthesized by the prototype workflow: <one line>") to satisfy it.\n4. conductor_advance(id${advSid}) to reach verify_plan. STOP there — verify_plan is the planning/build boundary; do NOT enter write_failing_tests.\n\nReturn the task id, the current_step you ended on, the ordered list of steps you walked, and notes on anything that errored.\n\nPLAN:\n${planJson}`,
+  `You are registering this plan as a conductor-tracked task in PRISM, then walking it through the PLANNING portion of the SDLC state machine ONLY (stop before build).\n\nThe WORKFLOW_STEPS are: review_previous_notes → draft_story → verify_plan → write_failing_tests → red_gate → implement_tasks → verify_green_state → green_gate. Planning = the first three steps.\n\n${PHASE_MERGE_GATE_DOCTRINE}\n\nLoad tools: ToolSearch("select:mcp__prism__task_create,mcp__prism__task_link_session,mcp__prism__conductor_advance,mcp__prism__conductor_gate").\n\nSteps:\n1. task_create with a clear title derived from the plan, the plan summary as description, assigned_agent="sm", tags=["phase-router","prototype","planning"], AND persist the rich plan by passing plan_diagram=<the plan.plan_diagram Mermaid source> and plan_doc=<the plan.plan_doc markdown> so PRISM renders the plan as a document (diagram on top, proposed change below). If task_create does not carry them, call task_update(id, plan_diagram=..., plan_doc=...) immediately after. Capture the returned task id.${linkStep}\n2. conductor_advance(id${advSid}) to move from review_previous_notes -> draft_story.\n3. The draft_story gate validation is "story_complete" (manual-only). Call conductor_gate(id, action="approve", override=true, reason="PRD synthesized by the prototype workflow: <one line>") to satisfy it.\n4. conductor_advance(id${advSid}) to reach verify_plan. STOP there — verify_plan is the planning/build boundary; do NOT enter write_failing_tests.\n\nReturn the task id, the current_step you ended on, the ordered list of steps you walked, and notes on anything that errored.\n\nPLAN:\n${planJson}`,
   { label: 'track:conductor', phase: 'Track', schema: TRACK_SCHEMA })
 
 return { feature, coverage, sourceGapsChased: sourceFindings.length, plan, tracking }

--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,0 +1,60 @@
+name: Auto-tag PRISM_VERSION on landing (cascade into release)
+
+# STRAND A — kill version stranding (task 56458db1).
+# When a PRISM_VERSION patch-bump LANDS on main, push the matching
+# v<version> git tag so release.yml's existing `push: tags: v*` trigger
+# fires and publishes the GitHub Release wheel — with NO manual /ship.
+# Idempotent: if the v<version> tag already exists, this is a clean no-op
+# (never a duplicate/erroring push).
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'services/prism-service/**'
+
+permissions:
+  contents: write
+
+jobs:
+  autotag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read PRISM_VERSION and compute tag name
+        id: ver
+        run: |
+          VERSION_FILE="services/prism-service/prism_service/__version__.py"
+          VERSION="$(grep -E '^PRISM_VERSION' "$VERSION_FILE" \
+            | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')"
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not read PRISM_VERSION from $VERSION_FILE"
+            exit 1
+          fi
+          TAG="v$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Computed release tag: $TAG"
+
+      - name: Create + push tag only if missing (idempotent)
+        env:
+          TAG: ${{ steps.ver.outputs.tag }}
+        run: |
+          git fetch --tags --force
+          # Idempotency guard: a re-run on main with the tag already
+          # present is a clean no-op, never a duplicate/erroring push.
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null \
+            || git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists — no-op (already released)."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG (auto-tagged on landing)"
+          git push origin "$TAG"
+          echo "Pushed $TAG — cascades into release.yml (push: tags: v*)."

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,31 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.14"
+PRISM_VERSION = "6.3.15"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.15: Harden the release pipeline — kill version/phase stranding & "
+    "blind green-gates (task 56458db1). STRAND A: new "
+    ".github/workflows/autotag.yml — on push to main scoped to "
+    "services/prism-service/**, reads PRISM_VERSION from __version__.py, and "
+    "(idempotently — git rev-parse/ls-remote guard) creates+pushes the "
+    "v<version> tag, which cascades into release.yml's existing `push: tags: "
+    "v*` trigger to publish the GitHub Release wheel with NO manual /ship. "
+    "STRAND B: prototype.js (the phase router) gains a PHASE-MERGE GATE "
+    "doctrine — multi-phase epics register phases as an ordered dependency "
+    "chain and gate each launch so phase N is MERGED TO MAIN before phase "
+    "N+1 launches; PR #130's dependency-aware base in implement.js Locate "
+    "path (b) stays as the substrate safety net (regression-guarded). "
+    "STRAND C: conductor_service.gate_decide is now UI-aware — new "
+    "module-level ui_artifact_gate_reason() REJECTS green_gate for a "
+    "`ui`-tagged task unless proof_type=='demo' AND completion_proof cites a "
+    "real UI artifact (agent-browser/verify screenshot vs :8888 or a "
+    "Playwright assertion); runs ahead of both the override and verifier "
+    "paths (the verifier is blind to the working tree). Non-`ui` tasks are "
+    "unaffected. Tests: tests/integration/test_autotag_release_pipeline.py + "
+    "test_phase_merge_and_dep_base.py + test_green_gate_ui_artifact.py "
+    "(19 green). "
     "v6.3.14: Phase 5 of epic 4fd1e6b4 — COLLAPSE the Background Activity UI "
     "for the memory concern into ~2 pipeline rows + 1 maintenance-clock row. "
     "GET /api/consolidation/workers no longer emits the discrete "

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -59,6 +59,46 @@ def green_gate_proof_note(files_modified: int, completion_proof: object) -> str:
     return "  ⚠ oracle: no completion_proof recorded"
 
 
+# Artifact-looking signals that evidence a real, demonstrable UI surface:
+# an agent-browser / verify screenshot vs the dev :8888 surface, or a
+# Playwright assertion. A pytest/unit line alone is NOT a UI artifact.
+_UI_ARTIFACT_SIGNALS = (
+    ".png", ".jpg", ".jpeg", ".webp", ".gif", ".svg",
+    "screenshot", "agent-browser", "playwright", ":8888", "127.0.0.1:8888",
+)
+
+
+def ui_artifact_gate_reason(tags: object, proof_type: object,
+                            completion_proof: object) -> str:
+    """STRAND C — demonstrable-UI requirement at green_gate (task 56458db1).
+
+    Returns a non-empty REJECTION reason when a `ui`-tagged task's
+    green_gate close lacks a real UI artifact; returns "" (no objection)
+    otherwise. UI-FIRST mandate: every feature ships a UI surface, so a
+    `ui` task cannot green-gate on a pytest/unit line alone.
+
+    A `ui` task PASSES only when BOTH hold:
+      * proof_type == 'demo' (an explicit demonstrable-UI proof), and
+      * completion_proof cites a real UI artifact path (agent-browser /
+        verify screenshot vs :8888, or a Playwright assertion).
+
+    Non-`ui` tasks are UNAFFECTED (returns "").
+    """
+    tag_set = {str(t).strip().lower() for t in (tags or [])}
+    if "ui" not in tag_set:
+        return ""
+    if str(proof_type or "").strip().lower() != "demo":
+        return ("ui task: green_gate requires proof_type='demo' with a real "
+                "UI artifact (agent-browser/verify screenshot vs :8888 or a "
+                "Playwright assertion) — not a pytest/unit line alone")
+    proof = str(completion_proof or "").lower()
+    if not any(sig in proof for sig in _UI_ARTIFACT_SIGNALS):
+        return ("ui task: completion_proof cites no UI artifact — a "
+                "demonstrable UI surface needs an agent-browser/verify "
+                "screenshot path (vs :8888) or a Playwright assertion")
+    return ""
+
+
 def overlapping_allowed_files(file_lists: list) -> set:
     """Ported from goalbuddy scripts/parallel-plan.mjs: parallel workers are
     safe ONLY when their allowed_files sets are provably disjoint. Returns the
@@ -1192,6 +1232,37 @@ class ConductorService:
                     "used (test run, screenshot, manual review, etc.)"
                 ),
             }
+        # STRAND C — demonstrable-UI requirement at green_gate (task
+        # 56458db1). A `ui`-tagged task cannot green-gate on a pytest/unit
+        # line alone; it needs proof_type='demo' + a real UI artifact path.
+        # This rule runs ahead of BOTH the override and the verifier paths
+        # (the verifier is blind to the working tree per implement.js:46-54),
+        # so a `ui` task is rejected here even when the verifier passes or an
+        # operator overrides. Non-`ui` tasks return "" and are unaffected.
+        if gate_step_id == "green_gate":
+            ui_reason = ui_artifact_gate_reason(
+                getattr(task, "tags", None),
+                getattr(task, "proof_type", ""),
+                getattr(task, "completion_proof", ""),
+            )
+            if ui_reason:
+                self._task_svc.update(
+                    task_id, gate_state="failed", gate_reason=ui_reason,
+                )
+                self._task_svc.record_history(
+                    task_id,
+                    action="gate_decide",
+                    details=(f"gate={gate_step_id}; action=approve; "
+                             f"ui-artifact=fail; reason={ui_reason}"),
+                    actor="conductor",
+                )
+                return {
+                    "ok": False,
+                    "task_id": task_id,
+                    "gate_step": gate_step_id,
+                    "gate_state": "failed",
+                    "reason": ui_reason,
+                }
         verifier_payload: Optional[dict] = None
         verifier_validation: Optional[str] = None
         verifier_reason = ""

--- a/services/prism-service/tests/integration/test_autotag_release_pipeline.py
+++ b/services/prism-service/tests/integration/test_autotag_release_pipeline.py
@@ -1,0 +1,173 @@
+"""RED scaffold — STRAND A: auto-tag on version-bump landing (task 56458db1).
+
+A landed PRISM_VERSION bump on main strands UN-published today: the only
+thing that pushes a v<version> tag is a manual /ship, so release.yml (which
+triggers ONLY on `push: tags: v*`) never fires for a merged bump (memory
+project_implement_merges_strand_unreleased_versions). This task adds a NEW
+.github/workflows/autotag.yml that, on push to main scoped to the service
+paths, reads PRISM_VERSION and creates+pushes the v<version> tag ONLY when
+no matching tag exists — which then cascades into release.yml's existing
+tag trigger, producing the GitHub Release wheel with NO manual /ship.
+
+Source-structure asserts (the CI workflow file IS the user-facing seam —
+a backend that "knows" the version but no workflow that pushes the tag is
+the exact stranding the task removes). ALL FAIL today: autotag.yml does
+not exist.
+
+Acceptance criteria pinned here:
+  A1 — autotag.yml exists, on.push.branches==[main], path filter scoped
+       to services/prism-service/**.
+  A2 — reads PRISM_VERSION from
+       services/prism-service/prism_service/__version__.py, computes tag
+       name v<version>.
+  A3 — creates+pushes the tag ONLY when no matching tag already exists
+       (idempotent — guarded so a re-run on main with an existing tag is
+       a no-op, never a duplicate/erroring push).
+  A4 — the pushed v<version> tag cascades into release.yml's existing
+       tag trigger (release.yml is UNCHANGED — its `push: tags: v*`
+       trigger is what the autotag push lands on).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent          # services/prism-service
+_REPO_ROOT = _SERVICE_ROOT.parent.parent            # E:/.prism
+_WORKFLOWS = _REPO_ROOT / ".github" / "workflows"
+_AUTOTAG = _WORKFLOWS / "autotag.yml"
+_RELEASE = _WORKFLOWS / "release.yml"
+_VERSION_FILE_REL = "services/prism-service/prism_service/__version__.py"
+
+
+def _autotag_src() -> str:
+    return _AUTOTAG.read_text(encoding="utf-8")
+
+
+# ── A1: workflow exists, triggers on push to main, path-scoped ───────────
+
+def test_autotag_workflow_file_exists():
+    assert _AUTOTAG.exists(), (
+        ".github/workflows/autotag.yml does not exist — a merged "
+        "PRISM_VERSION bump strands un-published (no tag is ever pushed "
+        "except a manual /ship)"
+    )
+
+
+def test_autotag_triggers_on_push_to_main():
+    """on.push.branches must include main — the tag is cut when a bump
+    LANDS on main, not on every branch."""
+    import yaml
+
+    doc = yaml.safe_load(_autotag_src())
+    # PyYAML parses the bare `on:` key as the boolean True.
+    on = doc.get("on", doc.get(True))
+    assert on is not None, "autotag.yml has no `on:` trigger block"
+    push = on.get("push") if isinstance(on, dict) else None
+    assert push is not None, "autotag.yml does not trigger on push"
+    branches = push.get("branches")
+    assert branches and "main" in branches, (
+        "autotag.yml push trigger is not scoped to branches:[main] — it "
+        f"must fire when a bump lands on main (got branches={branches!r})"
+    )
+
+
+def test_autotag_path_scoped_to_service():
+    """The push trigger must be path-filtered to services/prism-service/**
+    so unrelated commits (docs, plugin) don't trigger a tag attempt."""
+    import yaml
+
+    doc = yaml.safe_load(_autotag_src())
+    on = doc.get("on", doc.get(True))
+    push = on.get("push") if isinstance(on, dict) else None
+    paths = (push or {}).get("paths") or (push or {}).get("paths-ignore")
+    assert paths, (
+        "autotag.yml push trigger has no path filter — it must be scoped "
+        "to services/prism-service/** (the version source lives there)"
+    )
+    joined = " ".join(paths)
+    assert "services/prism-service" in joined, (
+        "autotag.yml path filter does not scope to services/prism-service/** "
+        f"(got paths={paths!r})"
+    )
+
+
+# ── A2: reads PRISM_VERSION from the version file, computes v<version> ────
+
+def test_autotag_reads_prism_version_from_version_file():
+    src = _autotag_src()
+    assert "__version__.py" in src or _VERSION_FILE_REL in src, (
+        "autotag.yml does not read the version from "
+        f"{_VERSION_FILE_REL} — it must source PRISM_VERSION from the "
+        "single source of truth, not a hard-coded literal"
+    )
+    assert "PRISM_VERSION" in src, (
+        "autotag.yml never references PRISM_VERSION — it cannot compute "
+        "the tag name from the version"
+    )
+
+
+def test_autotag_computes_v_prefixed_tag_name():
+    """The tag must be v<version> (matching release.yml's `tags: v*`)."""
+    src = _autotag_src()
+    # The computed tag must carry the leading 'v' so it matches the
+    # release.yml trigger glob `v*`. Look for a v-prefix being applied to
+    # the read version (e.g. "v$VERSION" / "v${VERSION}" / 'v' . version).
+    assert ("v$" in src or "v${" in src or 'v"$' in src
+            or "\"v\"" in src or "'v'" in src or "v{{" in src), (
+        "autotag.yml does not prefix the version with 'v' to form the tag "
+        "name — release.yml triggers on `tags: v*`, so a bare version tag "
+        "would never cascade into the publish flow"
+    )
+
+
+# ── A3: idempotent — only create+push when no matching tag exists ────────
+
+def test_autotag_is_idempotent_guard_present():
+    """A re-run on main with an existing v<version> tag must be a no-op —
+    the workflow must check whether the tag already exists before pushing
+    (git ls-remote / git tag -l / rev-parse guard), never blindly push a
+    duplicate that errors the job."""
+    src = _autotag_src().lower()
+    has_existence_check = (
+        "ls-remote" in src
+        or "git tag -l" in src
+        or "rev-parse" in src
+        or "git show-ref" in src
+        or "tag --list" in src
+    )
+    assert has_existence_check, (
+        "autotag.yml has no existing-tag guard — re-running on main with "
+        "the tag already present would push a duplicate (error) instead of "
+        "a clean no-op (not idempotent)"
+    )
+
+
+def test_autotag_pushes_the_tag():
+    """The workflow must actually create AND push the tag (the push is what
+    lands on release.yml's `push: tags` trigger)."""
+    src = _autotag_src()
+    assert "git push" in src and "tag" in src.lower(), (
+        "autotag.yml never pushes a git tag — without the push, release.yml "
+        "is never triggered and the bump stays un-published"
+    )
+
+
+# ── A4: cascades into the UNCHANGED release.yml tag trigger ──────────────
+
+def test_release_yml_tag_trigger_unchanged():
+    """release.yml must still trigger on `push: tags: v*` — the autotag
+    push is designed to cascade into it WITHOUT editing release.yml. This
+    guards the contract: the pushed tag is what release.yml consumes."""
+    assert _RELEASE.exists(), "release.yml missing — nothing to cascade into"
+    import yaml
+
+    doc = yaml.safe_load(_RELEASE.read_text(encoding="utf-8"))
+    on = doc.get("on", doc.get(True))
+    tags = ((on or {}).get("push") or {}).get("tags")
+    assert tags and any(t == "v*" or t.startswith("v") for t in tags), (
+        "release.yml no longer triggers on `push: tags: v*` — the autotag "
+        "cascade contract is broken (the pushed v<version> tag must land "
+        "on this trigger to publish the wheel)"
+    )

--- a/services/prism-service/tests/integration/test_green_gate_ui_artifact.py
+++ b/services/prism-service/tests/integration/test_green_gate_ui_artifact.py
@@ -1,0 +1,242 @@
+"""RED scaffold — STRAND C: UI-artifact requirement at green_gate
+(task 56458db1).
+
+VERIFIER-BLINDNESS (implement.js:46-54): the conductor gate verifier scopes
+Tier-0 git to the MCP daemon's cwd, not the working checkout, so it can
+return a non-fail verdict on a real change and the agent OVERRIDEs the
+blind gate with its own test trace. The hole: a `ui`-tagged task can
+green-gate on a pytest line ALONE — no proof the UI actually renders. Per
+the UI-FIRST mandate every feature ships a UI surface; a unit-test line is
+not a demonstrable UI.
+
+This task makes green_gate UI-aware THROUGH THE REAL DISPATCHER
+(ConductorService.gate_decide — the seam MCP conductor_gate calls), not a
+new isolated helper:
+  C1 — a `ui` task's green_gate is REJECTED when completion_proof cites
+       only a pytest/unit line and no UI artifact.
+  C2 — a `ui` task's green_gate PASSES when completion_proof cites a real
+       UI artifact path (agent-browser/verify screenshot vs :8888, or a
+       Playwright assertion) AND proof_type=='demo'.
+  C3 — non-`ui` tasks are UNAFFECTED (existing green_gate behavior is a
+       regression guard).
+
+These drive the REAL ConductorService gate_decide on the REAL green_gate
+step with a FakeVerifier pinned to PASS — so the ONLY thing that can flip
+the verdict is the net-new UI-artifact rule. A test that merely called a
+new is_ui_demo() helper would pass even if the rule never reached the
+gate (the false-green this scaffold exists to prevent).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+class FakeVerifier:
+    """Always returns a clean PASS so the gate's verdict is driven solely
+    by the new UI-artifact rule, not the Tier-0/Tier-1 machinery."""
+
+    def __init__(self, result: Optional[dict] = None) -> None:
+        self.calls: list[dict] = []
+        self.next_result = result or {
+            "status": "pass", "tier0": "pass", "tier1": "pass",
+            "tier2": "skipped", "summary": "all green",
+        }
+
+    def run(self, **kwargs: object) -> dict:
+        self.calls.append(dict(kwargs))
+        return self.next_result
+
+
+def _services(tmp_path, verifier: Optional[FakeVerifier] = None):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"),
+        enable_engine=False,
+        task_svc=task_svc,
+        verifier_svc=verifier,
+    )
+    return task_svc, cond
+
+
+def _green_gate_id() -> str:
+    from prism_service.models.workflow import WORKFLOW_STEPS
+
+    return next(s["id"] for s in WORKFLOW_STEPS
+                if s["type"] == "gate" and s["id"] == "green_gate")
+
+
+def _walk_to_green_gate(cond, task_id: str) -> None:
+    """Advance to green_gate, clearing earlier pending gates via override
+    so the test isolates the green_gate decision."""
+    from prism_service.models.workflow import WORKFLOW_STEPS
+
+    target_idx = next(i for i, s in enumerate(WORKFLOW_STEPS)
+                      if s["id"] == _green_gate_id())
+    guard = (target_idx + 1) * 3
+    while guard > 0:
+        guard -= 1
+        snap = cond._task_svc.get(task_id)
+        if snap.workflow_step == _green_gate_id() and snap.gate_state == "pending":
+            return
+        if snap.gate_state == "pending":
+            cond.gate_decide(task_id, action="approve",
+                             reason="walk intermediate", override=True)
+            continue
+        cond.advance_task(task_id)
+
+
+# ── C1: ui task — pytest-only proof is REJECTED at green_gate ────────────
+
+def test_ui_task_green_gate_rejected_with_pytest_only_proof(tmp_path):
+    """A `ui`-tagged task whose completion_proof cites ONLY a pytest line
+    (no UI artifact) must FAIL green_gate even though the verifier passes."""
+    verifier = FakeVerifier()
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(
+        title="ui feature — pytest-only proof",
+        tags=["ui"],
+        proof_type="test",
+        completion_proof="tests/unit/test_thing.py::test_renders PASSED",
+    )
+    _walk_to_green_gate(cond, t.id)
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: ui task with pytest-only proof",
+    )
+
+    assert result["ok"] is False, (
+        "a `ui` task green-gated on a pytest line with NO UI artifact — the "
+        "UI-FIRST mandate requires a demonstrable UI surface, not a unit test"
+    )
+    assert result["gate_state"] == "failed"
+    refreshed = task_svc.get(t.id)
+    assert refreshed.gate_state == "failed"
+    assert refreshed.workflow_step == _green_gate_id()
+    # The refusal reason must name the missing UI artifact so the operator
+    # knows WHY (progressive-disclosure-friendly, actionable).
+    assert "ui" in (result.get("reason") or "").lower() or "artifact" in (
+        result.get("reason") or "").lower(), (
+        "green_gate rejected the ui task but the reason does not mention the "
+        "missing UI artifact"
+    )
+
+
+# ── C2: ui task — real UI artifact + proof_type=demo PASSES ──────────────
+
+def test_ui_task_green_gate_passes_with_demo_artifact(tmp_path):
+    """A `ui` task whose completion_proof cites a real UI artifact path
+    (agent-browser/verify screenshot vs :8888) with proof_type='demo'
+    must PASS green_gate."""
+    verifier = FakeVerifier()
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(
+        title="ui feature — demo artifact proof",
+        tags=["ui"],
+        proof_type="demo",
+        completion_proof=(
+            "agent-browser screenshot vs http://127.0.0.1:8888/conductor — "
+            "docs/conductor_live_tokens.png"
+        ),
+    )
+    _walk_to_green_gate(cond, t.id)
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: ui task with demo screenshot artifact",
+    )
+
+    assert result["ok"] is True, (
+        "a `ui` task with a real UI artifact + proof_type=demo was rejected "
+        f"at green_gate (reason={result.get('reason')!r})"
+    )
+    assert result["gate_state"] == "passed"
+
+
+def test_ui_task_green_gate_rejected_when_demo_proof_type_missing(tmp_path):
+    """Even with an artifact-looking path, proof_type MUST be 'demo' — a
+    `ui` task that cites a screenshot path but leaves proof_type='test'
+    has not declared a demonstrable-UI proof and must be REJECTED."""
+    verifier = FakeVerifier()
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(
+        title="ui feature — artifact path but wrong proof_type",
+        tags=["ui"],
+        proof_type="test",
+        completion_proof="docs/conductor_live_tokens.png screenshot vs :8888",
+    )
+    _walk_to_green_gate(cond, t.id)
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: ui artifact path but proof_type=test",
+    )
+
+    assert result["ok"] is False, (
+        "a `ui` task passed green_gate without proof_type='demo' — the "
+        "demonstrable-UI contract requires the demo proof type, not just a "
+        "path that looks like a screenshot"
+    )
+    assert result["gate_state"] == "failed"
+
+
+# ── C3: non-ui tasks UNAFFECTED (regression guard) ───────────────────────
+
+def test_non_ui_task_green_gate_passes_with_test_proof(tmp_path):
+    """REGRESSION GUARD: a NON-`ui` task with a pytest proof must still PASS
+    green_gate exactly as before — the new UI-artifact requirement must not
+    leak onto non-ui tasks."""
+    verifier = FakeVerifier()
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(
+        title="backend feature — pytest proof",
+        tags=["backend"],
+        proof_type="test",
+        completion_proof="tests/unit/test_backend.py PASSED",
+    )
+    _walk_to_green_gate(cond, t.id)
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: non-ui task with pytest proof",
+    )
+
+    assert result["ok"] is True, (
+        "REGRESSION: a non-`ui` task was rejected at green_gate — the new "
+        "UI-artifact requirement leaked onto tasks without the `ui` tag"
+    )
+    assert result["gate_state"] == "passed"
+
+
+def test_untagged_task_green_gate_passes_with_test_proof(tmp_path):
+    """REGRESSION GUARD: an UNTAGGED task (no tags at all) keeps the legacy
+    verifier-driven green_gate behavior."""
+    verifier = FakeVerifier()
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(
+        title="untagged feature",
+        proof_type="test",
+        completion_proof="tests/unit/test_x.py PASSED",
+    )
+    _walk_to_green_gate(cond, t.id)
+
+    result = cond.gate_decide(
+        t.id, action="approve", reason="test: untagged task green path",
+    )
+
+    assert result["ok"] is True, (
+        "REGRESSION: an untagged task was rejected at green_gate by the new "
+        "UI-artifact rule"
+    )
+    assert result["gate_state"] == "passed"

--- a/services/prism-service/tests/integration/test_phase_merge_and_dep_base.py
+++ b/services/prism-service/tests/integration/test_phase_merge_and_dep_base.py
@@ -1,0 +1,135 @@
+"""RED scaffold — STRAND B: phase-merge orchestration + dep-base guard
+(task 56458db1).
+
+Two acceptance criteria, two halves:
+
+B1 (RED today) — the multi-phase driver (prototype / phase-router) must
+   gain a PHASE-MERGE GATE so phase N is merged to main BEFORE phase N+1
+   launches. Root cause (memory project_implement_branches_off_main): the
+   implement workflow cuts every task branch off main, so a stacked epic's
+   phase N+1 depends on un-merged phase N substrate and hard-halts. The
+   fix lands the merge-before-next-phase rule in the phase router
+   (prototype.js — the engine the /prototype phase router runs). FAILS
+   today: prototype.js registers a single planning task and never speaks
+   of merging phase N to main before launching phase N+1.
+
+B2 (PASSES today — REGRESSION GUARD, must STAY green) — PR #130's
+   dependency-aware base in implement.js Locate path (b) is the substrate
+   safety net. This task KEEPS it (must not be removed). These assertions
+   pin the path-(b) wiring so a later edit can't silently drop it.
+
+Source-structure asserts: the workflow JS the harness runs is the
+user-facing seam (mirrors test_implement_dependency_aware_branch_base.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_WORKFLOWS = _SERVICE_ROOT.parent.parent / ".claude" / "workflows"
+
+
+def _prototype_src() -> str:
+    return (_WORKFLOWS / "prototype.js").read_text(encoding="utf-8")
+
+
+def _implement_src() -> str:
+    return (_WORKFLOWS / "implement.js").read_text(encoding="utf-8")
+
+
+def _locate_block(src: str) -> str:
+    start = src.index("phase('Locate')")
+    end = src.index("Per-step handler prompts", start)
+    return src[start:end]
+
+
+# ── B1: phase-merge gate in the multi-phase driver (RED today) ───────────
+
+def test_phase_router_speaks_of_merging_phase_before_next():
+    """The phase router must encode 'merge phase N to main before launching
+    phase N+1' — the rule that prevents stacked-epic stranding."""
+    src = _prototype_src().lower()
+    assert "merge" in src, (
+        "prototype.js (the phase router) never mentions merging — it cannot "
+        "enforce phase N merged-to-main before phase N+1 launches, so a "
+        "stacked epic's next phase cuts off un-merged substrate"
+    )
+    # The merge must be tied to main and to the phase-sequencing concept,
+    # not an incidental word.
+    has_main = "main" in src
+    has_phase_seq = ("next phase" in src or "phase n+1" in src
+                     or "before" in src and "phase" in src)
+    assert has_main and has_phase_seq, (
+        "prototype.js does not gate the next phase on the prior phase being "
+        "merged to main — the phase-merge gate (B1) is absent"
+    )
+
+
+def test_phase_router_has_phase_merge_gate_marker():
+    """A discoverable marker for the phase-merge gate so the orchestration
+    is explicit (not buried). Accept any of the natural spellings."""
+    src = _prototype_src().lower()
+    assert ("phase-merge" in src or "phase merge" in src
+            or "merge gate" in src or "merge-gate" in src
+            or ("merged to main" in src and "phase" in src)), (
+        "prototype.js has no explicit phase-merge gate marker — the "
+        "merge-before-next-phase rule is not a first-class step in the "
+        "phase router"
+    )
+
+
+def test_phase_router_orders_phases_with_dependency_chain():
+    """Stacked phases must be ordered so each phase depends on the prior —
+    the driver must register phases with a dependency/sequence linkage
+    (depends_on / dependencies / sequential) so phase N+1 cannot launch
+    until phase N is done+merged."""
+    src = _prototype_src().lower()
+    assert ("depends_on" in src or "dependencies" in src
+            or "sequential" in src or "in order" in src
+            or "phase n" in src), (
+        "prototype.js does not chain phases by dependency/sequence — "
+        "without an ordering linkage there is no point at which 'phase N "
+        "merged' can gate 'phase N+1 launch'"
+    )
+
+
+# ── B2: dependency-aware base in implement.js Locate path (b) — GUARD ────
+# These PASS today (PR #130 landed the feature). They must STAY green: the
+# task preserves the substrate safety net rather than removing it.
+
+def test_guard_locate_still_reads_depends_on():
+    """REGRESSION GUARD: Locate must still read depends_on before choosing
+    the base. Removing this re-opens the ~15-min hard-halt (mx-a56419)."""
+    locate = _locate_block(_implement_src())
+    assert "depends_on" in locate, (
+        "REGRESSION: implement.js Locate no longer reads depends_on — the "
+        "PR #130 dependency-aware base safety net was removed"
+    )
+
+
+def test_guard_locate_still_finds_containing_branch_path_b():
+    """REGRESSION GUARD: path (b) — for a done-but-unmerged dep, the base is
+    the branch CONTAINING that dep's [conductor:<dep8>] commit, found via
+    `git log --all` + `branch --contains`."""
+    locate = _locate_block(_implement_src())
+    assert ("log --all" in locate or "branch -a --contains" in locate
+            or "branch --contains" in locate), (
+        "REGRESSION: implement.js Locate path (b) no longer searches ALL "
+        "branches for the dep's containing branch — substrate safety net "
+        "removed"
+    )
+    assert "conductor:" in locate and "grep" in locate, (
+        "REGRESSION: Locate no longer greps for the [conductor:<dep8>] "
+        "commit marker to resolve the containing branch (path b)"
+    )
+
+
+def test_guard_locate_still_rejects_base_behind_main():
+    """REGRESSION GUARD: the chosen base must never be behind origin/main."""
+    locate = _locate_block(_implement_src())
+    assert "behind" in locate.lower() and "origin/main" in locate, (
+        "REGRESSION: implement.js Locate dropped the 'base must not be "
+        "behind origin/main' guard from the dependency-aware base"
+    )


### PR DESCRIPTION
## Task 56458db1 — Harden PRISM release pipeline (kill version/phase stranding & blind green-gates)

The highest-leverage release/process hazards from the 2026-06-02 deep audit. Three strands, each red-test-first then minimal implementation.

### STRAND A — auto-tag on version-bump landing
New `.github/workflows/autotag.yml`: on push to `main` (paths-scoped to `services/prism-service/**`), reads `PRISM_VERSION` from `__version__.py`, idempotently (git rev-parse / ls-remote guard) creates + pushes the `v<version>` tag, which cascades into `release.yml`'s existing `push: tags: 'v*'` trigger to publish the GitHub Release wheel with NO manual `/ship`. `release.yml` is unchanged.

### STRAND B — phase-merge orchestration
`.claude/workflows/prototype.js` gains a `PHASE_MERGE_GATE_DOCTRINE`: multi-phase epics register phases as an ordered dependency chain and gate each launch so phase N is merged to main before phase N+1 launches. PR #130's dependency-aware base in `implement.js` Locate path (b) is preserved as the substrate safety net (regression-guarded).

### STRAND C — UI-smoke requirement at green_gate
`conductor_service.gate_decide` is now UI-aware: new module-level `ui_artifact_gate_reason()` rejects green_gate for a `ui`-tagged task unless `proof_type=='demo'` AND `completion_proof` cites a real UI artifact (agent-browser/verify screenshot vs :8888 or a Playwright assertion). Runs ahead of both the override and verifier paths (the verifier is blind to the working tree). Non-`ui` tasks are unaffected.

### Tests
`tests/integration/test_autotag_release_pipeline.py` + `test_phase_merge_and_dep_base.py` + `test_green_gate_ui_artifact.py` — 19 green. Full suite 796 passed; unit suite 666 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
