### PR TITLE
fix(v6.3.21): conductor token/burn graph — populate phase_progress.token_turns (#134, #137)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,32 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.20"
+PRISM_VERSION = "6.3.21"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.21: conductor token/burn graph — fix empty phase_progress.token_turns "
+    "(issues #134, #137). The three live transcript readers "
+    "(live_tokens_for_session, live_token_events_for_session, "
+    "project_token_events_in_window in claude_transcripts.py) gain an "
+    "`override_dir` param mirroring import_unseen's v6.2.16 pattern: when set, "
+    "read <override_dir>/<sid>.jsonl + nested <override_dir>/<sid>/*.jsonl "
+    "directly (via new _override_session_paths) instead of slug-scanning "
+    "~/.claude/projects. phase_progress now resolves override_dir via "
+    "claude_memory.configured_project_dir and fires the live read when EITHER "
+    "source_path OR override_dir is set (#134 — folder-mode/cwd-mismatched "
+    "projects no longer skip token reads). It builds the FULL uncapped per-turn "
+    "series from live_token_events_for_session and computes total_turns BEFORE "
+    "the [-40:] tail slice, so `turns` reports the honest total (>40) while "
+    "token_turns stays tail-capped (#137 secondary). New wall-clock fallback: "
+    "when linked-session events are empty (only unresolvable 32-hex MCP "
+    "handles), it calls project_token_events_in_window over the task's full "
+    "history window (#137 primary). A single shared token_turns_from_events "
+    "helper applies the 1s/600s clamp so the rate-derivation logic isn't "
+    "duplicated between the live path and the fallback. Tests: "
+    "tests/unit/test_phase_progress_token_turns.py (override_dir population w/ "
+    "empty source_path; MCP-handle window fallback; honest turns>40 with "
+    "tail-capped token_turns). "
     "v6.3.20: fix a fresh folder-mode project never indexing (issue #136). "
     "On a brand-new project, bootstrap ingest aborted with `OperationalError: "
     "no such table: relationships` from graph.rebuild: graphify produced "

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -651,13 +651,49 @@ def _session_id_of(path: Path) -> str:
     return ""
 
 
+def _override_session_paths(override_dir: str, session_id: str) -> list[Path]:
+    """Transcript paths for `session_id` under an explicit `override_dir` (the
+    per-project claude_project_dir): the flat <dir>/<sid>.jsonl plus every
+    nested workflow-subagent transcript under <dir>/<sid>/. Mirrors the
+    slug-scan layout so the override path reads exactly what the live path does.
+    When session_id is blank, returns every <dir>/*.jsonl (the window read)."""
+    d = Path(override_dir.strip())
+    if not d.is_dir():
+        return []
+    if not session_id:
+        return sorted(d.glob("*.jsonl"))
+    out: list[Path] = []
+    seen: set[Path] = set()
+    main = d / f"{session_id}.jsonl"
+    if main.is_file():
+        out.append(main)
+        seen.add(main)
+    sess_dir = d / session_id
+    if sess_dir.is_dir():
+        for f in sess_dir.rglob("*.jsonl"):
+            if f not in seen:
+                out.append(f)
+                seen.add(f)
+    return out
+
+
 def live_tokens_for_session(
     session_id: str, project_path: str, claude_home: Path | None = None,
+    override_dir: str | None = None,
 ) -> int:
     """Sum live `output_tokens` for `session_id` across its on-disk transcript
     AND any workflow-subagent transcripts nested under <slug>/<session_id>/.
-    Returns 0 when nothing is found (caller falls back to session_outcomes)."""
-    if not session_id or not project_path:
+    Returns 0 when nothing is found (caller falls back to session_outcomes).
+
+    When `override_dir` is set (the per-project claude_project_dir), read
+    <override_dir>/<sid>.jsonl + nested <override_dir>/<sid>/ directly instead
+    of slug-scanning ~/.claude/projects (v6.3.21, mirrors import_unseen)."""
+    if not session_id:
+        return 0
+    if override_dir and override_dir.strip():
+        return sum(_sum_output_tokens(p)
+                   for p in _override_session_paths(override_dir, session_id))
+    if not project_path:
         return 0
     claude_home = claude_home or resolve_claude_home()
     projects_dir = claude_home / "projects"
@@ -739,12 +775,24 @@ def _token_events(path: Path) -> list[tuple[float, int]]:
 
 def live_token_events_for_session(
     session_id: str, project_path: str, claude_home: Path | None = None,
+    override_dir: str | None = None,
 ) -> list[tuple[float, int]]:
     """Like live_tokens_for_session, but returns the per-turn
     (epoch_s, output_tokens) timeline across the parent transcript AND nested
     workflow-subagent transcripts, sorted ascending. Empty when none found.
-    Lets a caller bucket spend into arbitrary wall-clock windows."""
-    if not session_id or not project_path:
+    Lets a caller bucket spend into arbitrary wall-clock windows.
+
+    `override_dir` (v6.3.21): when set, read <override_dir>/<sid>.jsonl +
+    nested <override_dir>/<sid>/ directly instead of slug-scanning."""
+    if not session_id:
+        return []
+    if override_dir and override_dir.strip():
+        out: list[tuple[float, int]] = []
+        for p in _override_session_paths(override_dir, session_id):
+            out.extend(_token_events(p))
+        out.sort(key=lambda e: e[0])
+        return out
+    if not project_path:
         return []
     claude_home = claude_home or resolve_claude_home()
     projects_dir = claude_home / "projects"
@@ -772,6 +820,7 @@ def live_token_events_for_session(
 def project_token_events_in_window(
     project_path: str, since: float, until: float,
     claude_home: Path | None = None,
+    override_dir: str | None = None,
 ) -> list[tuple[float, int]]:
     """Per-turn (epoch_s, output_tokens) across ALL transcripts matching the
     project whose events fall in [since, until], sorted ascending.
@@ -783,25 +832,64 @@ def project_token_events_in_window(
     `since` cannot hold in-window events) and per-file reads are cached on
     (mtime,size) via _token_events. Best-effort: when two tasks were worked in
     the SAME window their spend can't be told apart, so this only fills the gap
-    when no authoritative linked-session events exist. [] when none match."""
-    if not project_path or until <= since:
+    when no authoritative linked-session events exist. [] when none match.
+
+    `override_dir` (v6.3.21): when set, bucket every <override_dir>/**/*.jsonl
+    transcript directly instead of slug-scanning ~/.claude/projects."""
+    if until <= since:
+        return []
+    out: list[tuple[float, int]] = []
+
+    def _bucket(f: Path) -> None:
+        try:
+            if f.stat().st_mtime < since:
+                return
+        except OSError:
+            return
+        out.extend((ep, tok) for ep, tok in _token_events(f) if since <= ep <= until)
+
+    if override_dir and override_dir.strip():
+        d = Path(override_dir.strip())
+        if d.is_dir():
+            for f in d.rglob("*.jsonl"):
+                _bucket(f)
+        out.sort(key=lambda e: e[0])
+        return out
+    if not project_path:
         return []
     claude_home = claude_home or resolve_claude_home()
     projects_dir = claude_home / "projects"
     if not projects_dir.is_dir():
         return []
-    out: list[tuple[float, int]] = []
     for sub in projects_dir.iterdir():
         if not sub.is_dir() or not slug_matches(sub.name, project_path):
             continue
         for f in sub.rglob("*.jsonl"):
-            try:
-                if f.stat().st_mtime < since:
-                    continue
-            except OSError:
-                continue
-            out.extend((ep, tok) for ep, tok in _token_events(f) if since <= ep <= until)
+            _bucket(f)
     out.sort(key=lambda e: e[0])
+    return out
+
+
+def token_turns_from_events(events: list[tuple[float, int]]) -> list[dict]:
+    """Derive the per-turn burn-RATE series {out, dt_s, tok_s} from a sorted
+    (epoch, output_tokens) timeline, applying the SHARED 1s/600s clamp. Single
+    source of truth so the live path and the wall-clock fallback can't drift.
+
+    Clamp rationale: transcript timestamps are message WRITE times, not
+    generation durations, so a rapid tool-result -> assistant pair can land <1s
+    apart and make out/dt read as a megatoken/s phantom (the "peak 1369.1k
+    tok/s" spike that flatlines every other bar). Floor sub-second / zero /
+    negative gaps at 1s, and cap idle gaps at the 600s ceiling."""
+    if not events:
+        return []
+    out: list[dict] = []
+    prev_ts = events[0][0]
+    for ts, tok in events:
+        dt = ts - prev_ts
+        if dt < 1.0 or dt > 600:
+            dt = 1.0
+        prev_ts = ts
+        out.append({"out": tok, "dt_s": round(dt, 2), "tok_s": round(tok / dt, 1)})
     return out
 
 
@@ -812,28 +900,11 @@ def live_token_turns_for_session(
     """Recent per-turn burn-RATE series for the conductor tile's live graph.
     Thin wrapper over live_token_events_for_session: takes the merged, sorted
     (epoch, output_tokens) timeline, keeps the last `limit` turns, and derives
-    {out, dt_s, tok_s} per turn where dt_s is wall-clock since the previous
-    turn and tok_s = out / dt_s. Idle gaps > 600s and clock skew clamp to a 1s
-    window so a long pause never reads as a phantom rate spike. [] when none."""
+    {out, dt_s, tok_s} per turn via token_turns_from_events. [] when none."""
     raw = live_token_events_for_session(session_id, project_path, claude_home)
     if not raw:
         return []
-    raw = raw[-limit:]
-    out: list[dict] = []
-    prev_ts = raw[0][0]
-    for ts, tok in raw:
-        dt = ts - prev_ts
-        # Clamp to a sane wall-clock window. Transcript timestamps are message
-        # WRITE times, not generation durations, so a rapid tool-result ->
-        # assistant pair can land <1s apart and make out/dt read as a
-        # megatoken/s phantom (the "peak 1369.1k tok/s" spike that flatlines
-        # every other bar). Floor sub-second / zero / negative gaps at 1s, and
-        # cap idle gaps at the 600s ceiling.
-        if dt < 1.0 or dt > 600:
-            dt = 1.0
-        prev_ts = ts
-        out.append({"out": tok, "dt_s": round(dt, 2), "tok_s": round(tok / dt, 1)})
-    return out
+    return token_turns_from_events(raw[-limit:])
 
 
 def current_session_id(

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1617,6 +1617,10 @@ class ConductorService:
     INTAKE_STEP = "intake"
 
     _TYPICAL_S_FALLBACK = 900.0  # 15 min — positive default when no history
+    # Floor for the wall-clock token fallback window: a young task whose work is
+    # already on disk (just-linked unresolvable MCP handle, #137) gets at least
+    # this much lookback so the burn graph isn't an empty [created, now] window.
+    _FALLBACK_LOOKBACK_S = 6 * 3600.0  # 6h
 
     def _project_source_path(self) -> str:
         """Resolve this project's source tree from the scores.db location
@@ -1635,6 +1639,47 @@ class ConductorService:
             src = ""
         self._src_path_cache = src
         return src
+
+    def _project_override_dir(self) -> str:
+        """Resolve this project's explicit Claude transcript dir
+        (claude_project_dir / override_dir) so the live token read works for a
+        folder-mode project whose source_path is empty or cwd-mismatched (#134).
+        Cached; '' when unconfigured."""
+        cached = getattr(self, "_override_dir_cache", None)
+        if cached is not None:
+            return cached
+        val = ""
+        try:
+            from pathlib import Path
+            from prism_service.services import claude_memory
+            project_id = Path(self._scores_db).parent.name
+            val = claude_memory.configured_project_dir(project_id) or ""
+        except Exception:
+            val = ""
+        self._override_dir_cache = val
+        return val
+
+    @staticmethod
+    def _now_epoch() -> float:
+        """Server clock as POSIX seconds (UTC)."""
+        from datetime import datetime, timezone
+        return datetime.now(timezone.utc).timestamp()
+
+    def _task_window_start(self, task_id: str) -> float:
+        """Earliest history timestamp for the task (its work window start) so
+        the wall-clock fallback brackets the FULL task span, not just the
+        current step. Falls back to (now - in_step_s) when history is empty."""
+        if self._task_svc is not None:
+            try:
+                rows = self._task_svc.history(task_id)
+                stamps = [self._parse_iso(getattr(r, "timestamp", "") or "")
+                          for r in rows]
+                stamps = [s for s in stamps if s is not None]
+                if stamps:
+                    return min(stamps)
+            except Exception:
+                pass
+        return self._now_epoch() - self._in_step_s(task_id)
 
     @staticmethod
     def _parse_iso(ts: str) -> Optional[float]:
@@ -1745,16 +1790,32 @@ class ConductorService:
         # step` (the graph is the derivative, the number is the integral — no
         # duplication). Empty for a task with no on-disk transcript yet.
         token_turns: list[dict] = []
+        total_turns = 0
         if self._task_svc is not None:
             try:
                 source_path = self._project_source_path()
+                override_dir = self._project_override_dir()
+                # Fire the live read when EITHER a source_path OR an explicit
+                # claude_project_dir (override_dir) is set — a folder-mode
+                # project with no source_path still reads tokens via the
+                # registered transcript dir (#134).
+                live_enabled = bool(source_path or override_dir)
                 live_fn = None
-                turns_fn = None
-                if source_path:
+                events_fn = None
+                window_fn = None
+                turns_from = None
+                if live_enabled:
                     from prism_service.services.claude_transcripts import (
                         live_tokens_for_session as live_fn,
-                        live_token_turns_for_session as turns_fn,
+                        live_token_events_for_session as events_fn,
+                        project_token_events_in_window as window_fn,
+                        token_turns_from_events as turns_from,
                     )
+                # Build the FULL uncapped per-turn event timeline across the
+                # task's live sessions; total_turns is computed off the UNCAPPED
+                # series so `turns` stays honest even past the 40-turn tail cap.
+                live_events: list[tuple[float, int]] = []
+                since_ts = None
                 for s in self._task_svc.sessions_for_task(task_id):
                     sid = s.get("session_id") if isinstance(s, dict) else getattr(s, "session_id", "")
                     used = s.get("tokens_used") if isinstance(s, dict) else getattr(s, "tokens_used", 0)
@@ -1762,21 +1823,42 @@ class ConductorService:
                     live_tok = 0
                     if live_fn and sid:
                         try:
-                            live_tok = int(live_fn(sid, source_path) or 0)
+                            live_tok = int(live_fn(sid, source_path, override_dir=override_dir) or 0)
                         except Exception:
                             live_tok = 0
                     tokens += max(outcome_tok, live_tok)
-                    if turns_fn and sid:
+                    if events_fn and sid:
                         try:
-                            token_turns.extend(turns_fn(sid, source_path) or [])
+                            live_events.extend(events_fn(sid, source_path, override_dir=override_dir) or [])
                         except Exception:
                             pass
+                live_events.sort(key=lambda e: e[0])
+                # Wall-clock fallback (#137 primary): a task whose only linked
+                # sessions are unresolvable 32-hex MCP handles has no live
+                # events — bucket the project's transcript spend across the
+                # task's history window so the tile still shows real turns.
+                if not live_events and window_fn:
+                    now = self._now_epoch()
+                    # Bracket the task's history span, but floor `since` at a
+                    # generous lookback so a young task whose work is already on
+                    # disk (the just-linked MCP-handle case) still captures its
+                    # recent turns instead of an empty [created≈now, now] window.
+                    since_ts = min(
+                        self._task_window_start(task_id),
+                        now - self._FALLBACK_LOOKBACK_S,
+                    )
+                    try:
+                        live_events = window_fn(
+                            source_path, since_ts, now, override_dir=override_dir
+                        ) or []
+                    except Exception:
+                        live_events = []
+                if turns_from:
+                    full_turns = turns_from(live_events)
+                    total_turns = len(full_turns)
+                    token_turns = full_turns[-40:]
             except Exception:
                 tokens = 0
-        # Bound the payload to the most recent turns (the live tail is what the
-        # animated graph shows); `turns` keeps the honest total count.
-        total_turns = len(token_turns)
-        token_turns = token_turns[-40:]
 
         return {
             "pct": round(max(0.0, min(1.0, pct)), 6),

--- a/services/prism-service/tests/unit/test_phase_progress_token_turns.py
+++ b/services/prism-service/tests/unit/test_phase_progress_token_turns.py
@@ -84,6 +84,20 @@ def _conductor(tmp_path):
     scores_db = str(proj_dir / "scores.db")
     task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
     cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    # session_outcomes is normally created by brain_engine; materialize it here
+    # (conductor-only flow) so sessions_for_task's LEFT JOIN resolves instead of
+    # OperationalError-ing to [] — mirrors test_conductor_live_tokens.py setup.
+    import sqlite3
+    conn = sqlite3.connect(scores_db)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS session_outcomes ("
+            "session_id TEXT PRIMARY KEY, duration_s REAL, tokens_used INTEGER, "
+            "files_read INTEGER, files_modified INTEGER, skills_invoked INTEGER)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
     return task_svc, cond
 
 

--- a/services/prism-service/tests/unit/test_phase_progress_token_turns.py
+++ b/services/prism-service/tests/unit/test_phase_progress_token_turns.py
@@ -1,0 +1,224 @@
+"""RED scaffold — conductor token/burn graph: phase_progress.token_turns must
+populate for folder-mode / MCP-handle tasks (#134, #137).
+
+phase_progress(task_id) builds the conductor tile's per-turn burn series
+(`token_turns`) and the honest `turns` total. Three confirmed defects leave the
+tile blank or lying for real tasks:
+
+  (#134) conductor_service.py:1753 `if source_path:` gates the live token read
+    on a non-empty source_path. A folder-mode project that registered its
+    Claude transcripts via `claude_project_dir` (override_dir) but has an
+    empty/cwd-mismatched source_path reads NO tokens — blank tile forever.
+    The fix: the live readers gain an `override_dir` param (mirroring
+    import_unseen's v6.2.16 pattern — glob <override_dir>/*.jsonl plus nested
+    <override_dir>/<session_id>/*.jsonl), phase_progress resolves it via
+    claude_memory.configured_project_dir(project_id), and fires the read when
+    EITHER source_path OR override_dir is set.
+
+  (#137 primary) Only sessions_for_task feeds the read, so a task whose ONLY
+    linked sessions are unresolvable 32-hex MCP handles (no transcript by that
+    id) renders blank. The fix: a wall-clock fallback over
+    project_token_events_in_window(source_path, since, now, override_dir=...)
+    derives the same {out, dt_s, tok_s} series — bounded to the task's history
+    window — when the linked-session turns come back empty.
+
+  (#137 secondary) The series is built from the 40-CAPPED
+    live_token_turns_for_session and `total_turns` is len() AFTER per-session
+    capping, so a 2,388-turn task reports `turns`==40. The fix: build the full
+    UNCAPPED series from live_token_events_for_session, set total_turns BEFORE
+    the [-40:] tail slice — `turns` stays honest (>40) while `token_turns` stays
+    tail-capped at 40.
+
+A single shared events->turns helper applies the 1s/600s clamp so the clamp
+isn't duplicated between the live path and the wall-clock fallback.
+
+These pin the REAL conductor seam end-to-end: phase_progress(task_id) reading
+through the actual resolvers (monkeypatched at their module home, not bypassed)
+with transcripts on disk — not a reader method in isolation. ALL FAIL today.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services import claude_transcripts as ct  # noqa: E402
+
+
+_PID = "phase_progress_pid"
+
+
+def _write_transcript(path: Path, turns: list[tuple[float, int]]) -> None:
+    """Write a Claude transcript JSONL with one assistant turn per (epoch, out)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    from datetime import datetime, timezone
+
+    lines = []
+    for ep, tok in turns:
+        ts = datetime.fromtimestamp(ep, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        lines.append(json.dumps({
+            "type": "assistant",
+            "timestamp": ts,
+            "message": {"usage": {"output_tokens": tok}},
+        }))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _conductor(tmp_path):
+    """ConductorService whose scores.db lives at <tmp>/projects/<pid>/scores.db
+    so phase_progress derives project_id == _PID for the resolvers."""
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    proj_dir = tmp_path / "projects" / _PID
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    scores_db = str(proj_dir / "scores.db")
+    task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    return task_svc, cond
+
+
+# ----------------------------------------------------------------------
+# Unit — the three live readers gained an override_dir parameter that
+# reads <override_dir>/*.jsonl + nested <override_dir>/<session_id>/.
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize("fn_name", [
+    "live_tokens_for_session",
+    "live_token_events_for_session",
+    "project_token_events_in_window",
+])
+def test_live_readers_accept_override_dir(fn_name):
+    fn = getattr(ct, fn_name)
+    params = inspect.signature(fn).parameters
+    assert "override_dir" in params, (
+        f"{fn_name} must accept an override_dir param (mirroring import_unseen)"
+    )
+
+
+def test_override_dir_reads_flat_and_nested_jsonl(tmp_path):
+    """live_token_events_for_session(override_dir=d) reads <d>/<sid>.jsonl AND
+    nested workflow-subagent transcripts under <d>/<sid>/ — without touching
+    ~/.claude/projects (project_path empty)."""
+    sid = "11111111-1111-1111-1111-111111111111"
+    d = tmp_path / "claudedir"
+    _write_transcript(d / f"{sid}.jsonl", [(1000.0, 100), (1002.0, 200)])
+    _write_transcript(d / sid / "subagent.jsonl", [(1004.0, 50)])
+
+    events = ct.live_token_events_for_session(sid, "", override_dir=str(d))
+    toks = sorted(tok for _, tok in events)
+    assert toks == [50, 100, 200], events
+
+
+def test_project_window_override_dir_buckets_by_wallclock(tmp_path):
+    """project_token_events_in_window(override_dir=d) buckets ALL <d> transcript
+    turns in [since, until] — the MCP-handle fallback source."""
+    d = tmp_path / "claudedir"
+    _write_transcript(d / "aaaa.jsonl", [(1000.0, 10), (1500.0, 20), (9999.0, 999)])
+
+    events = ct.project_token_events_in_window("", 900.0, 2000.0, override_dir=str(d))
+    toks = sorted(tok for _, tok in events)
+    assert toks == [10, 20], events  # the 9999 turn is out of window
+
+
+# ----------------------------------------------------------------------
+# Oracle (a) — override_dir population with EMPTY source_path (#134).
+# The conductor tile must show real token_turns for a folder-mode project
+# that registered claude_project_dir but has no/empty source_path.
+# ----------------------------------------------------------------------
+
+def _patch_resolvers(monkeypatch, source_path: str, override_dir: str):
+    """Bind the two phase_progress resolvers at their module homes (the REAL
+    seam): claude_transcripts._project_source_path and
+    claude_memory.configured_project_dir."""
+    monkeypatch.setattr(ct, "_project_source_path", lambda pid: source_path)
+    from prism_service.services import claude_memory as cm
+    monkeypatch.setattr(cm, "configured_project_dir", lambda pid: override_dir)
+
+
+def test_phase_progress_populates_from_override_dir_empty_source(tmp_path, monkeypatch):
+    task_svc, cond = _conductor(tmp_path)
+    sid = "22222222-2222-2222-2222-222222222222"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    _write_transcript(d / f"{sid}.jsonl", [(now - 30, 100), (now - 20, 150), (now - 10, 200)])
+
+    t = task_svc.create(title="folder-mode tile")
+    cond.advance_task(t.id)  # onto the workflow so it's a managed task
+    task_svc.link_session(t.id, sid)
+
+    # EMPTY source_path, but claude_project_dir (override_dir) is registered.
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["token_turns"], (
+        "token_turns must populate from override_dir even when source_path is "
+        "empty (#134) — got empty series"
+    )
+    assert all({"out", "dt_s", "tok_s"} <= set(turn) for turn in pp["token_turns"])
+
+
+# ----------------------------------------------------------------------
+# Oracle (b) — MCP-handle fallback to the wall-clock window read (#137).
+# A task whose ONLY linked session is an unresolvable 32-hex MCP handle
+# still shows token_turns via project_token_events_in_window(override_dir).
+# ----------------------------------------------------------------------
+
+def test_phase_progress_falls_back_for_mcp_handle_sessions(tmp_path, monkeypatch):
+    task_svc, cond = _conductor(tmp_path)
+    # The only linked "session" is a 32-hex MCP request handle — there is NO
+    # transcript named <handle>.jsonl. The work is on disk under a DIFFERENT id.
+    mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
+    real_sid = "33333333-3333-3333-3333-333333333333"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    _write_transcript(d / f"{real_sid}.jsonl", [(now - 40, 80), (now - 25, 120), (now - 5, 160)])
+
+    t = task_svc.create(title="mcp-handle tile")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, mcp_handle)
+
+    _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["token_turns"], (
+        "token_turns must fall back to the wall-clock window read when the only "
+        "linked session is an unresolvable MCP handle (#137 primary)"
+    )
+
+
+# ----------------------------------------------------------------------
+# Oracle (c) — honest turns>40 with a tail-capped token_turns (#137 secondary).
+# ----------------------------------------------------------------------
+
+def test_phase_progress_turns_total_is_honest_above_cap(tmp_path, monkeypatch):
+    task_svc, cond = _conductor(tmp_path)
+    sid = "44444444-4444-4444-4444-444444444444"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    # 50 turns, each 2s apart — well above the 40-turn tail cap.
+    turns = [(now - (50 - i) * 2, 100 + i) for i in range(50)]
+    _write_transcript(d / f"{sid}.jsonl", turns)
+
+    t = task_svc.create(title="long task")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, sid)
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["turns"] == 50, (
+        f"`turns` must report the HONEST total (50), not the capped count — "
+        f"got {pp['turns']} (#137 secondary)"
+    )
+    assert len(pp["token_turns"]) == 40, (
+        f"token_turns must stay tail-capped at 40, got {len(pp['token_turns'])}"
+    )


### PR DESCRIPTION
## What

The conductor task-tile burn graph (`phase_progress.token_turns`) rendered **blank** and the turn count **collapsed to 40** for real in-progress drives. Two reported issues, one root function (`ConductorService.phase_progress`):

- **#134** — the live transcript readers located transcripts by slug-matching `source_path`. A driving session whose cwd != `source_path` (background/headless drives, multi-repo) writes its transcript under a different slug → nothing matched → empty series. The whole live read was also gated on `if source_path:`, so folder-mode projects with no `source_path` skipped it entirely.
- **#137** — no wall-clock fallback (unlike the task timeline), so a task whose only session links are stale 32-hex MCP handles got a permanently blank tile. Secondary: `live_token_turns_for_session` pre-sliced to the last 40 turns *per session* before `total_turns` was measured, so the honest count collapsed to 40 (a real task with 1,019 turns reported 40).

## How

1. Added an `override_dir` parameter to the three live readers (`live_tokens_for_session`, `live_token_events_for_session`, `project_token_events_in_window`), mirroring `import_unseen`'s v6.2.16 pattern: read `<override_dir>/*.jsonl` + nested `<override_dir>/<session_id>/` directly instead of slug-scanning. (#134)
2. `phase_progress` resolves `override_dir` via `claude_memory.configured_project_dir(project_id)` and fires the live read when **either** `source_path` **or** `override_dir` is set. (#134)
3. Builds the **full uncapped** per-turn series from `live_token_events_for_session`; `total_turns` is computed **before** the `[-40:]` tail slice so `turns` stays honest. (#137 secondary)
4. Wall-clock fallback over `project_token_events_in_window` (window = max(task span, 6h)) when linked sessions yield no live events. (#137 primary)
5. Shared `token_turns_from_events` helper applies the 1s/600s clamp once (no duplication between the live path and the fallback).

## Verification

- `pytest tests -q` → **837 passed**; `pytest -k phase_progress` → 14 passed (8 new tests cover all 3 oracle cases: override_dir population with empty source_path; MCP-handle wall-clock fallback; honest turns>40 with tail-capped token_turns≤40).
- **Live dev:8888**: `/api/version` = 6.3.21; `/api/conductor/state` → a real in-progress task shows non-empty `token_turns` (40 `{out,dt_s,tok_s}` entries), `turns`=1019 (honest), `tokens_since_step`=387k.

Driven end-to-end through the PRISM conductor `implement` workflow (review → story → verify_plan → red tests → red_gate → implement → verify_green → green_gate). The `ui`-artifact green gate was satisfied with a :8888 screenshot receipt.

Closes #134
Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)
