### PR TITLE
fix(v6.3.22): conductor per-task token honesty — authoritative linkage + in_progress fallback gate + tokens_source flag (follow-up to #137)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,27 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.21"
+PRISM_VERSION = "6.3.22"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.22: conductor per-task token HONESTY (follow-up to #134/#137). "
+    "current_session_id (claude_transcripts.py) gains an override_dir param "
+    "mirroring the v6.3.21 readers — with project_path empty but override_dir "
+    "set it resolves the active transcript's sessionId via _override_session_"
+    "paths, so _resolve_link_session_id (mcp/tools.py) now stamps the REAL "
+    "session id (not the phantom ctx.request_id MCP handle) in folder-mode / "
+    "cwd-mismatch (#134), reducing wall-clock-fallback reliance. phase_progress "
+    "(conductor_service.py) applies the project-wide wall-clock fallback ONLY "
+    "when the driven task status=='in_progress' — a pending/parked task with no "
+    "authoritative live_events stays honestly blank (no painting another task's "
+    "burn, killing the 2625-turns duplication). New tokens_source field "
+    "('linked'|'wallclock'): when wall-clock-derived, tokens_since_step is fed "
+    "from the SAME fallback events (==series sum, >0) so the graph and the "
+    "number agree (no '2625 turns / 0 tokens' contradiction). TokenTurns.tsx "
+    "consumes the tokens_source prop — 'wallclock' renders dimmed + labelled "
+    "'project activity (approximate)'. Tests: tests/unit/test_conductor_token_"
+    "source.py (oracle a/b/c + UI guard, 8 green). "
     "v6.3.21: conductor token/burn graph — fix empty phase_progress.token_turns "
     "(issues #134, #137). The three live transcript readers "
     "(live_tokens_for_session, live_token_events_for_session, "

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -1569,9 +1569,14 @@ def _resolve_link_session_id() -> str:
         from prism_service.services.claude_transcripts import (
             _project_source_path, current_session_id,
         )
+        from prism_service.services import claude_memory
         src = _project_source_path(ctx.project_id)
-        if src:
-            real = current_session_id(src)
+        # Resolve the explicit claude_project_dir so folder-mode / cwd-mismatch
+        # (#134) — where src='' — still stamps a REAL session id instead of the
+        # phantom MCP request handle (which maps to no transcript).
+        override_dir = claude_memory.configured_project_dir(ctx.project_id) or ""
+        if src or override_dir:
+            real = current_session_id(src, override_dir=override_dir)
             if real:
                 return real
     except Exception:

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -909,11 +909,23 @@ def live_token_turns_for_session(
 
 def current_session_id(
     project_path: str, claude_home: Path | None = None,
+    override_dir: str | None = None,
 ) -> str:
     """Best-effort id of the project's ACTIVE Claude session — the sessionId
     of the most-recently-modified matching transcript. Used as the conductor
     link fallback so we stamp a REAL, resolvable session instead of the MCP
-    request handle (which maps to no transcript and no token data)."""
+    request handle (which maps to no transcript and no token data).
+
+    `override_dir` (mirrors the v6.3.21 readers): when set, resolve the active
+    session from <override_dir>/*.jsonl directly (via _override_session_paths
+    with a blank session_id) instead of slug-scanning ~/.claude/projects. This
+    lets folder-mode / cwd-mismatched projects (project_path empty) still stamp
+    a REAL session id off the explicit claude_project_dir (#134)."""
+    if override_dir and override_dir.strip():
+        paths = _override_session_paths(override_dir, "")
+        if paths:
+            newest = max(paths, key=lambda p: p.stat().st_mtime)
+            return _session_id_of(newest) or newest.stem
     if not project_path:
         return ""
     claude_home = claude_home or resolve_claude_home()

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1791,6 +1791,10 @@ class ConductorService:
         # duplication). Empty for a task with no on-disk transcript yet.
         token_turns: list[dict] = []
         total_turns = 0
+        # 'linked' = series came from authoritative per-session live events (or
+        # is honestly empty); 'wallclock' = the project-wide fallback supplied
+        # it. The SPA dims/labels the 'wallclock' case as approximate.
+        tokens_source = "linked"
         if self._task_svc is not None:
             try:
                 source_path = self._project_source_path()
@@ -1837,7 +1841,19 @@ class ConductorService:
                 # sessions are unresolvable 32-hex MCP handles has no live
                 # events — bucket the project's transcript spend across the
                 # task's history window so the tile still shows real turns.
-                if not live_events and window_fn:
+                # HONESTY GATE (#647d9c41): the fallback is project-WIDE, so it
+                # can only honestly apply to the ONE task actually being worked.
+                # A pending/parked task with no authoritative events stays
+                # blank (tokens_source='linked') rather than borrowing another
+                # task's burn. Only an in_progress task fills via wall-clock.
+                task_status = ""
+                try:
+                    driven = self._task_svc.get(task_id)
+                    task_status = (getattr(driven, "status", "") or "") if driven else ""
+                except Exception:
+                    task_status = ""
+                if (not live_events and window_fn
+                        and task_status == "in_progress"):
                     now = self._now_epoch()
                     # Bracket the task's history span, but floor `since` at a
                     # generous lookback so a young task whose work is already on
@@ -1853,6 +1869,13 @@ class ConductorService:
                         ) or []
                     except Exception:
                         live_events = []
+                    if live_events:
+                        # The series is project-wide/approximate — tag it AND
+                        # feed tokens_since_step from the SAME events so the
+                        # graph (rate) and the number (integral) agree (no
+                        # '2625 turns / 0 tokens' contradiction, PROBLEM 2).
+                        tokens_source = "wallclock"
+                        tokens = sum(int(tok) for _ep, tok in live_events)
                 if turns_from:
                     full_turns = turns_from(live_events)
                     total_turns = len(full_turns)
@@ -1872,4 +1895,7 @@ class ConductorService:
             # Per-turn burn rate series + honest total turn count.
             "token_turns": token_turns,
             "turns": total_turns,
+            # 'linked' (authoritative/empty) | 'wallclock' (project-wide
+            # approximate fallback — the SPA dims + labels it).
+            "tokens_source": tokens_source,
         }

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -26,6 +26,9 @@ export type PhaseProgress = {
   // the live TokenTurns graph beside each conductor tile.
   token_turns?: TokenTurn[];
   turns?: number;
+  // 'linked' = authoritative per-task series; 'wallclock' = project-wide
+  // approximate fallback (TokenTurns renders it dimmed + labelled).
+  tokens_source?: "linked" | "wallclock";
 };
 
 function fmtTokens(t: number): string {

--- a/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
@@ -18,22 +18,32 @@ export default function TokenTurns({
   total,
   live,
   reduced,
+  tokens_source,
 }: {
   turns?: TokenTurn[];
   total?: number;
   live?: boolean;
   reduced?: boolean | null;
+  // 'linked' = authoritative per-task series; 'wallclock' = project-wide
+  // approximate fallback — render dimmed + labelled so the number is never
+  // presented as authoritative per-task truth.
+  tokens_source?: "linked" | "wallclock";
 }) {
   const series = turns ?? [];
   const count = total ?? series.length;
   const peak = series.reduce((m, t) => Math.max(m, t.tok_s), 0) || 1;
   const latest = series.length ? series[series.length - 1] : null;
+  const approximate = tokens_source === "wallclock";
 
   return (
-    <div className="flex flex-col gap-1.5 h-full">
+    <div
+      className="flex flex-col gap-1.5 h-full"
+      style={approximate ? { opacity: 0.55 } : undefined}
+      title={approximate ? "project activity (approximate)" : undefined}
+    >
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-[9px] uppercase tracking-[0.12em] font-mono text-[color:var(--text-muted)] opacity-70">
-          burn · tok/s by turn
+          {approximate ? "project activity (approximate)" : "burn · tok/s by turn"}
         </span>
         <span className="flex items-center gap-1 text-[10px] font-mono tabular-nums text-[color:var(--text-muted)]">
           {live && (

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -190,6 +190,7 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
             total={task.phase_progress?.turns}
             live={status === "in_progress"}
             reduced={reduced}
+            tokens_source={task.phase_progress?.tokens_source}
           />
         </div>
       </div>

--- a/services/prism-service/tests/unit/test_conductor_token_source.py
+++ b/services/prism-service/tests/unit/test_conductor_token_source.py
@@ -1,0 +1,290 @@
+"""RED scaffold — conductor per-task token HONESTY (follow-up to #134/#137).
+
+#137 made phase_progress.token_turns populate via override_dir + a project-wide
+wall-clock fallback. That shipped two NEW lies the conductor tile now tells:
+
+  PROBLEM 1 — authoritative linkage still misses. _resolve_link_session_id
+    (tools.py:1559) only resolves the real transcript session when
+    claude_transcripts._project_source_path(project_id) is TRUTHY (tools.py:1573).
+    In folder-mode / cwd-mismatch (#134) src='' so it falls straight through to
+    ctx.request_id (tools.py:1579) — the 32-hex MCP request handle that maps to
+    NO transcript. current_session_id (claude_transcripts.py:910) does not yet
+    accept override_dir, so even with an explicit claude_project_dir configured
+    the link is stamped with the phantom handle. The downstream wall-clock
+    fallback then fires for EVERY task, painting parked tiles with the worked
+    tile's burn (the 2625-turns duplication).
+
+  PROBLEM 2 — the wall-clock fallback is project-WIDE and unconditional. A
+    pending / parked task with no authoritative live_events gets the SAME
+    project window series as the task actually being worked (conductor_service
+    .py:1840 `if not live_events and window_fn:`), so two tiles plot one series.
+    And the fallback fills token_turns (the graph) but never updates `tokens`
+    (conductor_service.py:1829 only), so the tile reads "2625 turns" while
+    tokens_since_step stays 0 — the "graph full / number 0" contradiction.
+
+THE FIX this file pins:
+  (a) current_session_id gains override_dir; _resolve_link_session_id resolves
+      override_dir via claude_memory.configured_project_dir and returns the REAL
+      session id (not ctx.request_id) when source_path='' + override_dir-set.
+  (b) phase_progress applies the wall-clock fallback ONLY when the driven task's
+      status == 'in_progress'. A pending task with no authoritative turns →
+      token_turns empty + a NEW tokens_source field == 'linked'. An in_progress
+      task with no live events → wall-clock fill tagged tokens_source=='wallclock'.
+  (c) when tokens_source=='wallclock', tokens_since_step is fed from the SAME
+      fallback events: > 0 AND == the series event sum (no graph/number lie).
+
+These pin the REAL seams: the link resolver through its request-context entry
+and the conductor service's phase_progress reading through the actual resolvers
+(monkeypatched at their module home, not bypassed) with transcripts on disk.
+A UI guard asserts TokenTurns.tsx consumes the tokens_source prop. ALL FAIL today.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services import claude_transcripts as ct  # noqa: E402
+
+_PID = "token_source_pid"
+
+
+def _write_transcript(path: Path, turns: list[tuple[float, int]], sid: str = "") -> None:
+    """Write a Claude transcript JSONL: one assistant turn per (epoch, out).
+    When `sid` is given, each line carries that sessionId so _session_id_of
+    resolves it (current_session_id reads sessionId off the newest file)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    from datetime import datetime, timezone
+
+    lines = []
+    for ep, tok in turns:
+        ts = datetime.fromtimestamp(ep, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        evt = {"type": "assistant", "timestamp": ts,
+               "message": {"usage": {"output_tokens": tok}}}
+        if sid:
+            evt["sessionId"] = sid
+        lines.append(json.dumps(evt))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _conductor(tmp_path):
+    """ConductorService whose scores.db lives at <tmp>/projects/<pid>/scores.db
+    so phase_progress derives project_id == _PID for the resolvers."""
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    proj_dir = tmp_path / "projects" / _PID
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    scores_db = str(proj_dir / "scores.db")
+    task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    import sqlite3
+    conn = sqlite3.connect(scores_db)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS session_outcomes ("
+            "session_id TEXT PRIMARY KEY, duration_s REAL, tokens_used INTEGER, "
+            "files_read INTEGER, files_modified INTEGER, skills_invoked INTEGER)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return task_svc, cond
+
+
+def _patch_resolvers(monkeypatch, source_path: str, override_dir: str):
+    """Bind phase_progress's resolvers at their module homes (the REAL seam)."""
+    monkeypatch.setattr(ct, "_project_source_path", lambda pid: source_path)
+    from prism_service.services import claude_memory as cm
+    monkeypatch.setattr(cm, "configured_project_dir", lambda pid: override_dir)
+
+
+# ----------------------------------------------------------------------
+# Oracle (a) — authoritative link-session resolution.
+# current_session_id gains override_dir; _resolve_link_session_id returns the
+# REAL session id (not ctx.request_id) when source_path='' + override_dir set.
+# ----------------------------------------------------------------------
+
+def test_current_session_id_accepts_override_dir_param():
+    params = inspect.signature(ct.current_session_id).parameters
+    assert "override_dir" in params, (
+        "current_session_id must accept an override_dir param mirroring the "
+        "v6.3.21 readers (live_tokens_for_session etc.)"
+    )
+
+
+def test_current_session_id_resolves_real_sid_from_override_dir(tmp_path):
+    """With project_path empty but override_dir set, current_session_id resolves
+    the active transcript's sessionId via _override_session_paths — the REAL id,
+    not ''."""
+    real_sid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    d = tmp_path / "claudedir"
+    _write_transcript(d / f"{real_sid}.jsonl", [(time.time() - 5, 120)], sid=real_sid)
+
+    got = ct.current_session_id("", override_dir=str(d))
+    assert got == real_sid, (
+        f"current_session_id(override_dir) must return the real sessionId off "
+        f"disk, got {got!r}"
+    )
+
+
+def test_resolve_link_session_id_returns_real_not_request_handle(tmp_path, monkeypatch):
+    """_resolve_link_session_id must return the REAL transcript session id (not
+    ctx.request_id) when source_path is '' but claude_project_dir is configured.
+    This is the linkage fix that stops the phantom MCP-handle stamp."""
+    from prism_service.mcp import tools as mcp_tools
+    from prism_service.mcp.request_context import (
+        PrismRequestContext, use_request_context,
+    )
+
+    real_sid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    request_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
+    d = tmp_path / "claudedir"
+    _write_transcript(d / f"{real_sid}.jsonl", [(time.time() - 3, 90)], sid=real_sid)
+
+    # Folder-mode: source_path EMPTY, but claude_project_dir IS configured.
+    monkeypatch.setattr(ct, "_project_source_path", lambda pid: "")
+    from prism_service.services import claude_memory as cm
+    monkeypatch.setattr(cm, "configured_project_dir", lambda pid: str(d))
+
+    ctx = PrismRequestContext(project_id=_PID, request_id=request_handle)
+    with use_request_context(ctx):
+        got = mcp_tools._resolve_link_session_id()
+
+    assert got == real_sid, (
+        f"_resolve_link_session_id must resolve the REAL session via override_dir "
+        f"when source_path is empty — got {got!r} (request_handle would be the bug)"
+    )
+    assert got != request_handle, "must NOT fall through to the MCP request handle"
+
+
+# ----------------------------------------------------------------------
+# Oracle (b) — pending-LINKED vs in_progress-WALLCLOCK gate + tokens_source flag.
+# ----------------------------------------------------------------------
+
+def test_phase_progress_has_tokens_source_field(tmp_path, monkeypatch):
+    task_svc, cond = _conductor(tmp_path)
+    t = task_svc.create(title="needs-source-field")
+    cond.advance_task(t.id)
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(tmp_path / "empty"))
+
+    pp = cond.phase_progress(t.id)
+    assert "tokens_source" in pp, "phase_progress must return a tokens_source field"
+    assert pp["tokens_source"] in ("linked", "wallclock"), pp["tokens_source"]
+
+
+def test_pending_task_no_authoritative_turns_stays_linked_and_empty(tmp_path, monkeypatch):
+    """A PENDING task whose only linked session is an unresolvable MCP handle
+    must NOT borrow another task's project-wide burn: token_turns empty,
+    tokens_source=='linked'. (No painting a parked tile.)"""
+    task_svc, cond = _conductor(tmp_path)
+    mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
+    other_sid = "cccccccc-cccc-cccc-cccc-cccccccccccc"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    # There IS project activity on disk (a DIFFERENT session) — the old code
+    # would bucket it into this parked task's window.
+    _write_transcript(d / f"{other_sid}.jsonl", [(now - 30, 100), (now - 10, 200)], sid=other_sid)
+
+    t = task_svc.create(title="parked tile")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, mcp_handle)
+    task_svc.update(t.id, status="pending")
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["tokens_source"] == "linked", (
+        f"a pending task must stay tokens_source=='linked', got {pp['tokens_source']!r}"
+    )
+    assert pp["token_turns"] == [], (
+        f"a pending task with no authoritative turns must NOT borrow project-wide "
+        f"burn — got {len(pp['token_turns'])} turns"
+    )
+
+
+def test_in_progress_task_no_live_events_fills_via_wallclock(tmp_path, monkeypatch):
+    """An IN_PROGRESS task whose only linked session is an unresolvable MCP
+    handle fills via the project-wide wall-clock fallback, tagged
+    tokens_source=='wallclock'."""
+    task_svc, cond = _conductor(tmp_path)
+    mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
+    real_sid = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    _write_transcript(d / f"{real_sid}.jsonl",
+                      [(now - 40, 80), (now - 25, 120), (now - 5, 160)], sid=real_sid)
+
+    t = task_svc.create(title="worked tile")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, mcp_handle)
+    task_svc.update(t.id, status="in_progress")
+    _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["token_turns"], (
+        "an in_progress task with no live events must fill via the wall-clock "
+        "fallback — got empty series"
+    )
+    assert pp["tokens_source"] == "wallclock", (
+        f"wall-clock-derived series must be tagged tokens_source=='wallclock', "
+        f"got {pp['tokens_source']!r}"
+    )
+
+
+# ----------------------------------------------------------------------
+# Oracle (c) — wall-clock tokens_since_step == series sum (no graph/number lie).
+# ----------------------------------------------------------------------
+
+def test_wallclock_tokens_since_step_equals_series_sum(tmp_path, monkeypatch):
+    """When tokens_source=='wallclock', tokens_since_step is fed from the SAME
+    fallback events: > 0 AND == the sum of the series' per-turn output tokens.
+    No '2625 turns / 0 tokens' contradiction."""
+    task_svc, cond = _conductor(tmp_path)
+    mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
+    real_sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    turns_in = [(now - 40, 80), (now - 25, 120), (now - 5, 160)]
+    _write_transcript(d / f"{real_sid}.jsonl", turns_in, sid=real_sid)
+
+    t = task_svc.create(title="worked tile sum")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, mcp_handle)
+    task_svc.update(t.id, status="in_progress")
+    _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["tokens_source"] == "wallclock", pp["tokens_source"]
+    series_sum = sum(int(turn["out"]) for turn in pp["token_turns"])
+    assert series_sum > 0, "wall-clock series must carry real per-turn tokens"
+    assert pp["tokens_since_step"] == series_sum, (
+        f"tokens_since_step ({pp['tokens_since_step']}) must equal the wall-clock "
+        f"series sum ({series_sum}) — the graph and the number must agree"
+    )
+
+
+# ----------------------------------------------------------------------
+# UI guard — TokenTurns.tsx must consume a tokens_source prop and dim/label
+# the 'wallclock' (project activity) case. Asserts the real UI seam exists.
+# ----------------------------------------------------------------------
+
+def test_token_turns_component_consumes_tokens_source_prop():
+    tsx = (_SERVICE_ROOT / "prism_service" / "web" / "src" / "components"
+           / "conductor" / "TokenTurns.tsx").read_text(encoding="utf-8")
+    assert "tokens_source" in tsx or "tokensSource" in tsx, (
+        "TokenTurns.tsx must consume a tokens_source / tokensSource prop"
+    )
+    assert re.search(r"project activity", tsx, re.IGNORECASE), (
+        "TokenTurns.tsx must label the wall-clock case 'project activity "
+        "(approximate)'"
+    )

--- a/services/prism-service/tests/unit/test_phase_progress_token_turns.py
+++ b/services/prism-service/tests/unit/test_phase_progress_token_turns.py
@@ -200,6 +200,12 @@ def test_phase_progress_falls_back_for_mcp_handle_sessions(tmp_path, monkeypatch
     t = task_svc.create(title="mcp-handle tile")
     cond.advance_task(t.id)
     task_svc.link_session(t.id, mcp_handle)
+    # Honesty gate (#647d9c41, follow-up to #137): the project-wide wall-clock
+    # fallback now fires ONLY for the task actually being worked. This oracle's
+    # intent — an MCP-handle task still shows its turns via the fallback — holds
+    # for an in_progress task; a parked/pending one stays honestly blank (pinned
+    # by tests/unit/test_conductor_token_source.py).
+    task_svc.update(t.id, status="in_progress")
 
     _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
 


### PR DESCRIPTION
## What

Follow-up to #137 (now closed). 6.3.21 made the conductor burn graph render; this makes its per-task attribution **honest**. Two coupled correctness items reported on #137 ([comment 4628481877](https://github.com/siegeon/.prism/issues/137#issuecomment-4628481877), [comment 4633161694](https://github.com/siegeon/.prism/issues/137#issuecomment-4633161694)):

1. **Per-task duplication** — with the wall-clock fallback live, every managed tile plotted the *same* project-wide series (two tasks both showed `turns=2625`, identical signature). The fallback only fires because task↔session links were stale 32-hex MCP request handles that map to no transcript.
2. **Source mismatch** — a pending tile filled its graph (wall-clock fallback) while `tokens_since_step` showed `0` (linked-only): one tile said "2625 turns of burn" **and** "0 tokens since step".

## How

1. **Authoritative linkage** — `current_session_id` gains an `override_dir` param (mirroring the v6.3.21 readers); `_resolve_link_session_id` resolves it via `claude_memory.configured_project_dir(project_id)` and stamps the **real** session id even when `source_path` is empty/cwd-mismatched (the #134 scenario), instead of falling through to the phantom request handle. Reduces reliance on the fallback.
2. **`in_progress` fallback gate** — `phase_progress` applies the wall-clock fallback only when the driven task's `status == "in_progress"`; parked/pending tiles stay honestly blank rather than painting another task's burn.
3. **`tokens_source` flag** — `phase_progress` returns `tokens_source: "linked" | "wallclock"` so the SPA can distinguish authoritative from approximate.
4. **Source consistency** — when the series is wall-clock-derived, `tokens_since_step` is fed from the **same** events (sum), so the graph and the number always agree.
5. **UI** — `TokenTurns.tsx` consumes `tokens_source`: `linked` renders normally; `wallclock` is dimmed (opacity 0.55) and labelled "project activity (approximate)".

## Verification

- `pytest tests/unit -q` → **700 passed**. New `test_conductor_token_source.py` (8 cases) covers all 3 oracle cases: (a) `_resolve_link_session_id` returns the real `current_session_id` (not the request handle) when only `claude_project_dir` is set; (b) pending task stays `linked`+empty while an `in_progress` task fills via `wallclock`; (c) wall-clock `tokens_since_step` > 0 and equals the series sum.
- **Live dev:8888** (v6.3.22): screenshot `docs/conductor_tokens_source_8888.png` shows the driven `in_progress` tile at full opacity with its own burn series, and a second tile dimmed + labelled "PROJECT ACTIVITY (APPROXIMATE)" — **distinct series, no duplication**.

Driven end-to-end through the PRISM conductor `implement` workflow; the `ui`-artifact green gate was satisfied with the :8888 screenshot receipt.

Known limitation (documented, accepted): a single driving session that works multiple tasks sequentially still can't be split per-task by either path; the `in_progress` gate + `tokens_source` flag make this **honest** rather than wrong.

Follow-up to #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
