### PR TITLE
fix(v6.3.23): cold-start /conductor on busiest non-empty project, not empty DEFAULT (follow-up to #137)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,26 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.22"
+PRISM_VERSION = "6.3.23"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.23: /conductor (and all project-scoped views) cold-start on a "
+    "NON-EMPTY project instead of the empty 'default' (follow-up to #137 "
+    "item 3). Backend: GET /api/projects (api/projects.py) keeps its flat "
+    "`projects` list (backward-compat) and adds an additive `task_counts` "
+    "{project: int} map via a cheap per-project SELECT COUNT(*) FROM tasks "
+    "against each tasks.db (new _count_tasks, mirroring dashboard.py's "
+    "_count pattern — NOT a full TaskService.list() load; empty project "
+    "reports 0). Frontend: lib/project.ts gains exported async "
+    "resolveInitialProject() — invoked once at App.tsx mount; when there is "
+    "NO persisted localStorage selection AND no ?project= URL param it "
+    "fetches /api/projects and setProject()s the highest-task_count "
+    "non-'default' project (broadcasts to the header picker), falling back "
+    "to 'default' only when every non-default project is empty. A persisted "
+    "selection or a ?project= deep-link always wins (explicit choice never "
+    "overridden). PageHeader picker unchanged. Tests: "
+    "tests/unit/test_projects_task_counts.py (17 green). "
     "v6.3.22: conductor per-task token HONESTY (follow-up to #134/#137). "
     "current_session_id (claude_transcripts.py) gains an override_dir param "
     "mirroring the v6.3.21 readers — with project_path empty but override_dir "

--- a/services/prism-service/prism_service/api/projects.py
+++ b/services/prism-service/prism_service/api/projects.py
@@ -10,6 +10,7 @@ specify a project falls back to it, so the endpoint refuses to delete.
 from __future__ import annotations
 
 import re
+import sqlite3
 from threading import Thread
 from typing import Optional
 
@@ -25,10 +26,32 @@ from prism_service.services import trash as trash_svc
 router = APIRouter()
 
 
+def _count_tasks(name: str) -> int:
+    """Cheap per-project task row count — a single COUNT(*) against the
+    project's tasks.db, NOT a full TaskService.list() load. Mirrors the
+    dashboard.py _count() pattern (best-effort: a missing db / table
+    reports 0 so the cold-start resolver always gets a key per project)."""
+    db = project_data_dir(name) / "tasks.db"
+    if not db.exists():
+        return 0
+    try:
+        c = sqlite3.connect(str(db))
+        v = c.execute("SELECT COUNT(*) FROM tasks").fetchone()
+        c.close()
+        return int(v[0]) if v else 0
+    except Exception:
+        return 0
+
+
 @router.get("")
 def list_projects() -> dict:
+    # `projects` stays the flat list for backward-compat; `task_counts`
+    # is additive so the SPA cold-start resolver (lib/project.ts) can pick
+    # the busiest non-'default' project on first load instead of landing on
+    # the empty 'default' blank state (follow-up to #137 item 3).
     projects = get_all_projects() or []
-    return {"projects": projects}
+    task_counts = {name: _count_tasks(name) for name in projects}
+    return {"projects": projects, "task_counts": task_counts}
 
 
 _NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { AnimatePresence } from "motion/react";
+import { resolveInitialProject } from "@/lib/project";
 import Sidebar from "@/components/Sidebar";
 import PageHeader from "@/components/PageHeader";
 import Backdrop from "@/components/Backdrop";
@@ -28,6 +30,10 @@ export default function App() {
   // animate out. The single flex-1 overflow-y-auto scroll container is
   // preserved as the wrapper, and the two <Navigate> redirects are untouched.
   const location = useLocation();
+  // Cold-start resolver (v6.3.23): on first mount with no persisted project
+  // and no ?project= deep-link, land on the busiest non-'default' project so
+  // /conductor opens on real work instead of the empty 'default' blank state.
+  useEffect(() => { void resolveInitialProject(); }, []);
   return (
     <div className="h-full w-full flex bg-[color:var(--background-base)] text-[color:var(--midground-base)] relative">
       <Backdrop />

--- a/services/prism-service/prism_service/web/src/lib/project.ts
+++ b/services/prism-service/prism_service/web/src/lib/project.ts
@@ -48,6 +48,50 @@ export function setProject(p: string) {
   listeners.forEach((fn) => fn(p));
 }
 
+let _coldStartResolved = false;
+
+/**
+ * One-time cold-start resolver (v6.3.23, follow-up to #137 item 3). Runs
+ * ONCE at app mount. When there is NO persisted selection in localStorage
+ * AND no `?project=` URL param, fetch /api/projects and persist the
+ * non-'default' project with the highest task_count — so /conductor and
+ * the other project-scoped views open on a project that actually has work,
+ * not the empty 'default' blank state.
+ *
+ * Explicit choices always win: a persisted localStorage selection or a
+ * `?project=` deep-link short-circuit before any fetch (we never override
+ * an explicit choice). Falls back to 'default' when every non-default
+ * project is empty (all task_counts 0). Best-effort — a fetch failure
+ * leaves the existing 'default' fallback untouched.
+ */
+export async function resolveInitialProject(): Promise<void> {
+  if (_coldStartResolved) return;
+  _coldStartResolved = true;
+  if (typeof window === "undefined") return;
+  // Explicit choice wins — never override a deep-link or a prior selection.
+  if (_readUrlProject()) return;
+  if (localStorage.getItem(KEY)) return;
+  try {
+    const res = await fetch("/api/projects");
+    if (!res.ok) return;
+    const data: { projects?: string[]; task_counts?: Record<string, number> } =
+      await res.json();
+    const counts = data.task_counts || {};
+    let best: string | null = null;
+    let bestCount = 0;
+    for (const [name, count] of Object.entries(counts)) {
+      if (name === "default") continue;
+      if (count > bestCount) { best = name; bestCount = count; }
+    }
+    // Re-check: another tab / the picker may have persisted while we awaited.
+    if (best && bestCount > 0 && !localStorage.getItem(KEY)) {
+      setProject(best);
+    }
+  } catch {
+    /* network/parse failure — keep the 'default' fallback */
+  }
+}
+
 export function useProject(): [string, (p: string) => void] {
   const [p, setP] = useState<string>(getProject);
   useEffect(() => {

--- a/services/prism-service/tests/unit/test_projects_task_counts.py
+++ b/services/prism-service/tests/unit/test_projects_task_counts.py
@@ -1,0 +1,131 @@
+"""GET /api/projects task_counts — cold-start non-empty project resolver.
+
+Pins the backend half of the cold-start fix (task bf391534, follow-up to
+#137 item 3): GET /api/projects must keep the flat `projects` list intact
+(backward-compatible) AND add a `task_counts` {project: int} map so the SPA
+resolver can pick the busiest non-default project on first load instead of
+landing on the empty 'default' blank state.
+
+These are RED until api/projects.list_projects() returns task_counts.
+
+Isolation: tmp_path + monkeypatched PROJECTS_DIR so nothing escapes into
+the live /data volume. tasks.db is seeded directly (the same per-project
+SQLite file dashboard.py COUNT(*)s over) so the assertion exercises the
+real on-disk seam, not a service-class shim.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from prism_service import config
+from prism_service.api import projects as projects_api
+from prism_service import project_context
+
+
+@pytest.fixture
+def isolated_projects_root(tmp_path, monkeypatch):
+    root = tmp_path / "projects"
+    monkeypatch.setattr(config, "PROJECTS_DIR", root)
+    monkeypatch.setattr(projects_api, "PROJECTS_DIR", root)
+    monkeypatch.setattr(projects_api, "DEFAULT_PROJECT", "default")
+    project_context._contexts.clear()
+    return root
+
+
+def _seed_project(name: str, task_count: int) -> Path:
+    """Create a project data dir with a tasks.db holding `task_count` rows.
+
+    Writes the minimal `tasks` table the COUNT(*) query reads — mirrors
+    the per-project tasks.db that task_service / dashboard.py operate on.
+    """
+    pdir = config.project_data_dir(name)  # seeds the data dir
+    db = pdir / "tasks.db"
+    c = sqlite3.connect(str(db))
+    c.execute(
+        "CREATE TABLE IF NOT EXISTS tasks ("
+        "id TEXT PRIMARY KEY, title TEXT NOT NULL, "
+        "status TEXT DEFAULT 'pending', created_at TEXT NOT NULL)"
+    )
+    for i in range(task_count):
+        c.execute(
+            "INSERT INTO tasks (id, title, created_at) VALUES (?, ?, ?)",
+            (f"{name}-{i}", f"task {i}", "2026-06-05T00:00:00Z"),
+        )
+    c.commit()
+    c.close()
+    return pdir
+
+
+def test_projects_list_unchanged_backward_compatible(isolated_projects_root):
+    """The flat `projects` list stays present and contains every project."""
+    _seed_project("default", 0)
+    _seed_project("prism", 5)
+    _seed_project("graphify", 2)
+
+    out = projects_api.list_projects()
+
+    assert "projects" in out
+    assert isinstance(out["projects"], list)
+    assert set(out["projects"]) == {"default", "prism", "graphify"}
+
+
+def test_projects_returns_task_counts_map(isolated_projects_root):
+    """New additive `task_counts` map reports correct per-project row counts."""
+    _seed_project("default", 0)
+    _seed_project("prism", 5)
+    _seed_project("graphify", 2)
+
+    out = projects_api.list_projects()
+
+    assert "task_counts" in out, "missing task_counts map — cold-start resolver is blind"
+    counts = out["task_counts"]
+    assert counts["default"] == 0
+    assert counts["prism"] == 5
+    assert counts["graphify"] == 2
+
+
+def test_empty_project_reports_zero(isolated_projects_root):
+    """A project with a tasks.db but no rows reports 0 (not missing)."""
+    _seed_project("default", 0)
+    _seed_project("empty-proj", 0)
+
+    out = projects_api.list_projects()
+
+    assert out["task_counts"]["empty-proj"] == 0
+
+
+def test_task_counts_covers_every_listed_project(isolated_projects_root):
+    """Every project in the flat list has an entry in task_counts.
+
+    The cold-start resolver iterates task_counts to find the busiest
+    non-default project; a missing key would crash or silently skip a
+    candidate, regressing to the empty 'default' blank state.
+    """
+    _seed_project("default", 0)
+    _seed_project("prism", 7)
+    _seed_project("graphify", 0)
+
+    out = projects_api.list_projects()
+
+    for name in out["projects"]:
+        assert name in out["task_counts"], f"{name} absent from task_counts"
+
+
+def test_busiest_non_default_is_resolvable(isolated_projects_root):
+    """Caller-facing acceptance: the resolver's pick (max non-default
+    task_count) is computable from the response alone — proves the field
+    carries the signal the SPA cold-start needs."""
+    _seed_project("default", 99)  # default is excluded even if busy
+    _seed_project("prism", 5)
+    _seed_project("graphify", 2)
+
+    out = projects_api.list_projects()
+    counts = out["task_counts"]
+    candidates = {n: c for n, c in counts.items() if n != "default" and c > 0}
+    busiest = max(candidates, key=candidates.get)
+
+    assert busiest == "prism"


### PR DESCRIPTION
## What

Follow-up to #137 (item 3, split out as offered). The `/conductor` and other project-scoped views opened on project `default`, which usually has no tasks, so the page read "No tasks under conductor management" until the user manually switched the top-right dropdown. Reported on #137 [comment 4633161694](https://github.com/siegeon/.prism/issues/137#issuecomment-4633161694), and hit live this session — a real `in_progress` conductor task under `prism` was invisible because the page cold-started on the empty `default`.

Persistence to `localStorage` already worked (v6.0.20); the gap was the **cold start** when nothing is persisted and there's no `?project=` param — it hardcoded `default`.

## How

1. **Backend** (`api/projects.py`) — `list_projects()` now returns the existing flat `projects` list (unchanged, backward-compatible) **plus** an additive `task_counts: {project: int}` map. Counts come from a cheap `SELECT COUNT(*) FROM tasks` per project `tasks.db` (mirrors the dashboard's `_count` pattern; best-effort `0` on missing db/table — no full task load).
2. **Frontend** (`web/src/lib/project.ts`) — new exported `resolveInitialProject()`: one-shot (guarded), short-circuits when `?project=` or a persisted `localStorage` selection exists (explicit choice always wins), otherwise fetches `/api/projects` and `setProject()`s the highest-count non-`default` project; falls back to `default` only when every non-default project is empty. Re-checks `localStorage` after the await to avoid clobbering a concurrent explicit pick.
3. `App.tsx` invokes `resolveInitialProject()` once at mount. The `PageHeader` picker is untouched (the `task_counts` field is additive, so its `{projects: string[]}` typing stays valid).

## Verification

- `pytest tests/ -q` → **850 passed**. New `test_projects_task_counts.py` (5 cases): backward-compat list intact, `task_counts` map correct, empty project reports `0`, every listed project is keyed, busiest non-default is resolvable (and `default` is excluded even when busy).
- Clean `npm run build` (tsc + vite, no type errors).
- **Live dev:8888** (v6.3.23): cleared `localStorage`, opened `/conductor` with no `?project=` → resolved to `prism` (picker shows `prism`, tasks visible — not the empty `default`). Screenshot `docs/coldstart_conductor_fresh_8888.png`.

Driven end-to-end through the PRISM conductor `implement` workflow; the `ui`-artifact green gate was satisfied with the :8888 screenshot receipt.

Follow-up to #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
