### PR TITLE
feat(v6.3.24): /conductor swimlanes show top-level tasks only

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.23"
+PRISM_VERSION = "6.3.24"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.24: /conductor swimlanes show TOP-LEVEL tasks only. "
+    "ConductorService.managed_tasks() and step_buckets() now skip any task "
+    "with a parent_id (mirroring the /tasks board's root-only filter) on top "
+    "of the existing done/cancelled exclusion — so demo/verification subtasks "
+    "stop rendering as standalone tiles and inflating step counts. Regression "
+    "test test_managed_tasks_and_buckets_show_only_top_level pins it. "
     "v6.3.23: /conductor (and all project-scoped views) cold-start on a "
     "NON-EMPTY project instead of the empty 'default' (follow-up to #137 "
     "item 3). Backend: GET /api/projects (api/projects.py) keeps its flat "

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1539,6 +1539,11 @@ class ConductorService:
             # audit trail but must not render as currently-managed tiles.
             if status in ("done", "cancelled"):
                 continue
+            # Conductor mirrors the /tasks board: only TOP-LEVEL tasks are
+            # tiles. Subtasks (parent_id set) belong under their parent's
+            # detail page, never as standalone swimlane cards.
+            if getattr(t, "parent_id", ""):
+                continue
             if step == "" and gate == "none":
                 # Claimed by a workflow but pre-first-advance (the Locate /
                 # draft_story intake window): surface in a synthetic leading
@@ -1590,6 +1595,8 @@ class ConductorService:
             step = getattr(t, "workflow_step", "") or ""
             status = getattr(t, "status", "") or ""
             if status in ("done", "cancelled"):
+                continue
+            if getattr(t, "parent_id", ""):
                 continue
             if not step:
                 # Mirror managed_tasks: claimed-but-pre-step in_progress work

--- a/services/prism-service/tests/integration/test_ui_first_conductor_gate_admin_surfaces.py
+++ b/services/prism-service/tests/integration/test_ui_first_conductor_gate_admin_surfaces.py
@@ -174,6 +174,30 @@ def test_post_conductor_advance_moves_task(tmp_path, monkeypatch):
     assert task_svc.get(t.id).workflow_step == "review_previous_notes"
 
 
+def test_managed_tasks_and_buckets_show_only_top_level(tmp_path, monkeypatch):
+    """Conductor swimlanes mirror the /tasks board: top-level tasks only.
+
+    A subtask (parent_id set) — even one actively at a workflow step — must
+    NOT appear as its own tile or inflate a step bucket; it lives under its
+    parent's detail page. Regression for the demo/verification subtasks that
+    were cluttering /conductor.
+    """
+    _, task_svc, cond = _client(tmp_path, monkeypatch)
+
+    parent = task_svc.create(title="parent epic")
+    _drive_to_red_gate(task_svc, cond, parent.id)
+
+    child = task_svc.create(title="verify subtask", parent_id=parent.id)
+    _drive_to_red_gate(task_svc, cond, child.id)
+
+    ids = {row["id"] for row in cond.managed_tasks()}
+    assert parent.id in ids, "top-level task must show on /conductor"
+    assert child.id not in ids, "subtask must NOT show as a standalone tile"
+
+    # step_buckets must agree: exactly one task at red_gate (the parent).
+    assert cond.step_buckets().get("red_gate") == 1, cond.step_buckets()
+
+
 # =====================================================================
 # Half B/C — frontend raw-dump + dead-page hygiene (disk scan of the
 # real SPA source). These pin the USER-FACING render, not a unit shim.


### PR DESCRIPTION
## What
`ConductorService.managed_tasks()` and `step_buckets()` now skip any task with a `parent_id`, mirroring the `/tasks` board's root-only filter, on top of the existing `done`/`cancelled` exclusion.

## Why
Subtasks (demo/verification children) were rendering as standalone tiles on `/conductor` and inflating step-bucket counts. The kanban board already shows root tasks only (`roots = tasks.filter(t => !t.parent_id)`); the conductor view now matches.

## Tests
- New regression: `test_managed_tasks_and_buckets_show_only_top_level` — a child task driven to `red_gate` must NOT appear in `managed_tasks` nor inflate `step_buckets`.
- Local gates green: `tsc -b` (0), `pytest tests/unit` (705 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)