### PR TITLE
feat(v6.3.28): task-detail Activity Gantt + synthetic-session leak fix + verifier pytest-invocation fix

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.27"
+PRISM_VERSION = "6.3.28"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.28: task-detail Activity Gantt (Way 1) — real transcript-backed "
+    "session lanes render as wall-time bars + gate honesty markers (override "
+    "hollow '!' / verified solid '✓'); synthetic gate-actor labels "
+    "(qa-red-gate-*, *-verifier-*) NO LONGER leak as bare session rows. New "
+    "api/tasks._build_timeline rides GET /api/tasks/{id} as a `timeline` block; "
+    "TaskActivityGantt.tsx + TaskDetailPage realSessions UUID filter. "
     "v6.3.27: Learned per-step ETA on the conductor tile (task 68a9720e) + "
     "the gate-verifier ROOT FIX. ETA: conductor_service gains _per_step_typical "
     "(median dwell per workflow step, learned from advance_task history) and "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -1,6 +1,7 @@
 """Tasks API — kanban list, detail, transitions, history."""
 
 import dataclasses
+import re
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Query
@@ -137,6 +138,83 @@ def next_task(project: str = Query("default")) -> dict:
     return {"next": _svc(project).next_task()}
 
 
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+
+
+def _build_timeline(history: list, sessions: list) -> dict:
+    """Typed activity timeline backing the task-detail Gantt (Way 1).
+
+    Two row kinds, deliberately NOT one-size-fits-all:
+      * lanes  — REAL transcript-backed work sessions (UUID id), positioned as
+        wall-time bars. Synthetic gate-actor labels (qa-red-gate-*, *-verifier-*)
+        are EXCLUDED here — they were never sessions; they surface as gate
+        markers instead. This is the fix for the bare-row leak.
+      * gates  — one marker per gate RESOLUTION (the deciding gate_decide row),
+        carrying honesty (real-verifier vs override), actor, and proof summary.
+    """
+    from datetime import datetime, timezone
+
+    def _epoch(ts: object) -> float | None:
+        try:
+            return datetime.fromisoformat(
+                str(ts).replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            return None
+
+    now = datetime.now(timezone.utc).timestamp()
+    hstamps = [e for e in (_epoch(h.get("timestamp")) for h in history
+                           if isinstance(h, dict)) if e is not None]
+    start = min(hstamps) if hstamps else now
+    end = max(now, max(hstamps) if hstamps else now)
+
+    lanes = []
+    for s in sessions or []:
+        sid = s.get("session_id", "") if isinstance(s, dict) else ""
+        if not _UUID_RE.match(sid or ""):
+            continue  # synthetic actor label -> not a work session lane
+        st = _epoch(s.get("started_at")) or start
+        dur = float(s.get("duration_s") or 0)
+        en = _epoch(s.get("ended_at")) or (st + dur if dur else end)
+        lanes.append({
+            "session_id": sid, "start": st, "end": max(en, st),
+            "duration_s": s.get("duration_s") or 0,
+            "skills": s.get("skills_invoked") or 0,
+            "live": s.get("ended_at") is None,
+        })
+
+    gates = []
+    for h in history:
+        if not isinstance(h, dict) or h.get("action") != "gate_decide":
+            continue
+        det = str(h.get("details") or "")
+        # Skip the intermediate REJECTED attempt (verifier=fail, not yet
+        # overridden) — show only the row that RESOLVED the gate.
+        if "verifier=fail" in det and "override=True" not in det:
+            continue
+        ts = _epoch(h.get("timestamp"))
+        if ts is None:
+            continue
+        gm = re.search(r"gate=(\w+?)_gate", det)
+        gate = gm.group(1) if gm else "gate"
+        override = ("override=True" in det
+                    or (h.get("actor") or "") == "manual-override")
+        am = re.search(r"override-actor=([^\s;]+)", det)
+        actor = am.group(1) if am else (h.get("actor") or "")
+        # Real suite result needs 2+ digits so "0/1 pass" can't masquerade as a
+        # green suite; red gates carry a "trace" proof instead.
+        pm = re.search(r"(\d{2,})\s+passed", det)
+        proof = (f"suite {pm.group(1)}✓" if pm
+                 else "trace" if "trace" in det.lower() else "")
+        gates.append({
+            "gate": gate, "ts": ts, "actor": actor, "override": override,
+            "verified": not override, "proof": proof, "reason": det[:200],
+        })
+
+    return {"window": {"start": start, "end": end},
+            "lanes": lanes, "gates": gates}
+
+
 @router.get("/{task_id}")
 def get_task(task_id: str, project: str = Query("default")) -> dict:
     svc = _svc(project)
@@ -163,6 +241,8 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
     # Attribute per-turn token spend (output_tokens bucketed into each turn's
     # (prev, this] wall-clock window) onto the history rows. Best-effort.
     _attach_turn_tokens(out["history"], out["sessions"], project)
+    # Way 1 — typed activity Gantt (real session lanes + gate markers).
+    out["timeline"] = _build_timeline(out["history"], out["sessions"])
     # phase_progress (a5e0d9f5): the animated SDLC bar in the detail header
     # reads the blended current-step fill. Best-effort — never break the
     # detail route if conductor is unavailable.

--- a/services/prism-service/prism_service/services/verifier_service.py
+++ b/services/prism-service/prism_service/services/verifier_service.py
@@ -281,7 +281,15 @@ def _run_python_tools(workspace: Path, py_files: list[str]) -> list[Claim]:
     # Runs whenever pytest is available as a PATH binary OR an importable
     # module (so a venv-only `python -m pytest` install still gates).
     if py_files and _pytest_available():
-        rc, out, err = _run_tool(["pytest", "-q", "--no-header"], workspace, timeout_s=600.0)
+        # Invoke via the running interpreter, NOT a bare `pytest`: on Windows
+        # `pytest` isn't on PATH (it's a venv Scripts entry), so the bare cmd
+        # raised [WinError 2] -> exit 127 -> the suite was SKIPPED and the gate
+        # saw a FALSE pass (0 tests run). sys.executable is the daemon's
+        # interpreter, which has pytest importable, so `-m pytest` always runs.
+        import sys as _sys
+        rc, out, err = _run_tool(
+            [_sys.executable, "-m", "pytest", "-q", "--no-header"],
+            workspace, timeout_s=600.0)
         claims.append(_claim(0, "tooling.pytest", "<full-suite>", rc, out, err))
     return claims
 

--- a/services/prism-service/prism_service/web/src/components/conductor/TaskActivityGantt.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/TaskActivityGantt.tsx
@@ -1,0 +1,182 @@
+// Way 1 — task ACTIVITY Gantt (bar-based, graphical, click-to-drill).
+// Replaces the flat "sessions" list as the way to see WHAT HAPPENED on a task:
+// real work sessions render as wall-time bars on a shared time axis; gate
+// decisions render as honesty markers (real-verifier vs override) on their own
+// lane. Synthetic gate-actor labels are NEVER drawn as bare session rows — they
+// ARE the gate markers. Same bar visual language as the TokenTurns burn graph.
+import { useState } from "react";
+import { motion } from "motion/react";
+
+export type GanttLane = {
+  session_id: string;
+  start: number; // epoch seconds
+  end: number;
+  duration_s: number;
+  skills: number;
+  live: boolean;
+};
+export type GanttGate = {
+  gate: string; // "red" | "green" | "gate"
+  ts: number;
+  actor: string;
+  override: boolean;
+  verified: boolean;
+  proof: string;
+  reason: string;
+};
+export type Timeline = {
+  window: { start: number; end: number };
+  lanes: GanttLane[];
+  gates: GanttGate[];
+};
+
+function clockHM(ts: number): string {
+  try {
+    return new Date(ts * 1000).toLocaleTimeString([], {
+      hour: "2-digit", minute: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+function fmtDur(s: number): string {
+  if (s >= 3600) return `${(s / 3600).toFixed(1)}h`;
+  if (s >= 60) return `${Math.round(s / 60)}m`;
+  return `${Math.round(s)}s`;
+}
+function shortId(id: string): string {
+  return id.length > 12 ? `${id.slice(0, 8)}…` : id;
+}
+
+export default function TaskActivityGantt({
+  timeline, reduced,
+}: { timeline: Timeline; reduced?: boolean | null }) {
+  const [open, setOpen] = useState<string | null>(null);
+  const { start, end } = timeline.window;
+  const span = Math.max(1, end - start);
+  const pct = (ts: number) =>
+    Math.max(0, Math.min(100, ((ts - start) / span) * 100));
+
+  // axis ticks at 0/25/50/75/100% of the window
+  const ticks = [0, 0.25, 0.5, 0.75, 1].map((f) => start + f * span);
+
+  if (timeline.lanes.length === 0 && timeline.gates.length === 0) {
+    return (
+      <p className="text-[12px] opacity-40 italic py-3">
+        No activity recorded yet.
+      </p>
+    );
+  }
+
+  return (
+    <div className="mt-2 select-none">
+      {/* time axis */}
+      <div className="relative h-4 ml-[120px] border-b border-[color:var(--border-default)]/40">
+        {ticks.map((t, i) => (
+          <span
+            key={i}
+            className="absolute -translate-x-1/2 text-[9px] font-mono text-[color:var(--text-muted)] opacity-60"
+            style={{ left: `${pct(t)}%` }}
+          >
+            {i === ticks.length - 1 ? "now" : clockHM(t)}
+          </span>
+        ))}
+      </div>
+
+      {/* session lanes */}
+      {timeline.lanes.map((l) => {
+        const left = pct(l.start);
+        const width = Math.max(1.5, pct(l.end) - left);
+        return (
+          <div key={l.session_id} className="flex items-center h-11 gap-2">
+            <button
+              onClick={() => setOpen(open === l.session_id ? null : l.session_id)}
+              className="w-[112px] shrink-0 text-right font-mono text-[10px] text-[color:var(--text-secondary)] truncate hover:opacity-100 opacity-80"
+              title={l.session_id}
+            >
+              {shortId(l.session_id)}
+            </button>
+            <div className="relative flex-1 h-7">
+              <motion.div
+                className="absolute top-1/2 -translate-y-1/2 h-5 rounded-sm cursor-pointer"
+                style={{
+                  left: `${left}%`, width: `${width}%`,
+                  background: l.live
+                    ? "var(--accent-amber-fg)"
+                    : "var(--accent-amber-bg)",
+                  boxShadow: "inset 0 0 0 1px var(--accent-amber-ring)",
+                }}
+                title={`${l.session_id} · ${fmtDur(l.duration_s)} · ${l.skills} skills${l.live ? " · live" : ""}`}
+                onClick={() => setOpen(open === l.session_id ? null : l.session_id)}
+                initial={false}
+                animate={l.live && !reduced
+                  ? { opacity: [1, 0.55, 1] } : { opacity: 1 }}
+                transition={l.live && !reduced
+                  ? { duration: 1.4, repeat: Infinity, ease: "easeInOut" } : { duration: 0.2 }}
+              />
+            </div>
+            <span className="w-[64px] shrink-0 text-[10px] font-mono text-[color:var(--text-muted)] tabular-nums">
+              {fmtDur(l.duration_s)}{l.skills ? ` · ${l.skills}sk` : ""}
+            </span>
+          </div>
+        );
+      })}
+
+      {/* gate marker lane */}
+      <div className="flex items-center h-11 gap-2 mt-1">
+        <span className="w-[112px] shrink-0 text-right font-mono text-[10px] text-[color:var(--text-muted)] uppercase tracking-wider">
+          gates
+        </span>
+        <div className="relative flex-1 h-7">
+          {timeline.gates.map((g, i) => {
+            const color = g.override
+              ? "var(--accent-amber-fg)" : "var(--accent-emerald-fg, #34d399)";
+            return (
+              <button
+                key={i}
+                onClick={() => setOpen(open === `g${i}` ? null : `g${i}`)}
+                className="absolute top-1/2 -translate-x-1/2 -translate-y-1/2 grid place-items-center"
+                style={{ left: `${pct(g.ts)}%` }}
+                title={`${g.gate}_gate · ${g.override ? "OVERRIDE" : "verified"} · ${g.actor}${g.proof ? " · " + g.proof : ""}\n${g.reason}`}
+              >
+                <span
+                  className="block h-3.5 w-3.5 rotate-45"
+                  style={{ background: color, boxShadow: `0 0 5px ${color}` }}
+                />
+                <span
+                  className="absolute -bottom-3 text-[8px] font-mono uppercase"
+                  style={{ color }}
+                >
+                  {g.gate}{g.override ? "!" : "✓"}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+        <span className="w-[64px] shrink-0" />
+      </div>
+
+      {/* drill-in detail for a clicked gate */}
+      {open?.startsWith("g") && (() => {
+        const g = timeline.gates[Number(open.slice(1))];
+        if (!g) return null;
+        return (
+          <div className="ml-[120px] mt-4 text-[11px] leading-snug rounded bg-[color:var(--surface-2)]/50 p-2 border border-[color:var(--border-default)]/40">
+            <span className="font-mono uppercase tracking-wider text-[color:var(--text-secondary)]">
+              {g.gate}_gate · {g.override ? "⚠ override" : "✓ verified"}
+            </span>
+            <div className="mt-1 opacity-70">actor: <span className="font-mono">{g.actor || "—"}</span>{g.proof ? ` · proof: ${g.proof}` : ""}</div>
+            <div className="mt-1 opacity-50 break-words">{g.reason}</div>
+          </div>
+        );
+      })()}
+
+      {/* legend */}
+      <div className="ml-[120px] mt-5 flex flex-wrap gap-x-4 gap-y-1 text-[9px] font-mono text-[color:var(--text-muted)] opacity-70">
+        <span><span className="inline-block h-2 w-3 align-middle rounded-sm" style={{ background: "var(--accent-amber-bg)" }} /> work session</span>
+        <span><span className="inline-block h-2 w-2 align-middle rotate-45" style={{ background: "var(--accent-amber-fg)" }} /> gate ! override</span>
+        <span><span className="inline-block h-2 w-2 align-middle rotate-45" style={{ background: "var(--accent-emerald-fg, #34d399)" }} /> gate ✓ verified</span>
+      </div>
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/lib/workflowChips";
 import PlanView from "@/components/plan/PlanView";
 import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import TaskActivityGantt, { type Timeline } from "@/components/conductor/TaskActivityGantt";
 import { EASE_OUT, DUR, SPRING_SNAPPY, staggerDelay } from "@/lib/motion";
 
 // Same status → tone map as TasksPage so the detail-page status chip
@@ -395,6 +396,7 @@ export default function TaskDetailPage() {
   const [task, setTask] = useState<Task | null>(null);
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [timeline, setTimeline] = useState<Timeline | null>(null);
   const [children, setChildren] = useState<ChildTask[]>([]);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
@@ -423,7 +425,7 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null }>(
         `/api/tasks/${id}?project=${project}`,
       );
       // phase_progress rides at the TOP LEVEL of the response (not nested in
@@ -431,6 +433,7 @@ export default function TaskDetailPage() {
       setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
+      setTimeline(d.timeline ?? null);
       setError(null);
       // Children aren't on the detail payload — derive them from the task
       // list (parent_id === this id). Cheap, and keeps the API unchanged.
@@ -537,6 +540,11 @@ export default function TaskDetailPage() {
   const statusTone = STATUS_TONE[taskStatus] ?? "slate";
   const pTone = priorityTone(task.priority);
   const conductorOn = (task.workflow_step ?? "") !== "" || (task.gate_state ?? "none") !== "none";
+  // Only transcript-backed (UUID) sessions are real work sessions. Synthetic
+  // gate-actor labels (qa-red-gate-*, *-verifier-*) surface as gate markers in
+  // the Activity Gantt, never as bare session rows.
+  const realSessions = sessions.filter((s) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(s.session_id));
 
   return (
     <Page>
@@ -895,12 +903,21 @@ export default function TaskDetailPage() {
       </Card>
 
       <Card>
-        <SectionLabel>Sessions ({sessions.length})</SectionLabel>
-        {sessions.length === 0 ? (
+        <SectionLabel>Activity</SectionLabel>
+        {timeline ? (
+          <TaskActivityGantt timeline={timeline} reduced={reduced} />
+        ) : (
+          <Empty>No activity recorded yet.</Empty>
+        )}
+      </Card>
+
+      <Card>
+        <SectionLabel>Sessions ({realSessions.length})</SectionLabel>
+        {realSessions.length === 0 ? (
           <Empty>No Claude sessions linked to this task yet.</Empty>
         ) : (
           <ul className="divide-y divide-[color:var(--midground-base)]/10 mt-2">
-            {sessions.map((s) => (
+            {realSessions.map((s) => (
               <li key={s.session_id} className="py-3">
                 <div className="flex items-baseline justify-between gap-3 flex-wrap">
                   <span className="font-mono text-[12px] break-all">{s.session_id}</span>

--- a/services/prism-service/tests/integration/test_task_activity_gantt.py
+++ b/services/prism-service/tests/integration/test_task_activity_gantt.py
@@ -1,0 +1,262 @@
+"""RED scaffold — task-detail Activity Gantt + stop the synthetic-gate-actor
+leak (task ade01b38).
+
+Pins the USER-FACING seams, not unit contracts:
+
+Backend (api/tasks._build_timeline + GET /api/tasks/{id}.timeline):
+  * lanes contain ONLY transcript-backed UUID-shaped session ids; non-UUID
+    synthetic gate-actor labels (qa-red-gate-*, *-verifier-*) are EXCLUDED
+    from lanes — the leak fix.
+  * each lane carries session_id, start, end (>=start), duration_s, skills,
+    live(=ended_at is None).
+  * gates markers derive from history action=='gate_decide' rows with correct
+    gate/ts/actor/override/verified(=not override)/proof, and SKIP the
+    intermediate REJECTED attempt (verifier=fail w/o override=True), rendering
+    only the RESOLVING row.
+  * the new field rides the REAL GET /api/tasks/{id} route (not just the
+    helper) — asserted through FastAPI TestClient end-to-end.
+
+Frontend (scanned on disk — the render path is the seam):
+  * web/src/components/conductor/TaskActivityGantt.tsx exists, exports a
+    Timeline type, draws a time axis + per-session bars + gate honesty markers
+    (override hollow '!' / verified '✓'), click-to-drill.
+  * TaskDetailPage.tsx imports TaskActivityGantt, threads d.timeline into
+    state, renders it inside an 'Activity' Card, and filters the Sessions list
+    to realSessions (UUID-only) with the count reflecting realSessions.length.
+
+ALL must FAIL today: _build_timeline is absent (no `timeline` field on the
+route), the TSX component file does not exist, and TaskDetailPage still renders
+every raw session row.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+# .../services/prism-service/tests/integration/<file> -> service root is 3 up.
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_WEB_SRC = _SERVICE_ROOT / "prism_service" / "web" / "src"
+
+_REAL_SID = "6f64ed28-1111-2222-3333-444444444444"
+_BASE = "2026-06-05T20:"
+
+
+def _iso(mm: int, ss: int) -> str:
+    return f"{_BASE}{mm:02d}:{ss:02d}+00:00"
+
+
+def _sessions() -> list[dict]:
+    """One REAL work session (UUID) + two SYNTHETIC gate actors (non-UUID).
+
+    Mirrors task 3826dac3's real shape: the driving session plus the two gate
+    actors the no-self-override guard links. Only the UUID one is a real lane.
+    """
+    return [
+        {
+            "session_id": _REAL_SID,
+            "started_at": _iso(0, 0),
+            "ended_at": _iso(30, 0),
+            "duration_s": 1800,
+            "tokens_used": 1234,
+            "files_read": 5,
+            "files_modified": 3,
+            "skills_invoked": 7,
+        },
+        {"session_id": "qa-red-gate-3826dac3", "started_at": None,
+         "ended_at": None, "duration_s": 0, "skills_invoked": 0},
+        {"session_id": "green-gate-verifier-3826dac3", "started_at": None,
+         "ended_at": None, "duration_s": 0, "skills_invoked": 0},
+    ]
+
+
+def _history() -> list[dict]:
+    """gate_decide rows: a REJECTED red attempt (verifier=fail, no override)
+    that must be SKIPPED, the RESOLVING red gate_decide, and a verified green
+    gate_decide carrying a real suite count."""
+    return [
+        {"id": 1, "action": "created", "timestamp": _iso(0, 0),
+         "actor": "", "details": ""},
+        {"id": 2, "action": "gate_decide", "timestamp": _iso(5, 0),
+         "actor": "qa", "details": "gate=red_gate verifier=fail; trace captured"},
+        {"id": 3, "action": "gate_decide", "timestamp": _iso(6, 0),
+         "actor": "manual-override",
+         "details": ("gate=red_gate verifier=fail; override=True "
+                     "override-actor=siegeon; trace captured")},
+        {"id": 4, "action": "gate_decide", "timestamp": _iso(25, 0),
+         "actor": "qa", "details": "gate=green_gate verifier=pass 47 passed"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Backend: _build_timeline contract
+# ---------------------------------------------------------------------------
+
+def test_lanes_exclude_non_uuid_synthetic_actors():
+    """THE LEAK FIX: only the UUID session becomes a lane; the two synthetic
+    gate-actor labels never do."""
+    from prism_service.api import tasks as T
+
+    tl = T._build_timeline(_history(), _sessions())
+    lane_ids = [l["session_id"] for l in tl["lanes"]]
+    assert lane_ids == [_REAL_SID], lane_ids
+    assert "qa-red-gate-3826dac3" not in lane_ids
+    assert "green-gate-verifier-3826dac3" not in lane_ids
+
+
+def test_lane_carries_expected_fields():
+    from prism_service.api import tasks as T
+
+    tl = T._build_timeline(_history(), _sessions())
+    (lane,) = tl["lanes"]
+    assert lane["session_id"] == _REAL_SID
+    assert lane["duration_s"] == 1800
+    assert lane["skills"] == 7
+    assert lane["live"] is False          # ended_at present
+    assert lane["end"] >= lane["start"]   # never inverted
+    assert "start" in tl["window"] and "end" in tl["window"]
+
+
+def test_live_lane_when_ended_at_is_none():
+    from prism_service.api import tasks as T
+
+    sess = [{
+        "session_id": _REAL_SID, "started_at": _iso(0, 0),
+        "ended_at": None, "duration_s": 0, "skills_invoked": 2,
+    }]
+    (lane,) = T._build_timeline(_history(), sess)["lanes"]
+    assert lane["live"] is True
+
+
+def test_gate_markers_skip_intermediate_rejected_attempt():
+    """Row 2 (red_gate verifier=fail, NO override) is the intermediate rejected
+    attempt and must NOT render; only the resolving rows do."""
+    from prism_service.api import tasks as T
+
+    gates = T._build_timeline(_history(), _sessions())["gates"]
+    assert len(gates) == 2, gates  # resolving red (override) + verified green
+    by_gate = {g["gate"]: g for g in gates}
+    assert set(by_gate) == {"red", "green"}
+
+
+def test_red_gate_marker_is_override_not_verified():
+    from prism_service.api import tasks as T
+
+    gates = T._build_timeline(_history(), _sessions())["gates"]
+    red = next(g for g in gates if g["gate"] == "red")
+    assert red["override"] is True
+    assert red["verified"] is False
+    assert red["actor"] in ("siegeon", "manual-override")
+    assert red["proof"] == "trace"
+
+
+def test_green_gate_marker_is_verified_with_suite_proof():
+    from prism_service.api import tasks as T
+
+    gates = T._build_timeline(_history(), _sessions())["gates"]
+    green = next(g for g in gates if g["gate"] == "green")
+    assert green["override"] is False
+    assert green["verified"] is True
+    assert "47" in green["proof"]  # "suite 47..." — real 2+ digit suite count
+
+
+# ---------------------------------------------------------------------------
+# Backend: the field rides the REAL GET /api/tasks/{id} route (end-to-end)
+# ---------------------------------------------------------------------------
+
+class _FakeTaskSvc:
+    """Minimal stand-in for TaskService — only what get_task touches."""
+
+    def __init__(self, task, history, sessions):
+        self._task, self._history, self._sessions = task, history, sessions
+
+    def get(self, _tid):
+        return self._task
+
+    def history(self, _tid):
+        return self._history
+
+    def sessions_for_task(self, _tid):
+        return self._sessions
+
+
+class _FakeCtx:
+    def __init__(self, task_svc):
+        self.task_svc = task_svc
+        self.conductor_svc = None  # best-effort phase_progress just skips
+
+
+def _client(monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from prism_service.api import tasks as tasks_api
+
+    task = {"id": "ade01b38", "title": "t", "status": "in_progress",
+            "priority": 0}
+    ctx = _FakeCtx(_FakeTaskSvc(task, _history(), _sessions()))
+    # _svc and get_task both resolve via api.tasks.get_project.
+    monkeypatch.setattr(tasks_api, "get_project", lambda _p: ctx)
+
+    app = FastAPI()
+    app.include_router(tasks_api.router, prefix="/api/tasks")
+    return TestClient(app)
+
+
+def test_route_returns_timeline_field_with_filtered_lanes(monkeypatch):
+    """The new `timeline` field is on the REAL route response (not just the
+    helper), and its lanes exclude the synthetic actors end-to-end."""
+    client = _client(monkeypatch)
+    r = client.get("/api/tasks/ade01b38?project=proj")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "timeline" in body, "GET /api/tasks/{id} must carry `timeline`"
+    tl = body["timeline"]
+    lane_ids = [l["session_id"] for l in tl["lanes"]]
+    assert lane_ids == [_REAL_SID], lane_ids
+    assert any(g["gate"] == "green" and g["verified"] for g in tl["gates"])
+
+
+# ---------------------------------------------------------------------------
+# Frontend: the render path is the seam (scanned on disk)
+# ---------------------------------------------------------------------------
+
+def _read(rel: str) -> str:
+    return (_WEB_SRC / rel).read_text(encoding="utf-8")
+
+
+def test_gantt_component_exists_and_exports_timeline_type():
+    p = _WEB_SRC / "components" / "conductor" / "TaskActivityGantt.tsx"
+    assert p.exists(), f"missing component: {p}"
+    src = p.read_text(encoding="utf-8")
+    assert "export type Timeline" in src
+    # time axis + per-session bars + gate honesty markers + click-to-drill.
+    assert "timeline.lanes" in src and "timeline.gates" in src
+    assert "override" in src and "verified" in src
+    assert "onClick" in src  # click-to-drill
+
+
+def test_taskdetail_threads_timeline_and_renders_activity_card():
+    src = _read("pages/TaskDetailPage.tsx")
+    assert "TaskActivityGantt" in src
+    assert "import" in src and "TaskActivityGantt" in src
+    assert "timeline" in src              # state threaded from d.timeline
+    assert "setTimeline" in src
+    assert "Activity" in src              # the new Card label
+    assert "<TaskActivityGantt" in src
+
+
+def test_taskdetail_sessions_list_filters_to_real_uuid_sessions():
+    """Synthetic metadata-less rows must never render; the count reflects
+    realSessions.length, not sessions.length."""
+    src = _read("pages/TaskDetailPage.tsx")
+    assert "realSessions" in src
+    # the count label must read off realSessions, not the raw sessions array.
+    assert "Sessions ({realSessions.length})" in src
+    assert "realSessions.map" in src
+    # a UUID guard must back the filter.
+    assert "[0-9a-f]{8}-[0-9a-f]{4}" in src

--- a/services/prism-service/tests/integration/test_task_session_association.py
+++ b/services/prism-service/tests/integration/test_task_session_association.py
@@ -277,8 +277,11 @@ def test_task_detail_page_renders_sessions_section():
 
 def test_task_detail_page_has_session_empty_state():
     src = (_WEB_SRC / "pages" / "TaskDetailPage.tsx").read_text(encoding="utf-8")
-    # An explicit 0-session branch (e.g. sessions.length === 0 ? <empty>).
-    assert "sessions.length === 0" in src, (
+    # An explicit 0-session branch (e.g. realSessions.length === 0 ? <empty>).
+    # The Sessions list now renders the UUID-filtered `realSessions` (synthetic
+    # gate-actor labels surface as Activity-Gantt markers, not bare rows), so the
+    # empty-state branch keys off realSessions.length (task ade01b38).
+    assert "Sessions.length === 0" in src, (
         "TaskDetailPage.tsx must render an explicit 0-session empty state"
     )
 

--- a/services/prism-service/tests/unit/test_reinforce_sdlc_gates_real_proof.py
+++ b/services/prism-service/tests/unit/test_reinforce_sdlc_gates_real_proof.py
@@ -169,7 +169,10 @@ def test_tier0_runs_full_suite_not_only_changed_test_files(tmp_path):
     captured: dict = {}
 
     def fake_run_tool(cmd, workspace, timeout_s=60.0):
-        if cmd and cmd[0] == "pytest":
+        # Tier0 invokes pytest as `[sys.executable, "-m", "pytest", ...]`
+        # (cd44b22 — venv-only installs expose `python -m pytest`, not a
+        # bare `pytest` on PATH), so detect it by membership, not cmd[0].
+        if cmd and "pytest" in cmd:
             captured["pytest_cmd"] = list(cmd)
         return (0, "1 passed", "")
 


### PR DESCRIPTION
Drives task `ade01b38` through the conductor. **red_gate passed on real verifier proof (no override)** — the first fully-honest gate after the verifier fixes landed.

## Activity Gantt + leak fix (ade01b38)
- `api/tasks.py`: `_build_timeline(history, sessions)` on `GET /api/tasks/{id}` — **UUID-only lanes** (synthetic `qa-red-gate-*`/`*-verifier-*` excluded = the leak fix); gate markers derived from `gate_decide` history (override hollow `!` / verified solid `✓`).
- `TaskActivityGantt.tsx` (new): Gantt swim-lanes — time axis, session bars, gate honesty markers, click-to-drill.
- `TaskDetailPage.tsx`: renders the Activity card; `realSessions` UUID filter on the Sessions list (synthetic actors no longer render as bare session rows).

## Verifier pytest-invocation fix (`cd44b22`)
- `_run_python_tools` invoked a bare `pytest` (not on Windows PATH → WinError 2 → exit 127 → false pass). Now invokes `[sys.executable, "-m", "pytest"]`. This was the **last layer of verifier blindness**; with it, Tier0 runs the committed suite and gates verify on real proof.
- Also fixed a stale mock test (`test_tier0_runs_full_suite...`) keyed on `cmd[0]=='pytest'` → now membership.

## Verification
- red_gate cleared by the verifier itself (no override). Full suite: **888 passed**. Gantt 10/10; self-override regression 8/8.
- `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)