### PR TITLE
fix(v6.3.29): conductor per-task tile shows task-exclusive activity (drop project-wide wallclock fallback)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,24 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.28"
+PRISM_VERSION = "6.3.29"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.29: conductor per-task tile shows task-EXCLUSIVE activity only "
+    "(task 5ecbbfb8, owner decision). phase_progress (conductor_service.py) "
+    "DROPS the #134/#137 project-WIDE wall-clock fallback that bucketed the "
+    "project's transcript spend across an in_progress task's history window "
+    "when its only links were unresolvable MCP handles — it painted parked/"
+    "worked tiles with another task's burn (the '2625 turns / 0 tokens' "
+    "contradiction). With no authoritative linked-session events the series is "
+    "now honestly empty: tokens_source=='linked', token_turns==[], turns==0, "
+    "tokens_since_step==0; the tile renders its existing 'awaiting first turn' "
+    "empty state, never 'project activity (approximate)'. A task WITH real "
+    "linked-session events still reports its own per-task series. The "
+    "current_session_id(override_dir) + _resolve_link_session_id override-dir "
+    "resolution and TokenTurns.tsx tokens_source prop (from v6.3.22) are "
+    "retained. Tests: tests/unit/test_conductor_token_source.py (8 green). "
     "v6.3.28: task-detail Activity Gantt (Way 1) — real transcript-backed "
     "session lanes render as wall-time bars + gate honesty markers (override "
     "hollow '!' / verified solid '✓'); synthetic gate-actor labels "

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2100,20 +2100,17 @@ class ConductorService:
                 live_enabled = bool(source_path or override_dir)
                 live_fn = None
                 events_fn = None
-                window_fn = None
                 turns_from = None
                 if live_enabled:
                     from prism_service.services.claude_transcripts import (
                         live_tokens_for_session as live_fn,
                         live_token_events_for_session as events_fn,
-                        project_token_events_in_window as window_fn,
                         token_turns_from_events as turns_from,
                     )
                 # Build the FULL uncapped per-turn event timeline across the
                 # task's live sessions; total_turns is computed off the UNCAPPED
                 # series so `turns` stays honest even past the 40-turn tail cap.
                 live_events: list[tuple[float, int]] = []
-                since_ts = None
                 for s in self._task_svc.sessions_for_task(task_id):
                     sid = s.get("session_id") if isinstance(s, dict) else getattr(s, "session_id", "")
                     used = s.get("tokens_used") if isinstance(s, dict) else getattr(s, "tokens_used", 0)
@@ -2131,45 +2128,17 @@ class ConductorService:
                         except Exception:
                             pass
                 live_events.sort(key=lambda e: e[0])
-                # Wall-clock fallback (#137 primary): a task whose only linked
-                # sessions are unresolvable 32-hex MCP handles has no live
-                # events — bucket the project's transcript spend across the
-                # task's history window so the tile still shows real turns.
-                # HONESTY GATE (#647d9c41): the fallback is project-WIDE, so it
-                # can only honestly apply to the ONE task actually being worked.
-                # A pending/parked task with no authoritative events stays
-                # blank (tokens_source='linked') rather than borrowing another
-                # task's burn. Only an in_progress task fills via wall-clock.
-                task_status = ""
-                try:
-                    driven = self._task_svc.get(task_id)
-                    task_status = (getattr(driven, "status", "") or "") if driven else ""
-                except Exception:
-                    task_status = ""
-                if (not live_events and window_fn
-                        and task_status == "in_progress"):
-                    now = self._now_epoch()
-                    # Bracket the task's history span, but floor `since` at a
-                    # generous lookback so a young task whose work is already on
-                    # disk (the just-linked MCP-handle case) still captures its
-                    # recent turns instead of an empty [created≈now, now] window.
-                    since_ts = min(
-                        self._task_window_start(task_id),
-                        now - self._FALLBACK_LOOKBACK_S,
-                    )
-                    try:
-                        live_events = window_fn(
-                            source_path, since_ts, now, override_dir=override_dir
-                        ) or []
-                    except Exception:
-                        live_events = []
-                    if live_events:
-                        # The series is project-wide/approximate — tag it AND
-                        # feed tokens_since_step from the SAME events so the
-                        # graph (rate) and the number (integral) agree (no
-                        # '2625 turns / 0 tokens' contradiction, PROBLEM 2).
-                        tokens_source = "wallclock"
-                        tokens = sum(int(tok) for _ep, tok in live_events)
+                # PER-TASK-EXCLUSIVE (owner decision, task 5ecbbfb8): the tile
+                # shows ONLY this task's authoritative linked-session activity.
+                # The old #134/#137 project-WIDE wall-clock fallback (bucket the
+                # project's transcript spend across the task window when the
+                # task's only links are unresolvable MCP handles) is DROPPED —
+                # it painted parked/worked tiles with another task's burn and
+                # produced the "2625 turns / 0 tokens" contradiction. With no
+                # authoritative live_events the series stays honestly empty:
+                # tokens_source=='linked', token_turns==[], turns==0,
+                # tokens_since_step==0. The empty state ("awaiting first turn")
+                # is the honest render; never borrow project-wide activity.
                 if turns_from:
                     full_turns = turns_from(live_events)
                     total_turns = len(full_turns)

--- a/services/prism-service/tests/unit/test_conductor_token_source.py
+++ b/services/prism-service/tests/unit/test_conductor_token_source.py
@@ -26,12 +26,16 @@ THE FIX this file pins:
   (a) current_session_id gains override_dir; _resolve_link_session_id resolves
       override_dir via claude_memory.configured_project_dir and returns the REAL
       session id (not ctx.request_id) when source_path='' + override_dir-set.
-  (b) phase_progress applies the wall-clock fallback ONLY when the driven task's
-      status == 'in_progress'. A pending task with no authoritative turns →
-      token_turns empty + a NEW tokens_source field == 'linked'. An in_progress
-      task with no live events → wall-clock fill tagged tokens_source=='wallclock'.
-  (c) when tokens_source=='wallclock', tokens_since_step is fed from the SAME
-      fallback events: > 0 AND == the series event sum (no graph/number lie).
+  (b) phase_progress drops the project-wide wall-clock fallback entirely for the
+      per-task tile (owner decision: task-exclusive activity ONLY). A pending OR
+      in_progress task with no authoritative linked-session turns → token_turns
+      empty, turns==0, tokens_since_step==0, tokens_source=='linked'. An
+      in_progress task WITH real linked events still reports its own per-task
+      series (tokens_source=='linked').
+
+NOTE: the legacy wall-clock-fill tests (in_progress→'wallclock' and
+  wallclock-tokens_since_step==series-sum) were the OLD contract that this task
+  reverses; they are replaced by the linked/empty/0 assertions below.
 
 These pin the REAL seams: the link resolver through its request-context entry
 and the conductor service's phase_progress reading through the actual resolvers
@@ -212,15 +216,20 @@ def test_pending_task_no_authoritative_turns_stays_linked_and_empty(tmp_path, mo
     )
 
 
-def test_in_progress_task_no_live_events_fills_via_wallclock(tmp_path, monkeypatch):
-    """An IN_PROGRESS task whose only linked session is an unresolvable MCP
-    handle fills via the project-wide wall-clock fallback, tagged
-    tokens_source=='wallclock'."""
+def test_in_progress_task_no_live_events_stays_linked_and_empty(tmp_path, monkeypatch):
+    """REVERSED CONTRACT (per-task tile, owner decision): an IN_PROGRESS task
+    whose only linked session is an unresolvable MCP handle must NOT borrow the
+    project-wide wall-clock burn. The per-task tile shows task-exclusive activity
+    ONLY, so with no authoritative linked-session events the series is honestly
+    empty: tokens_source=='linked', token_turns==[], turns==0,
+    tokens_since_step==0. (Drops the #134/#137 wall-clock fallback.)"""
     task_svc, cond = _conductor(tmp_path)
     mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
     real_sid = "dddddddd-dddd-dddd-dddd-dddddddddddd"
     d = tmp_path / "claudedir"
     now = time.time()
+    # There IS project activity on disk (a DIFFERENT, unlinked session) — the
+    # old code bucketed this into the worked task's window via wall-clock.
     _write_transcript(d / f"{real_sid}.jsonl",
                       [(now - 40, 80), (now - 25, 120), (now - 5, 160)], sid=real_sid)
 
@@ -231,45 +240,51 @@ def test_in_progress_task_no_live_events_fills_via_wallclock(tmp_path, monkeypat
     _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
 
     pp = cond.phase_progress(t.id)
-    assert pp["token_turns"], (
-        "an in_progress task with no live events must fill via the wall-clock "
-        "fallback — got empty series"
-    )
-    assert pp["tokens_source"] == "wallclock", (
-        f"wall-clock-derived series must be tagged tokens_source=='wallclock', "
+    assert pp["tokens_source"] == "linked", (
+        f"an in_progress task with no linked-session events must stay "
+        f"tokens_source=='linked' (no project-wide wall-clock fallback), "
         f"got {pp['tokens_source']!r}"
     )
+    assert pp["token_turns"] == [], (
+        f"per-task tile must show task-exclusive activity only — no project-wide "
+        f"burn may leak in. Got {len(pp['token_turns'])} turns"
+    )
+    assert pp["turns"] == 0, f"turns must be 0, got {pp['turns']}"
+    assert pp["tokens_since_step"] == 0, (
+        f"tokens_since_step must be 0 (no project-wide token sum leaks in), "
+        f"got {pp['tokens_since_step']}"
+    )
 
 
-# ----------------------------------------------------------------------
-# Oracle (c) — wall-clock tokens_since_step == series sum (no graph/number lie).
-# ----------------------------------------------------------------------
-
-def test_wallclock_tokens_since_step_equals_series_sum(tmp_path, monkeypatch):
-    """When tokens_source=='wallclock', tokens_since_step is fed from the SAME
-    fallback events: > 0 AND == the sum of the series' per-turn output tokens.
-    No '2625 turns / 0 tokens' contradiction."""
+def test_in_progress_task_with_linked_events_still_reports_real_per_task(tmp_path, monkeypatch):
+    """An IN_PROGRESS task WITH real authoritative linked-session events still
+    reports its own per-task series: token_turns non-empty, turns>0, real
+    tokens, tokens_source=='linked'. The reversal only drops the project-wide
+    fallback — it must NOT suppress genuine per-task linkage."""
     task_svc, cond = _conductor(tmp_path)
-    mcp_handle = "deadbeefdeadbeefdeadbeefdeadbeef"
-    real_sid = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+    real_sid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
     d = tmp_path / "claudedir"
     now = time.time()
     turns_in = [(now - 40, 80), (now - 25, 120), (now - 5, 160)]
     _write_transcript(d / f"{real_sid}.jsonl", turns_in, sid=real_sid)
 
-    t = task_svc.create(title="worked tile sum")
+    t = task_svc.create(title="real linked tile")
     cond.advance_task(t.id)
-    task_svc.link_session(t.id, mcp_handle)
+    # Link the REAL transcript session id (resolvable -> live events flow).
+    task_svc.link_session(t.id, real_sid)
     task_svc.update(t.id, status="in_progress")
     _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
 
     pp = cond.phase_progress(t.id)
-    assert pp["tokens_source"] == "wallclock", pp["tokens_source"]
-    series_sum = sum(int(turn["out"]) for turn in pp["token_turns"])
-    assert series_sum > 0, "wall-clock series must carry real per-turn tokens"
-    assert pp["tokens_since_step"] == series_sum, (
-        f"tokens_since_step ({pp['tokens_since_step']}) must equal the wall-clock "
-        f"series sum ({series_sum}) — the graph and the number must agree"
+    assert pp["tokens_source"] == "linked", pp["tokens_source"]
+    assert pp["token_turns"], (
+        "an in_progress task with real linked-session events must report its "
+        "own per-task burn series — got empty"
+    )
+    assert pp["turns"] > 0, f"turns must reflect the real series, got {pp['turns']}"
+    assert pp["tokens_since_step"] > 0, (
+        f"tokens_since_step must reflect real linked tokens, "
+        f"got {pp['tokens_since_step']}"
     )
 
 

--- a/services/prism-service/tests/unit/test_phase_progress_token_turns.py
+++ b/services/prism-service/tests/unit/test_phase_progress_token_turns.py
@@ -17,10 +17,12 @@ tile blank or lying for real tasks:
 
   (#137 primary) Only sessions_for_task feeds the read, so a task whose ONLY
     linked sessions are unresolvable 32-hex MCP handles (no transcript by that
-    id) renders blank. The fix: a wall-clock fallback over
-    project_token_events_in_window(source_path, since, now, override_dir=...)
-    derives the same {out, dt_s, tok_s} series — bounded to the task's history
-    window — when the linked-session turns come back empty.
+    id) renders blank. NOTE: the project-wide wall-clock fallback that #137
+    originally added here was REVERSED by task 5ecbbfb8 (owner decision: the
+    per-task tile shows task-EXCLUSIVE activity ONLY). An MCP-handle-only task
+    now stays honestly empty instead of borrowing the project window burn —
+    see test_phase_progress_no_wallclock_fallback_for_mcp_handle_sessions below
+    and tests/unit/test_conductor_token_source.py.
 
   (#137 secondary) The series is built from the 40-CAPPED
     live_token_turns_for_session and `total_turns` is len() AFTER per-session
@@ -182,12 +184,15 @@ def test_phase_progress_populates_from_override_dir_empty_source(tmp_path, monke
 
 
 # ----------------------------------------------------------------------
-# Oracle (b) — MCP-handle fallback to the wall-clock window read (#137).
-# A task whose ONLY linked session is an unresolvable 32-hex MCP handle
-# still shows token_turns via project_token_events_in_window(override_dir).
+# Oracle (b) — REVERSED CONTRACT (task 5ecbbfb8, owner decision): the per-task
+# tile shows task-EXCLUSIVE activity ONLY. The old #137 project-wide wall-clock
+# fallback (an in_progress MCP-handle task borrowing the project's window burn)
+# is DROPPED — superseded by tests/unit/test_conductor_token_source.py. An
+# in_progress task whose only link is an unresolvable MCP handle now stays
+# honestly empty rather than painting another task's burn.
 # ----------------------------------------------------------------------
 
-def test_phase_progress_falls_back_for_mcp_handle_sessions(tmp_path, monkeypatch):
+def test_phase_progress_no_wallclock_fallback_for_mcp_handle_sessions(tmp_path, monkeypatch):
     task_svc, cond = _conductor(tmp_path)
     # The only linked "session" is a 32-hex MCP request handle — there is NO
     # transcript named <handle>.jsonl. The work is on disk under a DIFFERENT id.
@@ -200,20 +205,20 @@ def test_phase_progress_falls_back_for_mcp_handle_sessions(tmp_path, monkeypatch
     t = task_svc.create(title="mcp-handle tile")
     cond.advance_task(t.id)
     task_svc.link_session(t.id, mcp_handle)
-    # Honesty gate (#647d9c41, follow-up to #137): the project-wide wall-clock
-    # fallback now fires ONLY for the task actually being worked. This oracle's
-    # intent — an MCP-handle task still shows its turns via the fallback — holds
-    # for an in_progress task; a parked/pending one stays honestly blank (pinned
-    # by tests/unit/test_conductor_token_source.py).
+    # Even an in_progress task no longer borrows the project-wide wall-clock burn
+    # (task 5ecbbfb8 reverses the #134/#137 fallback for the per-task surface).
     task_svc.update(t.id, status="in_progress")
 
     _patch_resolvers(monkeypatch, source_path=str(tmp_path / "src"), override_dir=str(d))
 
     pp = cond.phase_progress(t.id)
-    assert pp["token_turns"], (
-        "token_turns must fall back to the wall-clock window read when the only "
-        "linked session is an unresolvable MCP handle (#137 primary)"
+    assert pp["token_turns"] == [], (
+        "the per-task tile must NOT borrow project-wide wall-clock burn for an "
+        "MCP-handle-only task — task-exclusive activity ONLY (task 5ecbbfb8)"
     )
+    assert pp["tokens_source"] == "linked", pp["tokens_source"]
+    assert pp["turns"] == 0, pp["turns"]
+    assert pp["tokens_since_step"] == 0, pp["tokens_since_step"]
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Drives task `5ecbbfb8` through the conductor. **red_gate passed on real verifier proof, no override** (run bcc94995, tier0=fail observed independently).

## Task-exclusive activity (the "projects not tasks" root fix)
- `conductor_service.phase_progress` no longer falls back to project-wide `wallclock` burn for an in_progress task with no linked-session events. With no authoritative per-task events the series stays honestly **empty** (`tokens_source='linked'`, `token_turns=[]`, `turns=0`, `tokens_since_step=0`) — a per-task surface never borrows project-wide activity.
- Removed the dead `project_token_events_in_window`/`since_ts` path.

## No-preexisting hygiene
- The full suite caught a legacy v6.3.21 test (`test_phase_progress_falls_back_for_mcp_handle_sessions`) pinning the *opposite* contract; rewrote it to assert the new task-exclusive behavior.

## Verification
- red_gate cleared by the verifier itself (no override). Full suite **888 passed**. Oracle suite 8/8.
- Live :8888 (v6.3.29): a no-linked in_progress task shows `tokens_source=linked`/empty — no `project activity (approximate)` bleed.
- `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)