### PR TITLE
feat(v6.3.33): GoalBuddy likely_misfire field + conductor finished-task tile fixes

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,23 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.29"
+PRISM_VERSION = "6.3.32"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.32: likely_misfire — task cards record & audit how a task could "
+    "pass-but-be-WRONG (goalbuddy GAP-2, task 7bdb5701). New Task.likely_misfire "
+    "(models/task.py) round-trips the same DB serialize/deserialize path as the "
+    "oracle block (additive tasks.db column, migrate to ''); threaded through "
+    "TaskService.create/update, GET/PATCH /api/tasks (TaskCreate + TaskUpdate), "
+    "and the task_create/task_update MCP tools (schema + arg plumbing). New "
+    "module-level green_gate_misfire_note() in conductor_service mirrors "
+    "green_gate_proof_note: at the terminal green_gate it appends an ADVISORY "
+    "'misfire' note (annotate, never block) when a likely_misfire is recorded "
+    "but the completion_proof does not visibly address it (shared-word "
+    "heuristic), silent when the proof addresses it or no misfire is set. "
+    "TaskDetailPage renders the misfire beside the oracle in the Oracle card "
+    "(UI-FIRST, amber). Tests: tests/unit/test_task_misfire.py. "
     "v6.3.29: conductor per-task tile shows task-EXCLUSIVE activity only "
     "(task 5ecbbfb8, owner decision). phase_progress (conductor_service.py) "
     "DROPS the #134/#137 project-WIDE wall-clock fallback that bucketed the "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.32"
+PRISM_VERSION = "6.3.33"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.33: conductor tile tells the TRUTH about finished tasks (task "
+    "77470287) — three measurement bugs found reviewing completed task "
+    "7bdb5701's telemetry. (1) phase_progress (conductor_service.py) no longer "
+    "reads 0% on a DONE task: cancelled children (the implement workflow's "
+    "disposable ephemeral-fixture tasks) are EXCLUDED from children_total — they "
+    "had dragged a green-gated parent to 0/1 — and a task whose own status=='done' "
+    "now reports pct=1.0 basis='done'. (2) _in_step_s now FREEZES for terminal "
+    "tasks: a done/cancelled task ends its dwell at completed_at (fallback: last "
+    "history event) instead of wall-clock now, so a finished task stops reading "
+    "5.5h+ and growing in its final step. (3) TaskService.link_session drops a "
+    "truncated-prefix PHANTOM session: a session id that is a strict shorter "
+    "prefix of an already-linked id for the same task (e.g. the 8-char "
+    "'6d42fcd4' beside the full UUID) is refused, killing the duplicate "
+    "zero-stat session row. Tests: tests/unit/test_conductor_done_tile.py "
+    "(4 green). "
     "v6.3.32: likely_misfire — task cards record & audit how a task could "
     "pass-but-be-WRONG (goalbuddy GAP-2, task 7bdb5701). New Task.likely_misfire "
     "(models/task.py) round-trips the same DB serialize/deserialize path as the "

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -104,6 +104,7 @@ class TaskCreate(BaseModel):
     description: str = ""
     priority: int = 0
     tags: Optional[list[str]] = None
+    likely_misfire: str = ""
     enter_conductor: bool = False
 
 
@@ -124,6 +125,7 @@ def create_task(body: TaskCreate, project: str = Query("default")) -> dict:
         description=body.description or "",
         priority=body.priority or 0,
         tags=body.tags or [],
+        likely_misfire=body.likely_misfire or "",
     )
     advanced = None
     if body.enter_conductor:
@@ -264,6 +266,7 @@ class TaskUpdate(BaseModel):
     oracle: Optional[str] = None
     proof_type: Optional[str] = None
     completion_proof: Optional[str] = None
+    likely_misfire: Optional[str] = None
     allowed_files: Optional[list[str]] = None
     verify: Optional[list[str]] = None
     stop_if: Optional[list[str]] = None

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -1017,6 +1017,7 @@ TOOLS: list[Tool] = [
                 "oracle": {"type": "string", "description": "The observable signal that proves the user outcome is actually met (the 'oracle' — defined before work starts). E.g. a test suite, demo, artifact, metric, review, or decision."},
                 "proof_type": {"type": "string", "description": "Kind of completion evidence: test|demo|artifact|metric|review|source_backed_answer|decision."},
                 "completion_proof": {"type": "string", "description": "Receipt-backed evidence the oracle is satisfied; recorded when done and checked (advisory) at green_gate."},
+                "likely_misfire": {"type": "string", "description": "How this task could pass-but-be-WRONG (the goalbuddy 'misfire' — recorded upfront and audited advisory at green_gate when completion_proof doesn't address it). The cheapest defense against false-greens."},
                 "allowed_files": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: the file allowlist this slice may touch. Parallel workers are safe only with disjoint allowlists."},
                 "verify": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: commands that prove the slice (e.g. the test command)."},
                 "stop_if": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: conditions that HALT the slice (need files outside allowed_files, behavior ambiguous, verification fails twice)."},
@@ -1068,6 +1069,7 @@ TOOLS: list[Tool] = [
                 "oracle": {"type": "string", "description": "Set/replace the oracle — the observable signal that proves the outcome."},
                 "proof_type": {"type": "string", "description": "test|demo|artifact|metric|review|source_backed_answer|decision."},
                 "completion_proof": {"type": "string", "description": "Receipt-backed evidence the oracle is satisfied (checked advisory at green_gate)."},
+                "likely_misfire": {"type": "string", "description": "How this task could pass-but-be-WRONG (audited advisory at green_gate)."},
                 "allowed_files": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: set the file allowlist for the slice."},
                 "verify": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: set the verify commands."},
                 "stop_if": {"type": "array", "items": {"type": "string"}, "description": "Worker contract: set the stop conditions."},
@@ -3438,6 +3440,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 oracle=arguments.get("oracle", ""),
                 proof_type=arguments.get("proof_type", ""),
                 completion_proof=arguments.get("completion_proof", ""),
+                likely_misfire=arguments.get("likely_misfire", ""),
                 allowed_files=arguments.get("allowed_files"),
                 verify=arguments.get("verify"),
                 stop_if=arguments.get("stop_if"),
@@ -3463,7 +3466,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "task_update":
             update_kwargs: dict[str, Any] = {}
-            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id", "oracle", "proof_type", "completion_proof", "allowed_files", "verify", "stop_if", "plan_doc", "plan_diagram"):
+            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id", "oracle", "proof_type", "completion_proof", "likely_misfire", "allowed_files", "verify", "stop_if", "plan_doc", "plan_diagram"):
                 if key in arguments:
                     update_kwargs[key] = arguments[key]
             task = task_svc.update(arguments["id"], **update_kwargs)

--- a/services/prism-service/prism_service/models/task.py
+++ b/services/prism-service/prism_service/models/task.py
@@ -51,6 +51,12 @@ class Task:
     oracle: str = ""
     proof_type: str = ""
     completion_proof: str = ""
+    # likely_misfire (goalbuddy GAP-2) — "how could this pass but be WRONG?".
+    # The cheapest high-leverage defense against false-greens: recorded
+    # upfront beside the oracle and AUDITED at green_gate (advisory note
+    # when set but completion_proof doesn't visibly address it). Defaults
+    # to '' (additive/non-breaking); round-trips via the same DB path.
+    likely_misfire: str = ""
     # Worker contract (ported from goalbuddy state.yaml task T003) — bounds an
     # implementation slice so it stays explicit, verified, and reversible:
     #   allowed_files — the file allowlist the dev step may touch

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2054,15 +2054,35 @@ class ConductorService:
         except Exception:
             return 0.0
         last: Optional[float] = None
+        latest: Optional[float] = None
         for r in rows:
+            ts = self._parse_iso(getattr(r, "timestamp", "") or "")
+            if ts is None:
+                continue
+            if latest is None or ts > latest:
+                latest = ts
             if getattr(r, "action", "") == "advance_task":
-                ts = self._parse_iso(getattr(r, "timestamp", "") or "")
-                if ts is not None:
-                    last = ts
+                last = ts
         if last is None:
             return 0.0
         from datetime import datetime, timezone
-        elapsed = datetime.now(timezone.utc).timestamp() - last
+        # FREEZE for terminal tasks: a done/cancelled task must not keep
+        # accruing dwell against wall-clock forever (task 7bdb5701 read 5.5h+
+        # in green_gate hours after completing). End at completed_at, falling
+        # back to the last recorded history event.
+        end: Optional[float] = None
+        try:
+            _t = self._task_svc.get(task_id)
+            status = (getattr(_t, "status", "") or "") if _t else ""
+            if status in ("done", "cancelled"):
+                end = self._parse_iso(getattr(_t, "completed_at", "") or "") if _t else None
+                if end is None:
+                    end = latest
+        except Exception:
+            end = None
+        if end is None:
+            end = datetime.now(timezone.utc).timestamp()
+        elapsed = end - last
         return elapsed if elapsed > 0 else 0.0
 
     def phase_progress(self, task_id: str) -> dict:
@@ -2082,10 +2102,13 @@ class ConductorService:
         # ETA — forward projection over the remaining steps (learned per-step
         # medians; sharpens over time). Only meaningful while in the workflow.
         cur_step = ""
+        task_status = ""
         if self._task_svc is not None:
             try:
                 _t = self._task_svc.get(task_id)
-                cur_step = (getattr(_t, "workflow_step", "") or "") if _t else ""
+                if _t:
+                    cur_step = (getattr(_t, "workflow_step", "") or "")
+                    task_status = (getattr(_t, "status", "") or "")
             except Exception:
                 cur_step = ""
         eta_s, eta_n, eta_total = self._eta_s(cur_step, in_step_s, typical_s)
@@ -2096,13 +2119,24 @@ class ConductorService:
             try:
                 for t in self._task_svc.list():
                     if (getattr(t, "parent_id", "") or "") == task_id:
+                        st = (getattr(t, "status", "") or "")
+                        # CANCELLED children (e.g. the implement workflow's
+                        # disposable ephemeral-fixture tasks) are abandoned, not
+                        # pending work — counting them in the denominator dragged
+                        # a green-gated parent's tile to 0% (task 7bdb5701).
+                        if st == "cancelled":
+                            continue
                         children_total += 1
-                        if (getattr(t, "status", "") or "") == "done":
+                        if st == "done":
                             children_done += 1
             except Exception:
                 children_total = 0
 
-        if children_total > 0:
+        # A finished task is 100%, period — never a stale children/time ratio.
+        if task_status == "done":
+            pct = 1.0
+            basis = "done"
+        elif children_total > 0:
             pct = children_done / children_total
             basis = "children"
         else:

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -57,6 +58,37 @@ def green_gate_proof_note(files_modified: int, completion_proof: object) -> str:
         return (f"  ⚠ busywork risk: {files_modified} file-change(s) but no "
                 f"completion_proof (effort ≠ outcome)")
     return "  ⚠ oracle: no completion_proof recorded"
+
+
+def green_gate_misfire_note(likely_misfire: object,
+                            completion_proof: object) -> str:
+    """Advisory note (annotate, never block) for the goalbuddy GAP-2 misfire.
+
+    A `likely_misfire` records how a task could pass-but-be-WRONG. At
+    green_gate we want the completion_proof to VISIBLY address that risk;
+    if it doesn't, flag it (the recurring false-green / tests-pass≠
+    feature-works failure mode). Mirrors green_gate_proof_note: silent
+    when there's nothing to say.
+
+    * no misfire recorded            -> '' (nothing to audit)
+    * misfire recorded AND the proof references it -> '' (addressed)
+    * misfire recorded but the proof ignores it    -> a "⚠ misfire" note
+
+    "Addresses" is a deliberately cheap heuristic: the proof shares a
+    meaningful word (len>4) with the recorded misfire. Advisory only — a
+    false-silent here costs nothing the proof-note tooth doesn't catch.
+    """
+    misfire = str(likely_misfire or "").strip()
+    if not misfire:
+        return ""
+    proof = str(completion_proof or "").lower()
+    if proof:
+        misfire_words = {w for w in re.findall(r"[a-z]{5,}", misfire.lower())}
+        if any(w in proof for w in misfire_words):
+            return ""
+    return ("  ⚠ misfire: a likely pass-but-wrong risk was recorded but the "
+            "completion_proof does not visibly address it "
+            f"(\"{misfire[:80]}\")")
 
 
 # Artifact-looking signals that evidence a real, demonstrable UI surface:
@@ -1563,6 +1595,12 @@ class ConductorService:
             except Exception:
                 _churn = 0
             passed_gate_reason += green_gate_proof_note(_churn, _proof)
+            # goalbuddy GAP-2: audit the recorded pass-but-wrong risk.
+            # Advisory — annotate when the completion_proof doesn't address
+            # the misfire, silent otherwise.
+            _misfire = getattr(self._task_svc.get(task_id),
+                               "likely_misfire", "")
+            passed_gate_reason += green_gate_misfire_note(_misfire, _proof)
         self._task_svc.update(
             task_id,
             gate_state="passed",

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -523,6 +523,20 @@ class TaskService:
             "PRIMARY KEY (task_id, session_id))"
         )
 
+    @staticmethod
+    def _is_truncated_prefix(session_id: str, existing) -> bool:
+        """True when ``session_id`` is a strict, SHORTER prefix of an
+        already-linked session id for the same task — a truncated phantom
+        (e.g. the 8-char "6d42fcd4" prefix of the full "6d42fcd4-...-..."
+        UUID) that would otherwise render as a duplicate zero-stat row
+        (task 7bdb5701)."""
+        sid = session_id or ""
+        for other in existing:
+            o = other or ""
+            if o != sid and len(sid) < len(o) and o.startswith(sid):
+                return True
+        return False
+
     def link_session(
         self, task_id: str, session_id: str,
         ended_at: Optional[str] = None,
@@ -538,8 +552,15 @@ class TaskService:
         works in unit contexts.
         """
         now = datetime.now(timezone.utc).isoformat()
+        if not (session_id or "").strip():
+            return False
         if not self._scores_db:
             task_links = self._session_links.setdefault(task_id, {})
+            # Reject a truncated-prefix phantom (e.g. an 8-char "6d42fcd4"
+            # alongside the real "6d42fcd4-...-..." UUID) that would render as
+            # a duplicate zero-stat session row (task 7bdb5701).
+            if self._is_truncated_prefix(session_id, task_links.keys()):
+                return False
             row = task_links.setdefault(
                 session_id, {"session_id": session_id, "started_at": now,
                              "ended_at": None})
@@ -549,6 +570,14 @@ class TaskService:
         conn = sqlite3.connect(self._scores_db, timeout=5.0)
         try:
             self._ensure_task_sessions(conn)
+            existing = [
+                r[0] for r in conn.execute(
+                    "SELECT session_id FROM task_sessions WHERE task_id=?",
+                    (task_id,),
+                ).fetchall()
+            ]
+            if self._is_truncated_prefix(session_id, existing):
+                return False
             conn.execute(
                 "INSERT INTO task_sessions "
                 "(task_id, session_id, started_at, ended_at) "

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -41,6 +41,7 @@ CREATE TABLE IF NOT EXISTS tasks (
     oracle TEXT DEFAULT '',
     proof_type TEXT DEFAULT '',
     completion_proof TEXT DEFAULT '',
+    likely_misfire TEXT DEFAULT '',
     allowed_files TEXT DEFAULT '[]',
     verify TEXT DEFAULT '[]',
     stop_if TEXT DEFAULT '[]',
@@ -78,6 +79,8 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
     ("oracle", "TEXT DEFAULT ''"),
     ("proof_type", "TEXT DEFAULT ''"),
     ("completion_proof", "TEXT DEFAULT ''"),
+    # likely_misfire (goalbuddy GAP-2): audited "pass-but-wrong" risk.
+    ("likely_misfire", "TEXT DEFAULT ''"),
     # Worker contract (goalbuddy T003): JSON-encoded list columns.
     ("allowed_files", "TEXT DEFAULT '[]'"),
     ("verify", "TEXT DEFAULT '[]'"),
@@ -203,6 +206,9 @@ class TaskService:
             completion_proof=(row["completion_proof"]
                               if "completion_proof" in keys
                               and row["completion_proof"] is not None else ""),
+            likely_misfire=(row["likely_misfire"]
+                            if "likely_misfire" in keys
+                            and row["likely_misfire"] is not None else ""),
             allowed_files=(json.loads(row["allowed_files"])
                            if "allowed_files" in keys
                            and row["allowed_files"] else []),
@@ -254,6 +260,7 @@ class TaskService:
         oracle: str = "",
         proof_type: str = "",
         completion_proof: str = "",
+        likely_misfire: str = "",
         allowed_files: Optional[list[str]] = None,
         verify: Optional[list[str]] = None,
         stop_if: Optional[list[str]] = None,
@@ -273,6 +280,7 @@ class TaskService:
             oracle=oracle,
             proof_type=proof_type,
             completion_proof=completion_proof,
+            likely_misfire=likely_misfire,
             allowed_files=allowed_files or [],
             verify=verify or [],
             stop_if=stop_if or [],
@@ -284,9 +292,9 @@ class TaskService:
             "(id, title, description, status, priority, story_file, "
             "assigned_agent, created_at, updated_at, completed_at, "
             "blocked_reason, dependencies, tags, parent_id, "
-            "oracle, proof_type, completion_proof, "
+            "oracle, proof_type, completion_proof, likely_misfire, "
             "allowed_files, verify, stop_if, plan_doc, plan_diagram) "
-            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             (
                 task.id,
                 task.title,
@@ -305,6 +313,7 @@ class TaskService:
                 task.oracle,
                 task.proof_type,
                 task.completion_proof,
+                task.likely_misfire,
                 json.dumps(task.allowed_files),
                 json.dumps(task.verify),
                 json.dumps(task.stop_if),
@@ -394,7 +403,7 @@ class TaskService:
             "story_file=?, assigned_agent=?, updated_at=?, completed_at=?, "
             "blocked_reason=?, dependencies=?, tags=?, "
             "workflow_step=?, gate_state=?, gate_reason=?, parent_id=?, "
-            "oracle=?, proof_type=?, completion_proof=?, "
+            "oracle=?, proof_type=?, completion_proof=?, likely_misfire=?, "
             "allowed_files=?, verify=?, stop_if=?, "
             "plan_doc=?, plan_diagram=? "
             "WHERE id=?",
@@ -417,6 +426,7 @@ class TaskService:
                 task.oracle,
                 task.proof_type,
                 task.completion_proof,
+                task.likely_misfire,
                 json.dumps(task.allowed_files),
                 json.dumps(task.verify),
                 json.dumps(task.stop_if),

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -53,6 +53,7 @@ type Task = {
   oracle?: string;
   proof_type?: string;
   completion_proof?: string;
+  likely_misfire?: string;
   allowed_files?: string[];
   verify?: string[];
   stop_if?: string[];
@@ -760,7 +761,7 @@ export default function TaskDetailPage() {
         </Stagger>
       )}
 
-      {(task.oracle || task.proof_type || task.completion_proof) && (
+      {(task.oracle || task.proof_type || task.completion_proof || task.likely_misfire) && (
         <Card>
           <SectionLabel>Oracle — observable completion signal</SectionLabel>
           <div className="mt-2 space-y-3 text-[13px]">
@@ -792,6 +793,15 @@ export default function TaskDetailPage() {
                   </button>
                 : <div className="text-amber-300/90 text-[12px]">⚠ not yet recorded — green_gate will flag this</div>}
             </div>
+            {task.likely_misfire && (
+              <div>
+                <div className="opacity-50 mb-1 text-[11px] uppercase tracking-wider">likely misfire — how this could pass-but-be-wrong</div>
+                <div className="flex items-start gap-1.5 text-amber-300/90 leading-relaxed">
+                  <span className="shrink-0">⚠</span>
+                  <span className="opacity-90">{task.likely_misfire}</span>
+                </div>
+              </div>
+            )}
           </div>
         </Card>
       )}

--- a/services/prism-service/tests/unit/test_conductor_done_tile.py
+++ b/services/prism-service/tests/unit/test_conductor_done_tile.py
@@ -1,0 +1,132 @@
+"""RED scaffold — conductor tile must tell the truth about FINISHED tasks
+(task 77470287). Three bugs found reviewing completed task 7bdb5701's telemetry:
+
+  #1 phase_progress() returns pct 0.0 on a DONE task because a CANCELLED
+     ephemeral-fixture child is counted in children_done/children_total
+     (0/1). Fix: cancelled children don't count; a done task is 100%.
+  #5 _in_step_s() returns now-last_advance forever, so a finished task's
+     dwell grows without bound (5.5h+). Fix: freeze at completed_at for
+     terminal tasks.
+  #3 link_session() stamps a truncated 8-char session id alongside the real
+     UUID (phantom zero-stat row). Fix: skip a session id that is a strict
+     prefix of an already-linked, longer id for the same task.
+
+All FAIL before the fix on feat/conductor-tile-correctness.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_PID = "done_tile_pid"
+
+
+def _conductor(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    proj_dir = tmp_path / "projects" / _PID
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    scores_db = str(proj_dir / "scores.db")
+    task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    return task_svc, cond
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+# ----------------------------------------------------------------------
+# #1a — a cancelled child (ephemeral fixture) must NOT count toward progress.
+# ----------------------------------------------------------------------
+def test_cancelled_child_excluded_from_progress(tmp_path):
+    task_svc, cond = _conductor(tmp_path)
+    parent = task_svc.create(title="parent in flight")
+    task_svc.update(parent.id, workflow_step="implement_tasks")
+    fixture = task_svc.create(title="FIXTURE", parent_id=parent.id)
+    task_svc.update(fixture.id, status="cancelled")
+
+    pp = cond.phase_progress(parent.id)
+    # The only child is cancelled -> it must not appear in the denominator.
+    assert pp["children_total"] == 0, pp
+    # ...so progress falls back to the time basis, NOT a 0/1 children ratio.
+    assert pp["basis"] != "children", pp
+
+
+# ----------------------------------------------------------------------
+# #1b — a DONE task reports 100%, never 0%, regardless of child bookkeeping.
+# ----------------------------------------------------------------------
+def test_done_task_reports_full_progress(tmp_path):
+    task_svc, cond = _conductor(tmp_path)
+    parent = task_svc.create(title="finished task")
+    task_svc.update(parent.id, workflow_step="green_gate")
+    # a cancelled fixture child, exactly like the real 7bdb5701 case
+    fixture = task_svc.create(title="FIXTURE", parent_id=parent.id)
+    task_svc.update(fixture.id, status="cancelled")
+    task_svc.update(parent.id, status="done")
+
+    pp = cond.phase_progress(parent.id)
+    assert pp["pct"] == pytest.approx(1.0), pp
+    assert pp["basis"] == "done", pp
+
+
+# ----------------------------------------------------------------------
+# #5 — in_step_s FREEZES for a terminal task instead of tracking wall-clock.
+# ----------------------------------------------------------------------
+def test_in_step_s_frozen_for_done_task(tmp_path):
+    task_svc, cond = _conductor(tmp_path)
+    t = task_svc.create(title="done long ago")
+    # Advance INTO the final step a long time ago, complete shortly after.
+    long_ago = datetime.now(timezone.utc) - timedelta(days=2)
+    task_svc._db.execute(
+        "INSERT INTO task_history (task_id, actor, action, details, timestamp) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (t.id, "conductor", "advance_task", "from=x; to=green_gate",
+         _iso(long_ago)),
+    )
+    task_svc._db.commit()
+    completed = long_ago + timedelta(seconds=120)
+    task_svc.update(t.id, workflow_step="green_gate", status="done")
+    # stamp a deterministic completed_at
+    task_svc._db.execute(
+        "UPDATE tasks SET completed_at=? WHERE id=?", (_iso(completed), t.id))
+    task_svc._db.commit()
+
+    in_step = cond._in_step_s(t.id)
+    # Frozen at completed_at - advance == 120s (not ~2 days of wall-clock).
+    assert in_step == pytest.approx(120.0, abs=2.0), in_step
+
+
+# ----------------------------------------------------------------------
+# #3 — link_session skips a truncated-prefix phantom session id.
+# ----------------------------------------------------------------------
+def test_link_session_skips_truncated_prefix_phantom(tmp_path):
+    import sqlite3
+
+    task_svc, _ = _conductor(tmp_path)
+    t = task_svc.create(title="task with sessions")
+    real = "6d42fcd4-f7e2-4853-ab00-8da16b64773a"
+    task_svc.link_session(t.id, real)
+    # The phantom truncated id (first 8 chars) must be refused.
+    task_svc.link_session(t.id, "6d42fcd4")
+
+    # Read the link table directly — sessions_for_task needs session_outcomes
+    # which isn't materialized in this unit harness.
+    conn = sqlite3.connect(task_svc._scores_db)
+    try:
+        sids = {r[0] for r in conn.execute(
+            "SELECT session_id FROM task_sessions WHERE task_id=?", (t.id,)
+        ).fetchall()}
+    finally:
+        conn.close()
+    assert real in sids, sids
+    assert "6d42fcd4" not in sids, sids

--- a/services/prism-service/tests/unit/test_task_misfire.py
+++ b/services/prism-service/tests/unit/test_task_misfire.py
@@ -1,0 +1,209 @@
+"""likely_misfire field — records & audits how a task could pass-but-be-wrong.
+
+Sibling of test_task_oracle.py. Pins, RED-first (task 7bdb5701):
+  * likely_misfire defaults to "" and round-trips through the SAME DB
+    serialize/deserialize path as the oracle block (additive/non-breaking).
+  * The MCP dispatcher SEAM (handle_tool -> task_create / task_update)
+    plumbs likely_misfire end-to-end — not just the service method.
+  * The API SEAM (POST create / GET / PATCH update) accepts & echoes
+    likely_misfire — a real route field, not headless plumbing.
+  * green_gate emits an ADVISORY note (annotate, never block) when a
+    misfire is recorded but completion_proof does not visibly address it,
+    and is SILENT when the misfire is addressed — mirroring
+    green_gate_proof_note.
+
+These FAIL before the field/note/wiring exist (AttributeError /
+ImportError / missing field in JSON), which is the point of the red step.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _services(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"), enable_engine=False, task_svc=task_svc
+    )
+    return task_svc, cond
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """Isolated ProjectContext so handle_tool + the API router resolve the
+    SAME tmp-backed task_svc (mirrors test_mcp_graph_annotate)."""
+    from prism_service import config as cfg
+    from prism_service import project_context as pc
+    monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    pc._contexts.clear()
+    yield "test-misfire"
+    pc._contexts.clear()
+
+
+# ---- field round-trip (unit contract) ---------------------------------
+
+def test_likely_misfire_defaults_empty(tmp_path):
+    task_svc, _ = _services(tmp_path)
+    t = task_svc.create(title="x")
+    assert t.likely_misfire == ""
+    g = task_svc.get(t.id)
+    assert g.likely_misfire == ""
+
+
+def test_likely_misfire_round_trip_create_and_update(tmp_path):
+    task_svc, _ = _services(tmp_path)
+    t = task_svc.create(
+        title="x", likely_misfire="tests stub the API; dead UI passes green"
+    )
+    assert t.likely_misfire == "tests stub the API; dead UI passes green"
+    g = task_svc.get(t.id)
+    assert g.likely_misfire == "tests stub the API; dead UI passes green"
+    task_svc.update(t.id, likely_misfire="updated misfire risk")
+    g2 = task_svc.get(t.id)
+    assert g2.likely_misfire == "updated misfire risk"
+
+
+# ---- MCP dispatcher SEAM (handle_tool, not the service method) ---------
+
+def _call(tool, args, project_id):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool, args, project_id=project_id))[0].text
+
+
+def test_task_create_schema_advertises_likely_misfire():
+    from prism_service.mcp.tools import TOOLS
+    by_name = {t.name: t for t in TOOLS}
+    assert "likely_misfire" in by_name["task_create"].inputSchema["properties"]
+    assert "likely_misfire" in by_name["task_update"].inputSchema["properties"]
+
+
+def test_mcp_task_create_and_update_plumbs_likely_misfire(project):
+    from prism_service.project_context import get_project
+
+    created = json.loads(_call(
+        "task_create",
+        {"title": "misfire via mcp", "likely_misfire": "passes on stubbed seam"},
+        project,
+    ))
+    tid = created["id"]
+    assert created["likely_misfire"] == "passes on stubbed seam"
+
+    # Survives a SEPARATE read through the project context (durable, not
+    # an in-memory echo).
+    stored = get_project(project).task_svc.get(tid)
+    assert stored.likely_misfire == "passes on stubbed seam"
+
+    json.loads(_call(
+        "task_update",
+        {"id": tid, "likely_misfire": "revised misfire"},
+        project,
+    ))
+    assert get_project(project).task_svc.get(tid).likely_misfire == "revised misfire"
+
+
+# ---- API SEAM (real route, POST/GET/PATCH) ----------------------------
+
+def _api_client(project_id):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import tasks as tasks_api
+    app = FastAPI()
+    app.include_router(tasks_api.router, prefix="/api/tasks")
+    return TestClient(app), project_id
+
+
+def test_api_create_get_patch_round_trips_likely_misfire(project):
+    client, pid = _api_client(project)
+
+    post = client.post(
+        "/api/tasks", params={"project": pid},
+        json={"title": "api misfire", "likely_misfire": "API field is dead"},
+    )
+    assert post.status_code in (200, 201), post.text
+    tid = post.json()["task"]["id"]
+
+    got = client.get(f"/api/tasks/{tid}", params={"project": pid})
+    assert got.status_code == 200, got.text
+    assert got.json()["task"]["likely_misfire"] == "API field is dead"
+
+    patched = client.patch(
+        f"/api/tasks/{tid}", params={"project": pid},
+        json={"likely_misfire": "patched misfire"},
+    )
+    assert patched.status_code == 200, patched.text
+    again = client.get(f"/api/tasks/{tid}", params={"project": pid})
+    assert again.json()["task"]["likely_misfire"] == "patched misfire"
+
+
+# ---- green_gate advisory misfire note ---------------------------------
+
+def test_green_gate_misfire_note_fires_when_unaddressed():
+    from prism_service.services.conductor_service import green_gate_misfire_note
+    note = green_gate_misfire_note(
+        likely_misfire="UI is dead; stubbed API test still passes",
+        completion_proof="ran pytest; 12 passed; screenshot :8888/x.png",
+    )
+    assert note  # non-empty advisory
+    assert "misfire" in note.lower()
+
+
+def test_green_gate_misfire_note_silent_when_addressed():
+    from prism_service.services.conductor_service import green_gate_misfire_note
+    # Proof visibly references the misfire risk -> no advisory.
+    note = green_gate_misfire_note(
+        likely_misfire="dead UI passes",
+        completion_proof="verified the UI is not dead: screenshot shows the "
+                         "rendered card addresses the dead-UI passes risk",
+    )
+    assert note == ""
+
+
+def test_green_gate_misfire_note_silent_when_no_misfire():
+    from prism_service.services.conductor_service import green_gate_misfire_note
+    assert green_gate_misfire_note("", "anything") == ""
+
+
+# ---- integration: note rides the green_gate decision ------------------
+
+def _drive_to_green_gate(task_svc, cond, t):
+    guard = 0
+    while task_svc.get(t.id).workflow_step != "green_gate" and guard < 20:
+        if task_svc.get(t.id).gate_state == "pending":
+            cond.gate_decide(
+                t.id, "approve",
+                reason="walk; independent re-run: pytest -> 1 failed",
+                override=True, actor="walk-bot", session_id="walk-bot")
+        else:
+            cond.advance_task(t.id, validation="step")
+        guard += 1
+    assert task_svc.get(t.id).workflow_step == "green_gate"
+
+
+def test_green_gate_annotates_unaddressed_misfire(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    # Real artifact proof (clears the proof-carrying tooth) that does NOT
+    # mention the recorded misfire risk -> advisory should fire.
+    t = task_svc.create(
+        title="misfire integ",
+        likely_misfire="the stubbed API test passes even with a dead route",
+        completion_proof="full suite green; screenshot at :8888/card.png",
+    )
+    _drive_to_green_gate(task_svc, cond, t)
+    res = cond.gate_decide(t.id, "approve", reason="full green", override=True)
+    assert res["ok"] is True, res
+    assert "misfire" in task_svc.get(t.id).gate_reason.lower()


### PR DESCRIPTION
Consolidated workstream from a GoalBuddy-research dogfood session (one PR per workstream).

## v6.3.32 — likely_misfire audited task field (GoalBuddy GAP-2, task 7bdb5701)
Records "how could this task pass but be WRONG?" as a first-class field, audited at green_gate — the cheapest defense against false-greens.
- `Task.likely_misfire` round-trips model→DB→REST→MCP (additive column, same path as the oracle block)
- `green_gate_misfire_note()` — advisory note (annotate, never block) when a misfire is recorded but completion_proof ignores it
- `TaskDetailPage` renders it beside the oracle (UI-FIRST)
- Tests: `tests/unit/test_task_misfire.py`

## v6.3.33 — conductor tile tells the truth about finished tasks (task 77470287)
Three measurement bugs found reviewing 7bdb5701's recorded telemetry:
- **phase_progress** no longer reads 0% on a DONE task — cancelled children (the implement workflow's disposable ephemeral fixtures) are excluded from `children_total`, and a done task reports `pct=1.0 basis=done`
- **_in_step_s** freezes for terminal tasks at `completed_at` instead of growing against wall-clock (was reading 5.5h+ in the final step)
- **link_session** refuses a truncated-prefix phantom session id (the 8-char dup beside the real UUID)
- Tests: `tests/unit/test_conductor_done_tile.py`

## Gates
- `tsc -b` clean, SPA build clean
- `pytest tests/unit` — 735 passed, 0 failed
- Both features live-verified on dev v6.3.33 (:8888): misfire renders on the card; the done task's tile now reads 100% with a frozen dwell

🤖 Generated with [Claude Code](https://claude.com/claude-code)