### PR TITLE
feat(v6.3.35): conductor micro-slice reorient signal (GoalBuddy GAP-5)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,26 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.34"
+PRISM_VERSION = "6.3.35"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.35: conductor flags a MICRO-SLICE LOOP and says reorient (goalbuddy "
+    "GAP-5, task 77be27a1). New pure module-level board_health(tasks) in "
+    "conductor_service: over DONE ROOT tasks (status=='done' AND parent_id=='') "
+    "ordered by completed_at desc, it counts the LEADING run of 'low-value "
+    "completions' and sets reorient when that run >= 2 (mirrors goalbuddy "
+    "state.yaml max_consecutive_tiny_tasks:2). 'low-value' uses ONLY reliable "
+    "signals — a '⚠' advisory marker in the task's gate_reason (the busywork / "
+    "oracle-weak-proof / misfire / slice-only teeth all stamp it) OR "
+    "is_weak_proof(completion_proof) — NEVER files_modified (session file "
+    "attribution is a known-broken 0/0 telemetry gap; churn-based detection is "
+    "deferred until that's fixed). GET /api/conductor/state carries board_health "
+    "additively; ConductorPage renders a reorient BADGE ('⚠ N low-confidence "
+    "slices in a row — reorient toward a milestone') when reorient, silent "
+    "otherwise. Composes the per-task advisory teeth from GAP-2/GAP-4 into one "
+    "board-level signal; annotate-never-block. Tests: "
+    "tests/unit/test_conductor_board_health.py (12 green w/ test_task_busywork). "
     "v6.3.34: conductor distinguishes a green SLICE from a finished OUTCOME "
     "(goalbuddy GAP-4, task 3619859f). New first-class full_outcome_complete "
     "bool round-trips model->DB->/api/tasks->MCP->SPA. At the terminal "

--- a/services/prism-service/prism_service/api/conductor.py
+++ b/services/prism-service/prism_service/api/conductor.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Body, HTTPException, Query
 
 from prism_service.project_context import get_project
+from prism_service.services.conductor_service import board_health
 
 router = APIRouter()
 
@@ -28,7 +29,22 @@ def state(project: str = Query("default"), outcomes_limit: int = Query(200, ge=1
         # where they are in the workflow.
         "managed_tasks": s.managed_tasks(),
         "step_buckets": s.step_buckets(),
+        # GoalBuddy GAP-5: cross-task "reorient" signal composed from the
+        # per-task '⚠' advisory notes — fires when >= 2 low-value done-root
+        # completions lead the newest-first run. Additive; SPA renders a badge.
+        "board_health": board_health(_board_tasks(s)),
     }
+
+
+def _board_tasks(s) -> list:
+    """All tasks for the board_health scan (done-root filtering happens there)."""
+    svc = getattr(s, "_task_svc", None)
+    if svc is None:
+        return []
+    try:
+        return svc.list()
+    except Exception:
+        return []
 
 
 @router.post("/gate")

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -130,6 +130,62 @@ def green_gate_outcome_note(slice_green: bool, completion_proof: object,
     return (f"  ⚠ slice-complete, not owner-outcome-complete: {reason}")
 
 
+def _task_attr(task: object, name: str, default: str = "") -> object:
+    """Read a field off a task whether it's a dict or an object/Namespace."""
+    if isinstance(task, dict):
+        return task.get(name, default)
+    return getattr(task, name, default)
+
+
+def _is_low_value_completion(task: object) -> bool:
+    """A done task is LOW-VALUE on reliable signals only (goalbuddy GAP-5).
+
+    True when the green_gate gate_reason carries the '⚠' advisory marker the
+    note helpers stamp (busywork/oracle/misfire/slice-only) OR the
+    completion_proof is weak (is_weak_proof). Deliberately does NOT use
+    files_modified/diff churn — session file attribution is broken (0/0).
+    """
+    reason = str(_task_attr(task, "gate_reason", "") or "")
+    if "⚠" in reason:
+        return True
+    return is_weak_proof(_task_attr(task, "completion_proof", ""))
+
+
+def board_health(tasks) -> dict:
+    """Cross-task board "reorient" signal (goalbuddy GAP-5).
+
+    Over DONE ROOT tasks (status=='done', parent_id=='') ordered by
+    completed_at DESC, count the LEADING run of low-value completions and set
+    reorient=True when that run >= 2 (mirrors goalbuddy state.yaml
+    max_consecutive_tiny_tasks:2). Pure + module-level so it unit-tests over
+    synthetic task lists; accepts dicts or objects. A strong (clean) done-root
+    task at the newest-first head breaks the run (count resets to 0 there).
+    """
+    done_root = [
+        t for t in (tasks or [])
+        if str(_task_attr(t, "status", "") or "") == "done"
+        and not str(_task_attr(t, "parent_id", "") or "")
+    ]
+    done_root.sort(
+        key=lambda t: str(_task_attr(t, "completed_at", "") or ""),
+        reverse=True)
+    run = 0
+    for t in done_root:
+        if _is_low_value_completion(t):
+            run += 1
+        else:
+            break
+    reorient = run >= 2
+    reason = (
+        f"{run} low-confidence slices in a row — reorient toward a milestone"
+        if reorient else "")
+    return {
+        "consecutive_low_value": run,
+        "reorient": reorient,
+        "reason": reason,
+    }
+
+
 # Artifact-looking signals that evidence a real, demonstrable UI surface:
 # an agent-browser / verify screenshot vs the dev :8888 surface, or a
 # Playwright assertion. A pytest/unit line alone is NOT a UI artifact.

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -27,9 +27,16 @@ type ManagedTask = {
   phase_progress?: PhaseProgress | null;
 };
 
+type BoardHealth = {
+  consecutive_low_value?: number;
+  reorient?: boolean;
+  reason?: string;
+};
+
 type State = {
   managed_tasks?: ManagedTask[];
   step_buckets?: Record<string, number>;
+  board_health?: BoardHealth;
 };
 
 const GATE_TONE: Record<string, PillTone> = {
@@ -60,9 +67,25 @@ export default function ConductorPage() {
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
   const managed = data?.managed_tasks ?? [];
+  const boardHealth = data?.board_health;
+  const reorient = boardHealth?.reorient === true;
+  const lowValueN = boardHealth?.consecutive_low_value ?? 0;
 
   return (
     <Page>
+      {/* GoalBuddy GAP-5: cross-task reorient badge — silent unless the board
+          has shipped >= 2 low-confidence slices in a row (composed from the
+          per-task '⚠' advisory notes). Hermes primitives, no raw JSON. */}
+      {reorient && (
+        <Card>
+          <div className="flex items-center gap-2">
+            <TileBadge tone="amber">reorient</TileBadge>
+            <span className="text-[12px] text-[color:var(--text-secondary)]">
+              ⚠ {lowValueN} low-confidence slices in a row — reorient toward a milestone
+            </span>
+          </div>
+        </Card>
+      )}
       <Card>
         <SectionLabel>Under conductor</SectionLabel>
         <p className="text-[11px] opacity-60 mt-1 mb-3">

--- a/services/prism-service/tests/unit/test_conductor_board_health.py
+++ b/services/prism-service/tests/unit/test_conductor_board_health.py
@@ -1,0 +1,229 @@
+"""RED scaffold — cross-task board "reorient" signal (task 77be27a1, GAP-5).
+
+GoalBuddy GAP-5: compose the existing PER-TASK advisory '⚠' notes into ONE
+board-level signal, mirroring goalbuddy state.yaml max_consecutive_tiny_tasks:2.
+
+board_health(tasks) -> {consecutive_low_value:int, reorient:bool, reason:str}
+scans DONE ROOT tasks (status=='done', parent_id=='') newest-first by
+completed_at and counts the LEADING run of LOW-VALUE completions; reorient
+flips True when that leading run >= 2.
+
+"Low-value" uses only reliable signals (NOT files_modified — broken
+attribution): the done task's gate_reason carries the advisory '⚠' marker
+(busywork/oracle/misfire/slice-only), OR is_weak_proof(completion_proof).
+
+These tests pin BOTH the pure helper contract AND the user-facing seam:
+the GET /api/conductor/state response must carry board_health additively.
+They FAIL today (helper + API field don't exist yet).
+"""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _task(*, status="done", parent_id="", gate_reason="", completion_proof="",
+          completed_at="2026-06-07T00:00:00+00:00"):
+    """A synthetic task row carrying just the fields board_health reads."""
+    return SimpleNamespace(
+        status=status,
+        parent_id=parent_id,
+        gate_reason=gate_reason,
+        completion_proof=completion_proof,
+        completed_at=completed_at,
+    )
+
+
+# A strong (clean) done task: real proof, no advisory marker -> NOT low-value.
+def _strong(completed_at):
+    return _task(gate_reason="verified (532 tests pass): demo recorded",
+                 completion_proof="532 tests pass + demo at /x.mp4",
+                 completed_at=completed_at)
+
+
+# A low-value done task via the '⚠' advisory marker in gate_reason.
+def _weak_marker(completed_at):
+    return _task(
+        gate_reason="manual override: shipped  ⚠ busywork risk: 7 file-change(s)",
+        completion_proof="some words",
+        completed_at=completed_at)
+
+
+# A low-value done task via is_weak_proof(completion_proof) (placeholder proof).
+def _weak_proof(completed_at):
+    return _task(gate_reason="manual override: shipped",
+                 completion_proof="tbd", completed_at=completed_at)
+
+
+# ---------------------------------------------------------------------------
+# 0 low-value => no reorient.
+# ---------------------------------------------------------------------------
+def test_zero_low_value_no_reorient():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        _strong("2026-06-07T03:00:00+00:00"),
+        _strong("2026-06-07T02:00:00+00:00"),
+        _strong("2026-06-07T01:00:00+00:00"),
+    ])
+    assert out["consecutive_low_value"] == 0, out
+    assert out["reorient"] is False, out
+
+
+# ---------------------------------------------------------------------------
+# 1 leading low-value => still no reorient (threshold is >= 2).
+# ---------------------------------------------------------------------------
+def test_single_low_value_no_reorient():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        _weak_marker("2026-06-07T03:00:00+00:00"),  # newest, low-value
+        _strong("2026-06-07T02:00:00+00:00"),
+        _strong("2026-06-07T01:00:00+00:00"),
+    ])
+    assert out["consecutive_low_value"] == 1, out
+    assert out["reorient"] is False, out
+
+
+# ---------------------------------------------------------------------------
+# 2+ leading low-value => reorient True with a non-empty reason.
+# ---------------------------------------------------------------------------
+def test_two_leading_low_value_reorients():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        _weak_marker("2026-06-07T03:00:00+00:00"),  # newest, low-value
+        _weak_proof("2026-06-07T02:00:00+00:00"),   # low-value
+        _strong("2026-06-07T01:00:00+00:00"),       # breaks (but run already 2)
+    ])
+    assert out["consecutive_low_value"] == 2, out
+    assert out["reorient"] is True, out
+    assert out["reason"].strip(), out
+
+
+def test_three_leading_low_value_counts_full_run():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        _weak_marker("2026-06-07T03:00:00+00:00"),
+        _weak_proof("2026-06-07T02:00:00+00:00"),
+        _weak_marker("2026-06-07T01:00:00+00:00"),
+    ])
+    assert out["consecutive_low_value"] == 3, out
+    assert out["reorient"] is True, out
+
+
+# ---------------------------------------------------------------------------
+# A STRONG (clean) task at the HEAD of the newest-first run breaks the count
+# even when older tasks are low-value.
+# ---------------------------------------------------------------------------
+def test_strong_proof_at_head_breaks_run():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        _strong("2026-06-07T03:00:00+00:00"),       # newest, clean -> breaks
+        _weak_marker("2026-06-07T02:00:00+00:00"),
+        _weak_proof("2026-06-07T01:00:00+00:00"),
+    ])
+    assert out["consecutive_low_value"] == 0, out
+    assert out["reorient"] is False, out
+
+
+# ---------------------------------------------------------------------------
+# Only DONE ROOT tasks count: cancelled/in_progress/pending and non-root
+# (parent_id != '') tasks are excluded entirely from the scan.
+# ---------------------------------------------------------------------------
+def test_non_done_and_non_root_excluded():
+    from prism_service.services.conductor_service import board_health
+    out = board_health([
+        # newest two are NOT eligible -> ignored, not counted, not a break
+        _task(status="in_progress", gate_reason="  ⚠ busywork",
+              completed_at="2026-06-07T05:00:00+00:00"),
+        _task(status="cancelled", completion_proof="tbd",
+              completed_at="2026-06-07T04:30:00+00:00"),
+        _task(parent_id="some-parent", completion_proof="tbd",
+              completed_at="2026-06-07T04:00:00+00:00"),
+        # the two eligible done root tasks ARE both low-value
+        _weak_marker("2026-06-07T03:00:00+00:00"),
+        _weak_proof("2026-06-07T02:00:00+00:00"),
+    ])
+    assert out["consecutive_low_value"] == 2, out
+    assert out["reorient"] is True, out
+
+
+# ===========================================================================
+# USER-FACING SEAM — GET /api/conductor/state must carry board_health
+# ADDITIVELY (existing managed_tasks/step_buckets keys unchanged). A pure
+# helper that's never wired into the route is DEAD; this pins the route.
+# ===========================================================================
+
+
+def _client(tmp_path, monkeypatch):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from prism_service.api import conductor as conductor_api
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"), enable_engine=False, task_svc=task_svc)
+
+    class _Ctx:
+        conductor_svc = cond
+
+    monkeypatch.setattr(conductor_api, "get_project", lambda p: _Ctx())
+    app = FastAPI()
+    app.include_router(conductor_api.router, prefix="/api/conductor")
+    return TestClient(app), task_svc, cond
+
+
+def _done_low_value(task_svc, title):
+    """A done ROOT task whose gate_reason carries the '⚠' advisory marker."""
+    t = task_svc.create(title=title)
+    task_svc.update(
+        t.id, status="done", workflow_step="green_gate",
+        gate_reason="manual override: shipped  ⚠ busywork risk: 5 file-change(s)",
+        completion_proof="tbd")
+    return t
+
+
+def test_api_state_carries_board_health_additively(tmp_path, monkeypatch):
+    client, task_svc, cond = _client(tmp_path, monkeypatch)
+    # Two consecutive low-value done root completions -> reorient.
+    _done_low_value(task_svc, "tiny slice 1")
+    _done_low_value(task_svc, "tiny slice 2")
+
+    resp = client.get("/api/conductor/state", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    # Additive: the existing keys are still present.
+    assert "managed_tasks" in body, body.keys()
+    assert "step_buckets" in body, body.keys()
+
+    # The new field is present and reflects the reorient signal end-to-end.
+    assert "board_health" in body, body.keys()
+    bh = body["board_health"]
+    assert bh["reorient"] is True, bh
+    assert bh["consecutive_low_value"] >= 2, bh
+    assert bh["reason"].strip(), bh
+
+
+def test_api_state_board_health_silent_when_healthy(tmp_path, monkeypatch):
+    client, task_svc, cond = _client(tmp_path, monkeypatch)
+    # One strong done root task -> no reorient.
+    t = task_svc.create(title="clean slice")
+    task_svc.update(
+        t.id, status="done", workflow_step="green_gate",
+        gate_reason="verified (532 tests pass): demo recorded",
+        completion_proof="532 tests pass + demo at /x.mp4")
+
+    resp = client.get("/api/conductor/state", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+    bh = resp.json()["board_health"]
+    assert bh["reorient"] is False, bh


### PR DESCRIPTION
GoalBuddy GAP-5 (epic 5bf1ac76), driven through the implement workflow + green-gated.

## What
A board-level signal for "you've shipped N low-confidence slices in a row — reorient toward a milestone" (GoalBuddy max_consecutive_tiny_tasks:2).
- `conductor_service.board_health(tasks)` — over DONE ROOT tasks newest-first, counts the leading run of low-value completions; `reorient` when run ≥ 2
- "low-value" uses ONLY reliable signals: a `⚠` advisory marker in `gate_reason` (busywork/oracle/misfire/slice-only teeth) OR `is_weak_proof(completion_proof)` — **not** files_modified (broken 0/0 attribution; churn-based deferred)
- `GET /api/conductor/state` carries `board_health` additively
- `ConductorPage.tsx` renders the reorient badge (silent otherwise) — UI-FIRST
- Tests: `tests/unit/test_conductor_board_health.py`

## Gates
- `tsc -b` clean, SPA build clean
- `pytest tests/unit` — 757 passed, 0 failed
- green_gate passed (clean drive); live seam verified: `/api/conductor/state` returns `board_health` on v6.3.35

🤖 Generated with [Claude Code](https://claude.com/claude-code)