### PR TITLE
fix: Brain vec-dim self-heal, governance curation, /memory page, route code-splitting (v6.3.36-40)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,19 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.38"
+PRISM_VERSION = "6.3.39"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.39: FIX /memory page showed 'No entries match these filters' despite "
+    "a non-zero Entries count. Three causes: (1) it defaulted to status='all' "
+    "and fetched every archived generation (596 entries / 1.3MB) instead of "
+    "the active set, (2) the empty-state copy rendered DURING the initial "
+    "fetch (entries=[]) so a slow 2s load looked broken, (3) the status filter "
+    "chips were 'stale'/'retired' which no entry ever has. Now defaults to "
+    "status='active' (matches the Entries KPI, ~270KB), shows a Loading state "
+    "until the first fetch resolves, and the status chips are "
+    "active/archived/needs_review. "
     "v6.3.38: governance memory-curation overhaul. (1) DISABLE the keyword "
     "conflict detector — even after the v6.3.37 tightening it flagged 1499 "
     "pairs over 206 active memories (keyword overlap can't model semantic "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.36"
+PRISM_VERSION = "6.3.37"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.37: FIX governance conflict detector was a false-positive machine. "
+    "_detect_conflicts split on whitespace and flagged any two same-domain "
+    "entries that shared >=2 tokens INCLUDING filler ('the'/'prism'/'memory') "
+    "when one carried a negation word — it had flipped 389 unrelated memories "
+    "to needs_review (dashboard 'flagged conflicts'=138/run). Now compares "
+    "substantive tokens only (len>=4, not a stop/negation word) and requires "
+    ">=4 overlap. Reset the false positives back to active and dropped 61 "
+    "stale brain source files (non-code/skip-dir) so docs_vec coverage is "
+    "100%. Tests: test_governance_conflict_detection, test_brain_vec_dim_"
+    "selfheal, test_reflection_verdict_parse. "
     "v6.3.36: FIX Brain self-dogfood was silently degraded. (1) docs_vec "
     "self-heals an embedding-dimension change: when the live model dim "
     "(potion-base-32M=512) differs from the existing vec0 table (MiniLM=384), "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.35"
+PRISM_VERSION = "6.3.36"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.36: FIX Brain self-dogfood was silently degraded. (1) docs_vec "
+    "self-heals an embedding-dimension change: when the live model dim "
+    "(potion-base-32M=512) differs from the existing vec0 table (MiniLM=384), "
+    "brain_engine drops + recreates docs_vec at the current dim so inserts stop "
+    "raising 'Dimension mismatch' (every index_doc was failing its vector "
+    "insert). Reindex repopulates; FTS was unaffected. (2) reflection_runner "
+    "verdict parser now extracts the outermost {...} so a prose-before-JSON "
+    "reply (common after 15 tool turns) parses instead of being abandoned as "
+    "'verdict not valid JSON'. Together: hybrid vector search + the /learning "
+    "reflection loop work again on the dogfood 'prism' project. "
     "v6.3.35: conductor flags a MICRO-SLICE LOOP and says reorient (goalbuddy "
     "GAP-5, task 77be27a1). New pure module-level board_health(tasks) in "
     "conductor_service: over DONE ROOT tasks (status=='done' AND parent_id=='') "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.39"
+PRISM_VERSION = "6.3.40"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.40: PERF route-level code splitting. Every page was a static import, "
+    "so the graph/Sigma + conductor + settings + task-detail code all parsed "
+    "in one ~1.6MB main chunk before anything rendered (the SPA looked 'stuck "
+    "loading' on slow hardware). Pages are now React.lazy chunks fetched on "
+    "navigation: main bundle 1611KB -> 534KB (gzip 459->176), MemoryPage is a "
+    "10KB chunk, and a react-vendor chunk caches across deploys. "
     "v6.3.39: FIX /memory page showed 'No entries match these filters' despite "
     "a non-zero Entries count. Three causes: (1) it defaulted to status='all' "
     "and fetched every archived generation (596 entries / 1.3MB) instead of "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.3.37"
+PRISM_VERSION = "6.3.38"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.3.38: governance memory-curation overhaul. (1) DISABLE the keyword "
+    "conflict detector — even after the v6.3.37 tightening it flagged 1499 "
+    "pairs over 206 active memories (keyword overlap can't model semantic "
+    "contradiction; dense technical memories share terms and 'never/avoid' is "
+    "common in real guidance). It now no-ops; contradiction curation is "
+    "same-name supersession + the verify_staleness memory-op. (2) RELAX the "
+    "age windows: DOMAIN_SHELF_LIFE 14-60d -> 365-730d, USAGE_DECAY 30->365, "
+    "USAGE_ARCHIVE 60->730, BUDGET_CAP 100->200, so durable project knowledge "
+    "isn't auto-archived by a short timer. Curated the dogfood store: reset "
+    "the false needs_review flags and restored age-archived standalone "
+    "memories to active. "
     "v6.3.37: FIX governance conflict detector was a false-positive machine. "
     "_detect_conflicts split on whitespace and flagged any two same-domain "
     "entries that shared >=2 tokens INCLUDING filler ('the'/'prism'/'memory') "

--- a/services/prism-service/prism_service/config.py
+++ b/services/prism-service/prism_service/config.py
@@ -42,19 +42,25 @@ QUALITY_INTERVAL_SECONDS = int(
     os.environ.get("PRISM_QUALITY_INTERVAL", "21600"),  # 6h default
 )
 
-# Shelf-life defaults per domain (days)
+# Shelf-life defaults per domain (days). v6.3.38 — these were 14-60 days, which
+# auto-archived durable project knowledge (conventions, architecture decisions)
+# weeks after it was recorded; on the dogfood store that buried hundreds of
+# still-valid memories by age alone. Curation should be content-driven
+# (same-name supersession + verify_staleness + budget caps), not a short age
+# timer, so the windows are long enough that pure-age archiving only catches
+# genuinely ancient entries.
 DOMAIN_SHELF_LIFE: dict[str, int] = {
-    "default": 30,
-    "architecture": 60,
-    "conventions": 60,
-    "failures": 14,
-    "tactical": 14,
+    "default": 730,
+    "architecture": 730,
+    "conventions": 730,
+    "failures": 365,
+    "tactical": 365,
 }
 
-DOMAIN_BUDGET_CAP = 100
+DOMAIN_BUDGET_CAP = 200
 DUPLICATE_THRESHOLD = 0.85
-USAGE_DECAY_DAYS = 30
-USAGE_ARCHIVE_DAYS = 60
+USAGE_DECAY_DAYS = 365
+USAGE_ARCHIVE_DAYS = 730
 TASK_STALE_HOURS = 24
 
 DEFAULT_PROJECT = "default"

--- a/services/prism-service/prism_service/engines/brain_engine.py
+++ b/services/prism-service/prism_service/engines/brain_engine.py
@@ -787,6 +787,29 @@ class Brain:
                 dim = len(probe)
             except Exception:
                 dim = 384
+            # Self-heal a dimension change: if docs_vec already exists at a
+            # different float[N] than the live model, the IF NOT EXISTS below
+            # keeps the stale table and every insert raises "Dimension
+            # mismatch" (e.g. 384-dim MiniLM table vs 512-dim potion model).
+            # Drop it so it is recreated at the current dim; a reindex then
+            # repopulates the vectors. Lets PRISM_EMBEDDER / model upgrades
+            # work without a manual brain wipe.
+            try:
+                row = self._brain.execute(
+                    "SELECT sql FROM sqlite_master WHERE name='docs_vec'"
+                ).fetchone()
+                if row and row[0]:
+                    m = re.search(r"float\[(\d+)\]", row[0])
+                    if m and int(m.group(1)) != dim:
+                        print(
+                            f"Brain: docs_vec dim {m.group(1)} != model dim "
+                            f"{dim}; rebuilding vec table",
+                            file=sys.stderr,
+                        )
+                        self._brain.execute("DROP TABLE IF EXISTS docs_vec")
+                        self._brain.commit()
+            except Exception:
+                pass
             try:
                 self._brain.execute(
                     f"CREATE VIRTUAL TABLE IF NOT EXISTS docs_vec "

--- a/services/prism-service/prism_service/services/governance.py
+++ b/services/prism-service/prism_service/services/governance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from typing import Optional
@@ -15,6 +16,23 @@ from prism_service.config import (
     USAGE_DECAY_DAYS,
 )
 from prism_service.models.memory import HealthReport
+
+
+# Tokens too common to indicate a real shared topic. Without this filter the
+# conflict rule flagged any two same-domain entries that both mention
+# 'the'/'prism'/'memory' as long as one carried a negation word.
+_CONFLICT_STOPWORDS = frozenset({
+    "the", "and", "for", "with", "that", "this", "from", "into", "when",
+    "then", "than", "must", "always", "should", "shall", "will", "have",
+    "has", "are", "was", "were", "use", "uses", "used", "using", "via",
+    "per", "only", "also", "more", "most", "such", "they", "them", "their",
+    "your", "yours", "prism", "memory", "memories", "task", "tasks", "page",
+    "code", "file", "files", "dev", "feature", "features", "work", "works",
+    "done", "need", "needs", "like", "what", "which", "where", "while",
+    "over", "under", "each", "both", "every", "some", "many", "much",
+})
+# How many substantive tokens two entries must share before one is flagged.
+_CONFLICT_MIN_OVERLAP = 4
 
 
 class GovernanceEngine:
@@ -214,37 +232,52 @@ class GovernanceEngine:
     # ------------------------------------------------------------------
 
     def _detect_conflicts(self) -> int:
-        """Flag potentially contradictory entries within each domain.
+        """Flag pairs of active same-domain entries that look genuinely
+        contradictory: exactly one side carries a negation directive AND they
+        share several SUBSTANTIVE keywords.
 
-        Simple heuristic: if two active entries in the same domain share
-        keyword overlap and one contains negation words ('not', "don't",
-        'never', 'avoid'), flag them as potential conflicts.
+        v6.3.37 — the prior rule split on whitespace and required only 2
+        shared tokens *including filler* ('the', 'prism', 'memory'), so any
+        two same-domain entries where one said 'not'/'avoid' tripped it — it
+        had buried 334 unrelated memories in needs_review. We now compare
+        substantive tokens only (alphanumeric, len>=4, not a stop/negation
+        word) and require a meaningful overlap before flagging.
         """
-        negation_words = {"not", "don't", "dont", "never", "avoid", "shouldn't", "shouldnt"}
-        flagged = 0
+        negation_words = {
+            "not", "don't", "dont", "never", "avoid", "shouldn't", "shouldnt",
+        }
 
+        def _has_negation(text: str) -> bool:
+            return bool(set(text.lower().split()) & negation_words)
+
+        def _substantive(text: str) -> set[str]:
+            return {
+                t for t in re.findall(r"[a-z0-9]+", text.lower())
+                if len(t) >= 4
+                and t not in _CONFLICT_STOPWORDS
+                and t not in negation_words
+            }
+
+        flagged = 0
         for domain in self._memory.list_domains():
             entries = self._memory.list_entries(domain, status_filter="active")
-            for i in range(len(entries)):
-                words_i = set(f"{entries[i].name} {entries[i].description}".lower().split())
-                has_neg_i = bool(words_i & negation_words)
-
-                for j in range(i + 1, len(entries)):
-                    words_j = set(
-                        f"{entries[j].name} {entries[j].description}".lower().split()
-                    )
-                    has_neg_j = bool(words_j & negation_words)
-
-                    # Only flag when exactly one side has negation
-                    if has_neg_i == has_neg_j:
+            prepared = [
+                (
+                    e,
+                    _has_negation(f"{e.name} {e.description}"),
+                    _substantive(f"{e.name} {e.description}"),
+                )
+                for e in entries
+            ]
+            for i in range(len(prepared)):
+                _e_i, neg_i, sub_i = prepared[i]
+                for j in range(i + 1, len(prepared)):
+                    e_j, neg_j, sub_j = prepared[j]
+                    # exactly one side must carry a negation directive
+                    if neg_i == neg_j:
                         continue
-
-                    # Check keyword overlap (excluding common stop words)
-                    content_i = words_i - negation_words
-                    content_j = words_j - negation_words
-                    overlap = content_i & content_j
-                    if len(overlap) >= 2:
-                        self._memory.update_entry(entries[j].id, status="needs_review")
+                    if len(sub_i & sub_j) >= _CONFLICT_MIN_OVERLAP:
+                        self._memory.update_entry(e_j.id, status="needs_review")
                         flagged += 1
 
         return flagged

--- a/services/prism-service/prism_service/services/governance.py
+++ b/services/prism-service/prism_service/services/governance.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from datetime import datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from typing import Optional
@@ -16,23 +15,6 @@ from prism_service.config import (
     USAGE_DECAY_DAYS,
 )
 from prism_service.models.memory import HealthReport
-
-
-# Tokens too common to indicate a real shared topic. Without this filter the
-# conflict rule flagged any two same-domain entries that both mention
-# 'the'/'prism'/'memory' as long as one carried a negation word.
-_CONFLICT_STOPWORDS = frozenset({
-    "the", "and", "for", "with", "that", "this", "from", "into", "when",
-    "then", "than", "must", "always", "should", "shall", "will", "have",
-    "has", "are", "was", "were", "use", "uses", "used", "using", "via",
-    "per", "only", "also", "more", "most", "such", "they", "them", "their",
-    "your", "yours", "prism", "memory", "memories", "task", "tasks", "page",
-    "code", "file", "files", "dev", "feature", "features", "work", "works",
-    "done", "need", "needs", "like", "what", "which", "where", "while",
-    "over", "under", "each", "both", "every", "some", "many", "much",
-})
-# How many substantive tokens two entries must share before one is flagged.
-_CONFLICT_MIN_OVERLAP = 4
 
 
 class GovernanceEngine:
@@ -232,55 +214,21 @@ class GovernanceEngine:
     # ------------------------------------------------------------------
 
     def _detect_conflicts(self) -> int:
-        """Flag pairs of active same-domain entries that look genuinely
-        contradictory: exactly one side carries a negation directive AND they
-        share several SUBSTANTIVE keywords.
+        """Disabled — keyword overlap cannot detect semantic contradiction.
 
-        v6.3.37 — the prior rule split on whitespace and required only 2
-        shared tokens *including filler* ('the', 'prism', 'memory'), so any
-        two same-domain entries where one said 'not'/'avoid' tripped it — it
-        had buried 334 unrelated memories in needs_review. We now compare
-        substantive tokens only (alphanumeric, len>=4, not a stop/negation
-        word) and require a meaningful overlap before flagging.
+        v6.3.38 — the keyword heuristic (exactly one entry carries a negation
+        word + shared tokens) produced ONLY false positives at scale. On
+        PRISM's own store it flagged ~138 pairs per run (1499 candidate pairs
+        over 206 active entries): dense technical memories about the same
+        subsystem trivially share >=4 substantive terms, and 'never/avoid/not'
+        is common in legitimate guidance ('never commit to main'). Worse, it
+        auto-mutated status, burying ~390 valid memories in needs_review.
+        Genuine contradiction handling already lives in same-name supersession
+        (MemoryService.store) and the LLM-judged verify_staleness memory-op,
+        so this rule now no-ops. Reintroduce only with an embedding/NLI-based
+        detector that actually models meaning, not token overlap.
         """
-        negation_words = {
-            "not", "don't", "dont", "never", "avoid", "shouldn't", "shouldnt",
-        }
-
-        def _has_negation(text: str) -> bool:
-            return bool(set(text.lower().split()) & negation_words)
-
-        def _substantive(text: str) -> set[str]:
-            return {
-                t for t in re.findall(r"[a-z0-9]+", text.lower())
-                if len(t) >= 4
-                and t not in _CONFLICT_STOPWORDS
-                and t not in negation_words
-            }
-
-        flagged = 0
-        for domain in self._memory.list_domains():
-            entries = self._memory.list_entries(domain, status_filter="active")
-            prepared = [
-                (
-                    e,
-                    _has_negation(f"{e.name} {e.description}"),
-                    _substantive(f"{e.name} {e.description}"),
-                )
-                for e in entries
-            ]
-            for i in range(len(prepared)):
-                _e_i, neg_i, sub_i = prepared[i]
-                for j in range(i + 1, len(prepared)):
-                    e_j, neg_j, sub_j = prepared[j]
-                    # exactly one side must carry a negation directive
-                    if neg_i == neg_j:
-                        continue
-                    if len(sub_i & sub_j) >= _CONFLICT_MIN_OVERLAP:
-                        self._memory.update_entry(e_j.id, status="needs_review")
-                        flagged += 1
-
-        return flagged
+        return 0
 
     # ------------------------------------------------------------------
     # Rule: stuck tasks

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -225,6 +225,31 @@ def _strip_fence(raw_text: str) -> str:
     return cleaned
 
 
+def _extract_verdict_json(raw_text: str) -> dict:
+    """Parse the JSON verdict from a model response.
+
+    The reflect sub-agent is told to "Output ONLY the JSON object" but after
+    15 tool-using turns it routinely prepends a sentence or two of prose
+    before the object (observed live: "...source is empty.\\n\\n{...}"). The
+    old whole-string fence-strip then failed and a perfectly good verdict was
+    abandoned as "not valid JSON". Try, in order: the fence-stripped string,
+    then the outermost ``{...}`` span (handles prose before/after the object).
+    """
+    candidates = [_strip_fence(raw_text)]
+    i, j = raw_text.find("{"), raw_text.rfind("}")
+    if i != -1 and j > i:
+        candidates.append(raw_text[i:j + 1])
+    last_err: Exception | None = None
+    for cand in candidates:
+        try:
+            obj = _json.loads(cand)
+            if isinstance(obj, dict):
+                return obj
+        except Exception as exc:  # noqa: BLE001 - try next candidate
+            last_err = exc
+    raise last_err or ValueError("no JSON object found in response")
+
+
 def run_one(
     project: str,
     candidate_id: str,
@@ -304,7 +329,7 @@ def run_one(
         )
 
     try:
-        verdict = _json.loads(_strip_fence(raw_text))
+        verdict = _extract_verdict_json(raw_text)
     except Exception as exc:
         from prism_service.services.janitor_service import JanitorService
         JanitorService(scores_db).abandon(

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, lazy, Suspense } from "react";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 import { AnimatePresence } from "motion/react";
 import { resolveInitialProject } from "@/lib/project";
@@ -6,22 +6,27 @@ import Sidebar from "@/components/Sidebar";
 import PageHeader from "@/components/PageHeader";
 import Backdrop from "@/components/Backdrop";
 import LiveStatusStrip from "@/components/LiveStatusStrip";
+
+// Route-level code splitting (v6.3.40). Every page used to be a static import,
+// so the graph/Sigma, conductor animation, settings, and mermaid-adjacent code
+// all landed in one ~1.6MB main chunk that had to parse before anything
+// rendered. Each page is now its own chunk fetched on navigation; the initial
+// load is just the shell + the landing dashboard. DashboardPage stays eager
+// because it's the default route — lazy-loading it would only add a flash.
 import DashboardPage from "@/pages/DashboardPage";
-// The unified Brain surface (graph connections + search + context bundle).
-// Lives in ExplorePage.tsx; it replaced the old separate Brain + Graph pages.
-import ExplorePage from "@/pages/ExplorePage";
-import MemoryPage from "@/pages/MemoryPage";
-import MemoryDetailPage from "@/pages/MemoryDetailPage";
-import TasksPage from "@/pages/TasksPage";
-import TaskDetailPage from "@/pages/TaskDetailPage";
-import TaskTextPage from "@/pages/TaskTextPage";
-import ConductorPage from "@/pages/ConductorPage";
-import SessionsPage from "@/pages/SessionsPage";
-import RetrievalsPage from "@/pages/RetrievalsPage";
-import LearningPage from "@/pages/LearningPage";
-import ConsolidationPage from "@/pages/ConsolidationPage";
-import UnderstandPage from "@/pages/UnderstandPage";
-import SettingsPage from "@/pages/SettingsPage";
+const ExplorePage = lazy(() => import("@/pages/ExplorePage"));
+const MemoryPage = lazy(() => import("@/pages/MemoryPage"));
+const MemoryDetailPage = lazy(() => import("@/pages/MemoryDetailPage"));
+const TasksPage = lazy(() => import("@/pages/TasksPage"));
+const TaskDetailPage = lazy(() => import("@/pages/TaskDetailPage"));
+const TaskTextPage = lazy(() => import("@/pages/TaskTextPage"));
+const ConductorPage = lazy(() => import("@/pages/ConductorPage"));
+const SessionsPage = lazy(() => import("@/pages/SessionsPage"));
+const RetrievalsPage = lazy(() => import("@/pages/RetrievalsPage"));
+const LearningPage = lazy(() => import("@/pages/LearningPage"));
+const ConsolidationPage = lazy(() => import("@/pages/ConsolidationPage"));
+const UnderstandPage = lazy(() => import("@/pages/UnderstandPage"));
+const SettingsPage = lazy(() => import("@/pages/SettingsPage"));
 
 export default function App() {
   // Route-swap transition: AnimatePresence mode="wait" keyed on the pathname
@@ -43,6 +48,9 @@ export default function App() {
         <PageHeader />
         <div className="flex-1 overflow-y-auto">
           <AnimatePresence mode="wait">
+          <Suspense
+            fallback={<div className="p-8 text-sm opacity-50">Loading…</div>}
+          >
           <Routes location={location} key={location.pathname}>
             <Route path="/" element={<DashboardPage />} />
             {/* Brain = the one place to explore the knowledge. /graph and
@@ -64,6 +72,7 @@ export default function App() {
             <Route path="/settings" element={<SettingsPage />} />
             <Route path="/settings/:section" element={<SettingsPage />} />
           </Routes>
+          </Suspense>
           </AnimatePresence>
         </div>
       </main>

--- a/services/prism-service/prism_service/web/src/pages/MemoryPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/MemoryPage.tsx
@@ -42,7 +42,11 @@ const GROUPS: { id: GroupKey; label: string }[] = [
 ];
 
 const TYPES = ["all", "expertise", "convention", "decision", "anti-pattern"];
-const STATUSES = ["all", "active", "stale", "retired"];
+// Match the statuses MemoryService actually writes. The old list used
+// 'stale'/'retired', which no entry ever has, so clicking them always showed
+// "No entries match" — and the page defaulted to 'all', dumping every archived
+// generation (1.3MB) alongside the active set.
+const STATUSES = ["all", "active", "archived", "needs_review"];
 
 const TYPE_TONE: Record<string, PillTone> = {
   expertise: "teal",
@@ -130,8 +134,11 @@ export default function MemoryPage() {
   const [stats, setStats] = useState<Record<string, { active: number; archived: number; total: number }>>({});
   const [domain, setDomain] = useState<string>("all");
   const [type, setType] = useState<string>("all");
-  const [status, setStatus] = useState<string>("all");
+  // Default to the active set: it matches the "Entries" KPI and is a fraction
+  // of the payload (the full 'all' set includes every archived generation).
+  const [status, setStatus] = useState<string>("active");
   const [entries, setEntries] = useState<Entry[]>([]);
+  const [loaded, setLoaded] = useState(false);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [bump, setBump] = useState(0);
@@ -174,7 +181,8 @@ export default function MemoryPage() {
     if (type !== "all") params.set("type", type);
     if (status !== "all") params.set("status", status);
     const load = () => api.get<{ entries: Entry[] }>(`/api/memory/entries?${params}`)
-      .then((d) => setEntries(d.entries)).catch(() => { /* keep last */ });
+      .then((d) => { setEntries(d.entries); setLoaded(true); })
+      .catch(() => { setLoaded(true); /* keep last entries */ });
     load();
     const t = setInterval(load, 30000);
     return () => clearInterval(t);
@@ -310,7 +318,9 @@ export default function MemoryPage() {
         </div>
       </Card>
 
-      {entries.length === 0 ? (
+      {!loaded ? (
+        <Card><Empty>Loading memories…</Empty></Card>
+      ) : entries.length === 0 ? (
         <Card><Empty>No entries match these filters.</Empty></Card>
       ) : (
         grouped.map((g) => (

--- a/services/prism-service/prism_service/web/vite.config.ts
+++ b/services/prism-service/prism_service/web/vite.config.ts
@@ -22,6 +22,15 @@ export default defineConfig({
   build: {
     outDir: "../web_dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        // Pull the rarely-changing React runtime into its own chunk so it
+        // caches across deploys and trims the per-build main chunk.
+        manualChunks: {
+          "react-vendor": ["react", "react-dom", "react-router-dom"],
+        },
+      },
+    },
   },
   server: {
     proxy: {

--- a/services/prism-service/tests/unit/test_brain_vec_dim_selfheal.py
+++ b/services/prism-service/tests/unit/test_brain_vec_dim_selfheal.py
@@ -1,0 +1,113 @@
+"""docs_vec self-heals an embedding-dimension change.
+
+Regression guard for v6.3.36. The vec0 table is created `IF NOT EXISTS`, so
+when the embedder's output dim changes (MiniLM 384 -> potion-base-32M 512)
+the stale table survived and every index_doc vector insert raised
+"Dimension mismatch ... Expected 384 ... received 512" — silently, because
+FTS still worked. ``Brain._init_brain_schema`` must drop + recreate docs_vec
+at the live model dim, and must NOT drop it when the dim is unchanged.
+"""
+
+from __future__ import annotations
+
+import re
+
+import numpy as np
+import pytest
+
+from prism_service.engines import brain_engine as be
+
+
+class _FakeModel:
+    """Stand-in embedder whose output dimension we control.
+
+    Returns numpy arrays like the real model2vec / sentence-transformers
+    backends — Brain._embed calls ``.tolist()`` on each row.
+    """
+
+    def __init__(self, dim: int) -> None:
+        self._dim = dim
+
+    def encode(self, texts):
+        return np.asarray(
+            [[0.1] * self._dim for _ in texts], dtype=np.float32
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state(monkeypatch):
+    monkeypatch.setattr(be, "_MODEL", None)
+    monkeypatch.setattr(be, "_SQLITE_VEC_LOADED", False)
+
+
+def _docs_vec_dim(brain) -> int | None:
+    row = brain._brain.execute(
+        "SELECT sql FROM sqlite_master WHERE name='docs_vec'"
+    ).fetchone()
+    if not row or not row[0]:
+        return None
+    m = re.search(r"float\[(\d+)\]", row[0])
+    return int(m.group(1)) if m else None
+
+
+def _vec_count(brain) -> int:
+    return brain._brain.execute("SELECT count(*) FROM docs_vec").fetchone()[0]
+
+
+def _close(brain) -> None:
+    for attr in ("_brain", "_graph", "_scores"):
+        try:
+            getattr(brain, attr).close()
+        except Exception:
+            pass
+
+
+def _new_brain(tmp_path):
+    return be.Brain(
+        str(tmp_path / "brain.db"),
+        str(tmp_path / "graph.db"),
+        str(tmp_path / "scores.db"),
+    )
+
+
+def test_docs_vec_rebuilds_on_dim_change(tmp_path, monkeypatch):
+    # First boot: 384-dim model -> docs_vec float[384] with a row in it.
+    monkeypatch.setattr(be, "_MODEL", _FakeModel(384))
+    b1 = _new_brain(tmp_path)
+    if not b1.vector_enabled:
+        pytest.skip("sqlite-vec not available in this environment")
+    assert _docs_vec_dim(b1) == 384
+    b1._ingest_single("d1", "def foo():\n    return 1\n", source_file="d1.py")
+    assert _vec_count(b1) == 1
+    _close(b1)
+
+    # Second boot on the SAME db: 512-dim model. The stale 384 table must be
+    # rebuilt at 512, and a fresh 512-dim insert must succeed (the bug was
+    # every insert raising "Dimension mismatch").
+    monkeypatch.setattr(be, "_MODEL", _FakeModel(512))
+    b2 = _new_brain(tmp_path)
+    assert b2.vector_enabled
+    assert _docs_vec_dim(b2) == 512, "stale 384 table should be rebuilt at 512"
+    assert _vec_count(b2) == 0, "rebuilt table starts empty; reindex repopulates"
+    ok = b2._ingest_single("d2", "def bar():\n    return 2\n", source_file="d2.py")
+    assert ok is True
+    assert _vec_count(b2) == 1
+    _close(b2)
+
+
+def test_docs_vec_preserved_on_same_dim(tmp_path, monkeypatch):
+    # Self-heal must be CONDITIONAL: an unchanged dim must not drop the table
+    # (a normal restart must never wipe existing vectors).
+    monkeypatch.setattr(be, "_MODEL", _FakeModel(384))
+    b1 = _new_brain(tmp_path)
+    if not b1.vector_enabled:
+        pytest.skip("sqlite-vec not available in this environment")
+    b1._ingest_single("d1", "content one", source_file="d1.py")
+    assert _vec_count(b1) == 1
+    _close(b1)
+
+    monkeypatch.setattr(be, "_MODEL", _FakeModel(384))
+    b2 = _new_brain(tmp_path)
+    assert _docs_vec_dim(b2) == 384
+    assert _vec_count(b2) == 1, "same-dim reboot must preserve existing vectors"
+    _close(b2)

--- a/services/prism-service/tests/unit/test_governance_conflict_detection.py
+++ b/services/prism-service/tests/unit/test_governance_conflict_detection.py
@@ -1,0 +1,68 @@
+"""Governance conflict detection must not over-flag benign memories.
+
+Regression guard for v6.3.37. The old heuristic split on whitespace and
+required only 2 shared tokens *including filler* ('the', 'prism', 'memory'),
+so any two same-domain entries where one merely contained 'not'/'avoid' got
+flipped to needs_review — it had buried 334 unrelated memories. The rule now
+compares substantive tokens (len>=4, not a stop/negation word) and requires a
+higher overlap, so it flags genuine contradictions only.
+"""
+
+from __future__ import annotations
+
+from prism_service.services.governance import GovernanceEngine
+from prism_service.services.memory_service import MemoryService
+
+
+def _mem(tmp_path) -> MemoryService:
+    return MemoryService(str(tmp_path / "mulch"))
+
+
+def _gov(mem) -> GovernanceEngine:
+    # _detect_conflicts only touches the memory service.
+    return GovernanceEngine(mem, None, None)
+
+
+def test_benign_memories_with_shared_filler_not_flagged(tmp_path):
+    mem = _mem(tmp_path)
+    # Both mention common filler ('the','prism','version'/'dev'); one carries a
+    # negation. Under the OLD rule this pair was flagged. They share no
+    # substantive topic, so both must stay active.
+    mem.store(
+        "project", "always-bump-version",
+        "Always bump the prism version on every commit to the footer.",
+        type="convention", classification="tactical",
+    )
+    mem.store(
+        "project", "avoid-docker-dev",
+        "Do not use docker for dev; never run the prism build that way.",
+        type="convention", classification="tactical",
+    )
+    gov = _gov(mem)
+    flagged = gov._detect_conflicts()
+    assert flagged == 0
+    statuses = {
+        e.name: e.status
+        for e in mem.list_entries("project", status_filter="active")
+    }
+    assert statuses == {"always-bump-version": "active", "avoid-docker-dev": "active"}
+
+
+def test_genuine_contradiction_is_flagged(tmp_path):
+    mem = _mem(tmp_path)
+    # Same substantive topic (squash/merge/branches/trunk/commits), opposite
+    # directive — exactly what the rule should catch.
+    mem.store(
+        "workflow", "squash-policy",
+        "Squash merge feature branches into trunk and collapse their commits into one.",
+        type="convention", classification="tactical",
+    )
+    mem.store(
+        "workflow", "keep-history-policy",
+        "Avoid squash merge for branches; keep every commit on trunk, never collapse commits.",
+        type="convention", classification="tactical",
+    )
+    active_before = mem.list_entries("workflow", status_filter="active")
+    assert len(active_before) == 2, "test setup: both should persist as active"
+    gov = _gov(mem)
+    assert gov._detect_conflicts() >= 1

--- a/services/prism-service/tests/unit/test_governance_conflict_detection.py
+++ b/services/prism-service/tests/unit/test_governance_conflict_detection.py
@@ -1,11 +1,13 @@
-"""Governance conflict detection must not over-flag benign memories.
+"""Governance conflict detection must never auto-bury memories.
 
-Regression guard for v6.3.37. The old heuristic split on whitespace and
-required only 2 shared tokens *including filler* ('the', 'prism', 'memory'),
-so any two same-domain entries where one merely contained 'not'/'avoid' got
-flipped to needs_review — it had buried 334 unrelated memories. The rule now
-compares substantive tokens (len>=4, not a stop/negation word) and requires a
-higher overlap, so it flags genuine contradictions only.
+Regression guard for v6.3.36-38. The keyword heuristic (one same-domain entry
+carries a negation word + shared tokens) produced only false positives at
+scale — on the real store it flipped ~390 valid memories to needs_review and
+reported ~138 'conflicts' per run (1499 candidate pairs over 206 entries),
+because dense technical memories trivially share terms and 'never/avoid/not'
+is common in legitimate guidance. Keyword overlap cannot model contradiction,
+so the rule was disabled. It must now no-op: return 0 and mutate nothing, even
+for a blatant same-topic opposite-directive pair.
 """
 
 from __future__ import annotations
@@ -19,15 +21,11 @@ def _mem(tmp_path) -> MemoryService:
 
 
 def _gov(mem) -> GovernanceEngine:
-    # _detect_conflicts only touches the memory service.
     return GovernanceEngine(mem, None, None)
 
 
-def test_benign_memories_with_shared_filler_not_flagged(tmp_path):
+def test_detector_is_a_noop_returns_zero(tmp_path):
     mem = _mem(tmp_path)
-    # Both mention common filler ('the','prism','version'/'dev'); one carries a
-    # negation. Under the OLD rule this pair was flagged. They share no
-    # substantive topic, so both must stay active.
     mem.store(
         "project", "always-bump-version",
         "Always bump the prism version on every commit to the footer.",
@@ -38,20 +36,14 @@ def test_benign_memories_with_shared_filler_not_flagged(tmp_path):
         "Do not use docker for dev; never run the prism build that way.",
         type="convention", classification="tactical",
     )
-    gov = _gov(mem)
-    flagged = gov._detect_conflicts()
-    assert flagged == 0
-    statuses = {
-        e.name: e.status
-        for e in mem.list_entries("project", status_filter="active")
-    }
-    assert statuses == {"always-bump-version": "active", "avoid-docker-dev": "active"}
+    assert _gov(mem)._detect_conflicts() == 0
 
 
-def test_genuine_contradiction_is_flagged(tmp_path):
+def test_detector_never_mutates_status_even_on_real_contradiction(tmp_path):
     mem = _mem(tmp_path)
-    # Same substantive topic (squash/merge/branches/trunk/commits), opposite
-    # directive — exactly what the rule should catch.
+    # Same topic, opposite directive — the kind of pair the old rule chased.
+    # The detector must NOT touch status (no auto-burying); curation of true
+    # contradictions is handled by supersession + verify_staleness instead.
     mem.store(
         "workflow", "squash-policy",
         "Squash merge feature branches into trunk and collapse their commits into one.",
@@ -62,7 +54,7 @@ def test_genuine_contradiction_is_flagged(tmp_path):
         "Avoid squash merge for branches; keep every commit on trunk, never collapse commits.",
         type="convention", classification="tactical",
     )
-    active_before = mem.list_entries("workflow", status_filter="active")
-    assert len(active_before) == 2, "test setup: both should persist as active"
     gov = _gov(mem)
-    assert gov._detect_conflicts() >= 1
+    assert gov._detect_conflicts() == 0
+    statuses = {e.name: e.status for e in mem.list_entries("workflow")}
+    assert statuses == {"squash-policy": "active", "keep-history-policy": "active"}

--- a/services/prism-service/tests/unit/test_reflection_verdict_parse.py
+++ b/services/prism-service/tests/unit/test_reflection_verdict_parse.py
@@ -1,0 +1,58 @@
+"""Reflection verdict parser tolerates prose-before-JSON.
+
+Regression guard for v6.3.36. A reflect sub-agent told to "Output ONLY the
+JSON object" routinely prepends a sentence or two of reasoning after 15
+tool-using turns. The old whole-string fence-strip then failed and a perfectly
+good verdict was abandoned as "verdict not valid JSON" (observed live:
+``"...source is empty.\\n\\n{...}"``). ``_extract_verdict_json`` must recover
+the object from prose before/after it, from markdown fences, or bare.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prism_service.services.reflection_runner import _extract_verdict_json
+
+
+def test_plain_json_object():
+    assert _extract_verdict_json('{"qualitative_score": 0.5}') == {
+        "qualitative_score": 0.5
+    }
+
+
+def test_markdown_fenced_json():
+    assert _extract_verdict_json('```json\n{"a": 1}\n```') == {"a": 1}
+
+
+def test_prose_before_json_the_live_failure_mode():
+    raw = (
+        "The reflection target checkout is empty. I cannot verify any file "
+        "under it, so no candidate memory can be grounded.\n\n"
+        '{"qualitative_score": 0.35, "new_memories": [], "confidence": 0.4}'
+    )
+    out = _extract_verdict_json(raw)
+    assert out["qualitative_score"] == 0.35
+    assert out["new_memories"] == []
+
+
+def test_prose_before_and_after_json():
+    raw = 'Here is my verdict:\n{"confidence": 0.4}\nLet me know if you need more.'
+    assert _extract_verdict_json(raw) == {"confidence": 0.4}
+
+
+def test_fenced_json_with_leading_prose():
+    assert _extract_verdict_json('Reasoning first...\n```json\n{"x": 2}\n```') == {
+        "x": 2
+    }
+
+
+def test_no_json_raises():
+    with pytest.raises(Exception):
+        _extract_verdict_json("no json object here at all")
+
+
+def test_bare_list_is_not_a_verdict():
+    # a verdict must be an object; a top-level array is rejected
+    with pytest.raises(Exception):
+        _extract_verdict_json("[1, 2, 3]")


### PR DESCRIPTION
Lands the stranded v6.3.36–v6.3.40 series (this branch was never pushed; its parser fix being absent from main is why the learning loop kept minting 0 on fresh branches).

- v6.3.36: Brain vec dimension self-heal (docs_vec stuck at float[384] while embedder emits 512 — every vector insert failed silently); robust reflection verdict parse
- v6.3.37: governance conflict detector over-flagging + lock fixes
- v6.3.38: disable unsound keyword conflict heuristic; relax memory age-TTLs (14-60d → 365-730d)
- v6.3.39: /memory page empty-state/status-filter fixes
- v6.3.40: route-level code splitting (main bundle 1611KB → 534KB)

Note: `reflection_runner.py`'s parser fix here is superseded by the more robust `_extract_verdict` landing in the follow-up learning-loop PR, which reconciles on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)