### PR TITLE
fix(v6.5.4): bound the auto-update drain so the daemon stops stranding on the old build

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,28 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.5.3"
+PRISM_VERSION = "6.5.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.5.4: Auto-update no longer strands the daemon on the old build "
+    "(task 73ec7273, lineage of GH #66). The restart watcher set "
+    "_server.should_exit but NEVER _server.force_exit, so a held-open MCP "
+    "streamable-HTTP connection blocked uvicorn's graceful drain forever — "
+    ".run() never returned, the main-thread os.execv (the version flip) was "
+    "never reached, and the wheel sat on disk while the served version "
+    "stranded on the old build. FIX (main.py _restart_watcher): after "
+    "should_exit, escalate to force_exit once the drain exceeds "
+    "PRISM_RESTART_DRAIN_TIMEOUT_S (default 10s) so uvicorn DROPS the "
+    "connection, .run() returns, and the EXISTING main-thread execv fires — "
+    "graceful-first, force-after-timeout so in-flight Brain writes/task "
+    "mutations get the drain window. auto_updater.perform_restart now honors "
+    "its previously-dead drain_timeout_s param the same way. #66 invariants "
+    "preserved: execv stays on the MAIN thread, pidfile not unlinked before "
+    "the in-place execv. SettingsPage.tsx now shows a loud 'Update ready — "
+    "click to restart' control when restart_required is true, turning a "
+    "slow/blocked drain into a one-click user action. Tests: "
+    "tests/integration/test_auto_update_restart_drain.py. "
     "v6.5.3: Tasks timeline readable with rich markdown (task f01b6619). New "
     "web/src/components/Markdown.tsx is the ONE block-markdown + verdict-token "
     "renderer for the SPA: it fuses OnboardingView's dependency-free block "

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -498,14 +498,38 @@ if __name__ == "__main__":
     _config = uvicorn.Config(app, host="0.0.0.0", port=UI_PORT)
     _server = uvicorn.Server(_config)
 
+    # How long to let uvicorn drain held-open connections before forcing.
+    # A persistent MCP streamable-HTTP connection never closes on a graceful
+    # drain (should_exit alone), so without a force escalation .run() would
+    # block forever and the served version would strand on the old build
+    # (task 73ec7273, lineage of #66). Operator-tunable; bounded default.
+    try:
+        _drain_timeout_s = float(os.environ.get("PRISM_RESTART_DRAIN_TIMEOUT_S", "10"))
+    except (TypeError, ValueError):
+        _drain_timeout_s = 10.0
+
     def _restart_watcher() -> None:
-        # Poll the daemon-thread-set flag; when set, ask uvicorn to drain
-        # and stop. The actual os.execv happens on the main thread AFTER
-        # _server.run() returns, so live sockets are closed first.
+        # Poll the daemon-thread-set flag; when set, ask uvicorn to drain and
+        # stop (should_exit). If a held-open connection keeps .run() from
+        # returning within _drain_timeout_s, escalate to force_exit so uvicorn
+        # DROPS connections and .run() returns — the existing main-thread
+        # os.execv (below) then fires. Graceful-first, force-after-timeout so
+        # in-flight Brain writes / task mutations get the drain window.
         while not _server.should_exit:
             if _au.restart_requested():
                 _log.info("auto-update restart requested; draining uvicorn")
                 _server.should_exit = True
+                deadline = time.monotonic() + _drain_timeout_s
+                while time.monotonic() < deadline:
+                    if _server.force_exit:
+                        return
+                    time.sleep(0.1)
+                _log.warning(
+                    "drain exceeded %.0fs; forcing uvicorn shutdown so the "
+                    "re-exec is not stranded on a held-open connection",
+                    _drain_timeout_s,
+                )
+                _server.force_exit = True
                 return
             time.sleep(2.0)
 

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -141,7 +141,14 @@ def perform_restart(server=None, drain_timeout_s: float = 10.0) -> None:
     if _DEFER_RESTART:
         return
     if server is not None:
-        # Signal a graceful drain so listening sockets close before exec.
+        # BOUNDED graceful-first drain (task 73ec7273, lineage of #66):
+        # 1) should_exit -> uvicorn drains its loop + closes idle sockets;
+        # 2) if a held-open MCP streamable-HTTP connection refuses to close,
+        #    after drain_timeout_s set force_exit so uvicorn DROPS it and
+        #    .run() can return. Graceful-first then force-after-timeout means
+        #    in-flight Brain writes / task mutations get the drain window
+        #    before any force-kill (likely_misfire d). We never gate the exec
+        #    on a clean drain — the timeout is the ceiling.
         try:
             server.should_exit = True
         except Exception:
@@ -152,6 +159,16 @@ def perform_restart(server=None, drain_timeout_s: float = 10.0) -> None:
                 stop()
             except Exception:
                 pass
+        # Honor drain_timeout_s: give the graceful path that long, then force.
+        deadline = time.monotonic() + max(0.0, float(drain_timeout_s))
+        while time.monotonic() < deadline:
+            if getattr(server, "force_exit", False):
+                break
+            time.sleep(0.05)
+        try:
+            server.force_exit = True
+        except Exception:
+            pass
     argv = [sys.executable, "-m", "prism_service.main"]
     os.execv(sys.executable, argv)
 

--- a/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
@@ -425,10 +425,25 @@ function UpdatesPanel() {
       </dl>
 
       {status.restart_required && (
-        <div className="rounded-md border border-amber-500/30 bg-amber-500/10 text-amber-100 px-3 py-2 text-sm">
-          New version installed — daemon restart required to apply.
-          On Linux/Mac the service re-execs itself; on Windows run{" "}
-          <span className="font-mono">prism stop && prism start --daemon</span>.
+        <div className="rounded-md border border-amber-500/40 bg-amber-500/15 text-amber-100 px-3 py-3 text-sm flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <div className="font-serif text-base text-amber-50">
+              Update ready — click to restart
+            </div>
+            <div className="text-xs text-amber-200/90 mt-0.5">
+              A new version is installed and waiting. Restart the daemon now to
+              flip the served version — if a held-open connection slows the
+              drain it is force-closed after a bounded window.
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={applyNow}
+            disabled={applying}
+            className="shrink-0 rounded-md border border-amber-400/50 bg-amber-400/20 hover:bg-amber-400/30 disabled:opacity-50 px-3 py-1.5 text-sm font-medium text-amber-50"
+          >
+            {applying ? "Restarting…" : "Click to restart"}
+          </button>
         </div>
       )}
 

--- a/services/prism-service/tests/integration/test_auto_update_restart_drain.py
+++ b/services/prism-service/tests/integration/test_auto_update_restart_drain.py
@@ -1,0 +1,255 @@
+"""Integration (RED): auto-update must not strand the daemon on a blocked drain.
+
+Task 73ec7273 — "Auto-update no longer strands the daemon on the old build"
+(lineage of GH #66). The customer (native venv, persistent MCP streamable-HTTP
+sessions) stayed on v6.5.0 while 6.5.2/6.5.3 were published. Root cause: the
+restart watcher sets `_server.should_exit = True` but NEVER `force_exit`, so
+uvicorn's graceful drain blocks forever on a held-open MCP connection — the
+main-thread `.run()` never returns, the `os.execv` flip is never reached, and
+the served version is stranded on the old build. `perform_restart`'s
+`drain_timeout_s` parameter is dead code (auto_updater.py:125-156).
+
+These tests pin the BOUNDED-drain fix and FAIL today (red) because:
+  * perform_restart ignores drain_timeout_s and never sets force_exit;
+  * the SPA banner is passive ("run prism stop && prism start") not a loud
+    one-click "update ready — click to restart" control.
+
+#66 invariants that MUST stay green (asserted here too): the os.execv flip
+stays on the MAIN thread and the pidfile is not unlinked before the in-place
+execv.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from prism_service.services import auto_updater as au
+
+
+def _arm_update_available():
+    with au._state_lock:
+        au._state.in_docker = False
+        au._state.update_available = True
+        au._state.asset_url = (
+            "https://example.com/prism_service-9.9.9-py3-none-any.whl"
+        )
+        au._state.latest_version = "9.9.9"
+        au._state.restart_required = True
+
+
+def _reset_state():
+    with au._state_lock:
+        au._state.in_docker = False
+        au._state.update_available = False
+        au._state.asset_url = None
+        au._state.latest_version = None
+        au._state.restart_required = False
+    clear = getattr(au, "clear_restart_request", None)
+    if callable(clear):
+        clear()
+
+
+class _StuckServer:
+    """A uvicorn-Server stand-in whose graceful drain NEVER completes — it
+    models a held-open MCP streamable-HTTP connection. should_exit alone does
+    NOT make run() return; only force_exit does (matches uvicorn semantics)."""
+
+    def __init__(self):
+        # Seed flags without tripping the recorder.
+        object.__setattr__(self, "events", [])
+        object.__setattr__(self, "_done", threading.Event())
+        object.__setattr__(self, "should_exit", False)
+        object.__setattr__(self, "force_exit", False)
+
+    def __setattr__(self, name, value):
+        # Record the FIRST flip of should_exit / force_exit to True so the
+        # test can assert escalation ordering against real attribute writes.
+        if name in ("should_exit", "force_exit") and value and name not in self.events:
+            self.events.append(name)
+        object.__setattr__(self, name, value)
+
+    def run(self):
+        # Block until force_exit is set, like uvicorn draining a stuck conn.
+        while not self.force_exit:
+            time.sleep(0.01)
+        self._done.set()
+
+    def stop(self):
+        # A bare should_exit/stop must NOT unblock a held-open connection.
+        self.events.append("stop")
+
+
+# ---------------------------------------------------------------------------
+# AC-1/AC-2/AC-3: perform_restart honors drain_timeout_s, escalates
+# should_exit -> force_exit after the timeout, then os.execv — BOUNDED, not
+# hung on a clean drain.
+# ---------------------------------------------------------------------------
+
+def test_perform_restart_bounds_drain_then_force_exits(monkeypatch):
+    """With a held-open (non-draining) connection, perform_restart must NOT
+    hang: after drain_timeout_s it sets _server.force_exit so uvicorn drops the
+    connection, then os.execv fires. Ordering must be graceful-first:
+    should_exit BEFORE force_exit BEFORE execv (no in-flight-write force-kill).
+    """
+    server = _StuckServer()
+
+    def _fake_execv(path, argv):
+        server.events.append("execv")
+
+    monkeypatch.setattr(au.os, "execv", _fake_execv)
+    _arm_update_available()
+    au.request_restart()
+
+    # Drive perform_restart on a background thread so we can prove it RETURNS
+    # within the bounded window even though the server drain never completes.
+    drain_timeout_s = 0.5
+    err = {}
+
+    def _runner():
+        try:
+            au.perform_restart(server=server, drain_timeout_s=drain_timeout_s)
+        except Exception as e:  # pragma: no cover - surfaced via err
+            err["e"] = e
+
+    t = threading.Thread(target=_runner, name="perform-restart", daemon=True)
+    started = time.monotonic()
+    t.start()
+    # Generous ceiling: bounded drain (0.5s) + escalation slack. If the param
+    # is dead and the code waits on a clean drain, this join times out.
+    t.join(timeout=drain_timeout_s + 4.0)
+    elapsed = time.monotonic() - started
+    try:
+        assert not err, f"perform_restart raised: {err.get('e')!r}"
+        assert not t.is_alive(), (
+            "perform_restart hung on the stuck drain — drain_timeout_s is dead; "
+            "force_exit was never set so .run()/drain never returned"
+        )
+        assert server.force_exit is True, (
+            "after drain_timeout_s elapsed, _server.force_exit must be set so "
+            "uvicorn drops the held-open connection"
+        )
+        assert "execv" in server.events, "os.execv must fire after the bounded drain"
+        # graceful-first then force-after-timeout ordering (likely_misfire d).
+        assert "should_exit" in server.events, (
+            "should_exit must be recorded before the force escalation"
+        )
+        assert server.events.index("should_exit") < server.events.index("execv")
+        if "force_exit" in server.events:
+            assert (
+                server.events.index("should_exit")
+                < server.events.index("force_exit")
+                < server.events.index("execv")
+            ), "ordering must be should_exit -> force_exit -> execv"
+        # The drain must have been BOUNDED by the timeout, not instant and not
+        # unbounded: it should take at least ~drain_timeout_s (graceful window)
+        # but finish well under the join ceiling.
+        assert elapsed >= drain_timeout_s * 0.5, (
+            "force_exit fired before honoring the graceful drain window — "
+            "in-flight writes could be lost (likely_misfire d)"
+        )
+    finally:
+        _reset_state()
+
+
+# ---------------------------------------------------------------------------
+# AC-4 (#66 invariant): the bounded-drain escalation must NOT re-introduce an
+# off-main-thread execv, and must NOT unlink the pidfile before the in-place
+# execv. We call perform_restart on the MAIN thread (this test thread) and
+# assert execv fires here with the pidfile intact.
+# ---------------------------------------------------------------------------
+
+def test_bounded_restart_execs_on_caller_thread_keeps_pidfile(monkeypatch, tmp_path):
+    """The force-after-timeout escalation must keep the os.execv on the calling
+    (main) thread — no helper thread re-execs (GH #66) — and must leave the
+    pidfile in place (execv preserves the PID)."""
+    from prism_service.data_dir import pid_file
+
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    pf = pid_file()
+    pf.parent.mkdir(parents=True, exist_ok=True)
+    pf.write_text(str(__import__("os").getpid()), encoding="utf-8")
+
+    caller_thread = threading.current_thread().name
+    seen = {}
+
+    def _fake_execv(path, argv):
+        seen["thread"] = threading.current_thread().name
+
+    monkeypatch.setattr(au.os, "execv", _fake_execv)
+    _arm_update_available()
+    au.request_restart()
+    try:
+        # server=None: main.py already ran the server to completion; the
+        # bounded path still must execv on THIS thread and keep the pidfile.
+        au.perform_restart(server=None, drain_timeout_s=0.2)
+    finally:
+        _reset_state()
+
+    assert seen.get("thread") == caller_thread, (
+        "os.execv must run on the caller's (main) thread — an off-main-thread "
+        "re-exec reintroduces GH #66"
+    )
+    assert pf.exists(), (
+        "perform_restart must leave the pidfile in place across the in-place execv"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: GET /api/update/status surfaces restart_required (the field the SPA
+# polls to know an update is ready). Mount the real router, hit the real route.
+# ---------------------------------------------------------------------------
+
+def test_api_update_status_surfaces_restart_required():
+    """The /api/update/status route must return restart_required in its JSON
+    body — proven through the real FastAPI router + TestClient, not a direct
+    get_status() call (the field must survive serialization on the live seam)."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from prism_service.api.update import router as update_router
+
+    app = FastAPI()
+    app.include_router(update_router, prefix="/api/update")
+    _arm_update_available()  # sets restart_required=True
+    try:
+        with TestClient(app) as client:
+            resp = client.get("/api/update/status")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "restart_required" in body, (
+            "GET /api/update/status must surface restart_required for the SPA"
+        )
+        assert body["restart_required"] is True
+    finally:
+        _reset_state()
+
+
+# ---------------------------------------------------------------------------
+# AC-6: SettingsPage.tsx must render a LOUD 'update ready — click to restart'
+# control when restart_required is true — not just the passive informational
+# banner ("run prism stop && prism start"). Asserted against the source so the
+# user-facing surface can't silently regress.
+# ---------------------------------------------------------------------------
+
+def test_settings_page_shows_loud_click_to_restart_control():
+    """When restart_required is true the SPA must offer a one-click restart
+    control (turning a slow/blocked drain into a user action), not only a
+    passive 'restart required' notice."""
+    spa = (
+        Path(__file__).resolve().parents[2]
+        / "prism_service" / "web" / "src" / "pages" / "SettingsPage.tsx"
+    )
+    src = spa.read_text(encoding="utf-8")
+    assert "restart_required" in src, "SettingsPage must read restart_required"
+    lowered = src.lower()
+    # A loud, actionable 'update ready — click to restart' control: an onClick
+    # restart handler gated on restart_required, not just static prose.
+    assert "click to restart" in lowered, (
+        "SettingsPage must show a loud 'update ready — click to restart' "
+        "control when restart_required is true (one-click action, not a "
+        "passive 'run prism stop' notice)"
+    )


### PR DESCRIPTION
## What
The auto-updater pip-installs the new wheel but the served version never flips — the re-exec is gated behind uvicorn's graceful drain, which blocks forever on long-lived MCP streaming connections. Confirmed root cause of a customer stuck on v6.5.0 (Linux, systemctl --user): wheel on disk, `os.execv` never reached.

## How
- `main.py` `_restart_watcher`: after `should_exit`, if `.run()` hasn't returned within `PRISM_RESTART_DRAIN_TIMEOUT_S` (default 10s), escalate to `server.force_exit=True` so uvicorn **drops** the held-open connection, `.run()` returns, and the existing main-thread `os.execv` fires. Graceful-first, force-after-timeout.
- `auto_updater.py` `perform_restart`: the previously-**dead** `drain_timeout_s` param is now honored (deadline → force_exit → execv).
- #66 invariants preserved: `os.execv` stays main-thread; pidfile is not unlinked.
- `SettingsPage.tsx`: the passive 'restart required' note is now a loud **'Update ready — click to restart'** control — never a silent stall.
- PRISM_VERSION 6.5.3 → 6.5.4.

## Proof
`tests/integration/test_auto_update_restart_drain.py` (4 green) — a held-open/non-draining connection no longer blocks the re-exec; `force_exit` is set after the timeout and `os.execv` is invoked (not gated on a clean drain). Full suite 1014 passed; tsc + SPA build clean.

## Deploy note
Instances on the OLD updater will still hang draining when they try to reach this build — each needs ONE manual restart to cross over onto the fixed updater, after which future updates self-deploy.

refs #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)