### PR TITLE
feat(v6.5.9): memory tiles show real content + one-click summary backfill (#2567758d)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,24 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.5.8"
+PRISM_VERSION = "6.5.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.5.9: Memory view shows real content instead of a permanent "
+    "'Summarizing…' placeholder (task 2567758d). ~100 active memories had "
+    "summary='' because the standalone memory_summary_worker is retired — "
+    "summaries are only minted in REACTION to a memory.written event, so "
+    "pre-pipeline memories sat summary-less forever while the tile face "
+    "showed fake-progress. FIX: (1) MemoryPage tile renders entry.description "
+    "as real content when summary is empty (summary is an optional upgrade, "
+    "not the required face); 'Awaiting summary' KPI reframed to a truthful "
+    "'Summaries N/M' coverage count. (2) New POST /api/memory/backfill-summaries "
+    "enqueues every active summary-less memory onto the memory.written bus so "
+    "the budget-governed consumer pool mints haiku one-liners for the backlog; "
+    "a 'Generate summaries (N)' button in the Memory header triggers it. "
+    "Idempotent (input-hash + near-dup gates; only summary-less active entries "
+    "enqueue). Tests: tests/integration/test_memory_backfill_summaries.py. "
     "v6.5.8: PREVENT the embedding-path deadlock at the SOURCE so the "
     "out-of-process supervisor (v6.5.7) is genuine last-resort (GH #162, task "
     "76cdb309). Root cause: a thread holding the GIL while blocked on a native "

--- a/services/prism-service/prism_service/api/memory.py
+++ b/services/prism-service/prism_service/api/memory.py
@@ -316,3 +316,34 @@ def import_claude_memories(project: str = Query("default")) -> dict:
         "imported": imported, "skipped": skipped, "failed": failed,
         "memory_dir": str(mem_dir), "details": details,
     }
+
+
+@router.post("/backfill-summaries")
+def backfill_summaries(project: str = Query("default")) -> dict:
+    """Enqueue every active, summary-less memory onto the learning
+    pipeline's memory.written bus so the budget-governed consumer pool
+    mints a one-line summary (haiku) for the backlog.
+
+    Why this exists: the standalone memory_summary_worker is retired —
+    summaries are now minted only in REACTION to a memory.written event
+    (event_handlers.handle_memory_written). Memories written before that
+    pipeline have no event to drain, so they stay summary='' forever.
+    This re-emits the event for each. Idempotent: only active +
+    summary-less entries enqueue, so once the pipeline fills a summary
+    that entry drops out; the pipeline's input-hash + near-dup gates
+    make re-running safe.
+    """
+    svc = _svc(project)
+    from prism_service.services import event_pool as ep
+    bus = ep.get_bus()
+    queued = 0
+    for d in svc.list_domains():
+        for e in svc.list_entries(domain=d, status_filter="active"):
+            if e.summary or e.invalid_at:
+                continue
+            bus.emit(ep.Event(
+                type=ep.MEMORY_WRITTEN,
+                payload={"memory_id": e.id, "project": project},
+            ))
+            queued += 1
+    return {"queued": queued, "project": project}

--- a/services/prism-service/prism_service/web/src/pages/MemoryPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/MemoryPage.tsx
@@ -175,6 +175,27 @@ export default function MemoryPage() {
     }
   };
 
+  // Backfill — enqueue every summary-less memory onto the learning pipeline's
+  // memory.written bus so the budget-governed consumer pool mints one-liners
+  // over time. Idempotent; only summary-less active entries enqueue.
+  const generateSummaries = async () => {
+    setBusy(true);
+    try {
+      const r = await api.post<{ queued: number; project: string }>(
+        `/api/memory/backfill-summaries?project=${project}`, {},
+      );
+      setNotice(
+        r.queued > 0
+          ? `Queued ${r.queued} memor${r.queued === 1 ? "y" : "ies"} for summarization — one-liners mint over time as the budget-governed pipeline drains.`
+          : `No summary-less memories to queue — every shown memory already has a summary.`
+      );
+    } catch (e) {
+      setNotice(`Backfill failed: ${(e as Error).message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
   useEffect(() => {
     const params = new URLSearchParams({ project });
     if (domain !== "all") params.set("domain", domain);
@@ -191,6 +212,12 @@ export default function MemoryPage() {
   const total = useMemo(
     () => Object.values(stats).reduce((a, b) => a + (b?.active ?? 0), 0),
     [stats],
+  );
+  // Summaries are an OPTIONAL upgrade, not the tile face. Surface a truthful
+  // coverage count (N summarized of M shown) instead of fake "awaiting" work.
+  const summarizedCount = useMemo(
+    () => entries.filter((e) => e.summary).length,
+    [entries],
   );
   const pendingSummaries = useMemo(
     () => entries.filter((e) => !e.summary).length,
@@ -253,13 +280,24 @@ export default function MemoryPage() {
           Tiles lead with <em>proven</em> memories (recalled in real sessions);
           click any tile for the full description, evidence, and supersede chain.
         </p>
-        <button
-          onClick={importClaudeMemories}
-          disabled={busy}
-          className="px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-40 shrink-0"
-        >
-          {busy ? "Working…" : "Import Claude memories"}
-        </button>
+        <div className="flex items-center gap-2 shrink-0">
+          {pendingSummaries > 0 && (
+            <button
+              onClick={generateSummaries}
+              disabled={busy}
+              className="px-4 py-2 rounded-md border border-[color:var(--midground-base)]/40 text-xs uppercase tracking-wider disabled:opacity-40"
+            >
+              {busy ? "Working…" : `Generate summaries (${pendingSummaries})`}
+            </button>
+          )}
+          <button
+            onClick={importClaudeMemories}
+            disabled={busy}
+            className="px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-40"
+          >
+            {busy ? "Working…" : "Import Claude memories"}
+          </button>
+        </div>
       </div>
 
       {notice && (
@@ -279,7 +317,7 @@ export default function MemoryPage() {
         <Kpi label="Domains" value={domains.length} />
         <Kpi label="Showing" value={entries.length} />
         <Kpi label="Proven (recalled)" value={provenCount} />
-        <Kpi label="Awaiting summary" value={pendingSummaries} />
+        <Kpi label="Summaries" value={`${summarizedCount}/${entries.length}`} />
       </section>
 
       <Card>
@@ -413,7 +451,7 @@ function MemoryTile({ entry, onClick }: { entry: Entry; onClick: () => void }) {
           ? "text-[color:var(--text-secondary)]"
           : "text-[color:var(--text-muted)] italic")
       }>
-        {entry.summary || "Summarizing…"}
+        {entry.summary || entry.description}
       </div>
       <div className="flex flex-wrap items-center gap-1">
         {type && <TileBadge tone={typeTone}>{type}</TileBadge>}

--- a/services/prism-service/tests/integration/test_memory_backfill_summaries.py
+++ b/services/prism-service/tests/integration/test_memory_backfill_summaries.py
@@ -1,0 +1,225 @@
+"""RED scaffold — POST /api/memory/backfill-summaries (task 2567758d).
+
+Pins the USER-FACING integration end-to-end through the REAL memory
+router + the REAL event_pool bus singleton — not just a service method:
+
+  * POST /api/memory/backfill-summaries enqueues ONLY active,
+    summary-less memories onto the memory.written bus.
+  * Entries that already carry a non-empty summary are SKIPPED.
+  * Entries with invalid_at set are SKIPPED (active-only scoping).
+  * Each enqueued item emits an event_pool.Event of type MEMORY_WRITTEN
+    whose payload carries BOTH memory_id AND project.
+  * The endpoint returns {"queued": N, "project": project} for the SPA
+    "Generate summaries (N)" button.
+  * Idempotent: a second run with no new summary-less entries queues 0.
+  * The MemoryPage UI source drops the "Summarizing…" placeholder (renders
+    entry.description when summary is empty), reframes the KPI to a truthful
+    "Summaries N/M" coverage count, and wires the backfill button.
+
+All FAIL today: the route 404s and the UI still ships the placeholder /
+"Awaiting summary" KPI / no backfill button.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_WEB_SRC = _SERVICE_ROOT / "prism_service" / "web" / "src"
+
+from prism_service.services import event_pool as ep
+from prism_service.services.memory_service import MemoryService
+
+
+# ---------------------------------------------------------------------------
+# A real tmp-backed MemoryService wired into the real router via get_project.
+# ---------------------------------------------------------------------------
+
+def _client(monkeypatch, svc):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from prism_service.api import memory as memory_api
+
+    class _Ctx:
+        memory_svc = svc
+
+    monkeypatch.setattr(memory_api, "get_project", lambda p: _Ctx())
+    app = FastAPI()
+    app.include_router(memory_api.router, prefix="/api/memory")
+    return TestClient(app)
+
+
+@pytest.fixture
+def captured_bus(monkeypatch):
+    """Replace the process-singleton bus with one whose emit() records the
+    Events, so the test can assert on the REAL emission seam the endpoint
+    uses (ep.get_bus().emit(...))."""
+    events: list = []
+
+    class _SpyBus:
+        def emit(self, event):
+            events.append(event)
+
+    monkeypatch.setattr(ep, "_BUS", _SpyBus())
+    monkeypatch.setattr(ep, "get_bus", lambda: ep._BUS)
+    return events
+
+
+@pytest.fixture
+def svc(tmp_path):
+    return MemoryService(str(tmp_path / "expertise"))
+
+
+def _store(svc, name, desc, *, summary=None, invalidate=False):
+    e = svc.store(
+        domain="feedback", name=name, description=desc,
+        type="convention", classification="tactical",
+    )
+    patch = {}
+    if summary is not None:
+        patch["summary"] = summary
+    if invalidate:
+        patch["invalid_at"] = "2026-06-01T00:00:00+00:00"
+    if patch:
+        svc.update_entry(e.id, **patch)
+        e = svc.get_entry(e.id)
+    return e
+
+
+# ---------------------------------------------------------------------------
+# API SEAM — only active + summary-less entries enqueue
+# ---------------------------------------------------------------------------
+
+def test_backfill_enqueues_only_active_summaryless(svc, captured_bus, monkeypatch):
+    client = _client(monkeypatch, svc)
+
+    bare1 = _store(svc, "bare-one", "the first entry that still needs a one-line summary minted")
+    bare2 = _store(svc, "bare-two", "a totally different memory about token budget governance pacing")
+    _store(svc, "already", "has a summary", summary="a crisp haiku line")
+    _store(svc, "stale", "invalidated entry", invalidate=True)
+
+    resp = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["project"] == "prism"
+    assert body["queued"] == 2, f"only the 2 bare entries enqueue: {body}"
+
+    emitted_ids = {e.payload["memory_id"] for e in captured_bus}
+    assert emitted_ids == {bare1.id, bare2.id}, (
+        "must enqueue exactly the active, summary-less entries — "
+        "summarized + invalidated entries are skipped"
+    )
+
+
+def test_backfill_emits_memory_written_with_memory_id_and_project(svc, captured_bus, monkeypatch):
+    client = _client(monkeypatch, svc)
+    e = _store(svc, "lonely-bare", "no summary yet")
+
+    resp = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+
+    assert len(captured_bus) == 1
+    ev = captured_bus[0]
+    assert ev.type == ep.MEMORY_WRITTEN, "event type must be memory.written"
+    # The likely_misfire to defend against: payload missing project -> the
+    # reactive handler can't resolve the project's MemoryService.
+    assert ev.payload.get("memory_id") == e.id
+    assert ev.payload.get("project") == "prism"
+
+
+def test_backfill_skips_summarized_entries(svc, captured_bus, monkeypatch):
+    client = _client(monkeypatch, svc)
+    _store(svc, "done-one", "summarized one", summary="line one")
+    _store(svc, "done-two", "summarized two", summary="line two")
+
+    resp = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["queued"] == 0
+    assert captured_bus == [], "no events for already-summarized entries"
+
+
+def test_backfill_skips_invalidated_entries(svc, captured_bus, monkeypatch):
+    client = _client(monkeypatch, svc)
+    _store(svc, "gone", "invalidated, no summary", invalidate=True)
+
+    resp = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["queued"] == 0
+    assert captured_bus == [], "invalid_at entries are out of active scope"
+
+
+def test_backfill_is_idempotent(svc, captured_bus, monkeypatch):
+    """Re-running enqueues only entries STILL lacking a summary. With no new
+    bare entries and nothing minting summaries between runs, the second run
+    re-queues the same set; the count is stable and never grows."""
+    client = _client(monkeypatch, svc)
+    _store(svc, "bare", "no summary")
+
+    first = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert first.json()["queued"] == 1
+    captured_bus.clear()
+
+    second = client.post("/api/memory/backfill-summaries", params={"project": "prism"})
+    assert second.status_code == 200, second.text
+    # Same surviving bare entry -> count does not grow; re-runs are safe.
+    assert second.json()["queued"] == 1
+
+
+# ---------------------------------------------------------------------------
+# UI SEAM — MemoryPage.tsx renders real content, truthful KPI, backfill button
+# (page render is verified via the running deploy; here we pin that the source
+#  actually drops the placeholder + wires the button — mirrors the established
+#  source-structure asserts in test_task_session_association.py.)
+# ---------------------------------------------------------------------------
+
+def _memory_page_src() -> str:
+    return (_WEB_SRC / "pages" / "MemoryPage.tsx").read_text(encoding="utf-8")
+
+
+def test_memory_tile_drops_summarizing_placeholder():
+    src = _memory_page_src()
+    assert "Summarizing" not in src, (
+        "MemoryPage.tsx must NOT render the fake 'Summarizing…' progress "
+        "placeholder — show entry.description when summary is empty"
+    )
+
+
+def test_memory_tile_renders_description_fallback():
+    src = _memory_page_src()
+    # The tile face must fall back to the real content (entry.description)
+    # when summary is empty — pin the `summary || description` shape on the
+    # tile face, not just any occurrence of entry.description in the file.
+    assert ("entry.summary || entry.description" in src
+            or "summary || entry.description" in src), (
+        "MemoryPage.tsx tile must render entry.description as the real "
+        "content fallback when summary is empty (summary || description)"
+    )
+
+
+def test_memory_kpi_reframed_to_summaries_coverage():
+    src = _memory_page_src()
+    assert "Awaiting summary" not in src, (
+        "the misleading 'Awaiting summary' KPI must be reframed"
+    )
+    assert "Summaries" in src, (
+        "MemoryPage.tsx must show a truthful 'Summaries N/M' coverage KPI"
+    )
+
+
+def test_memory_page_wires_backfill_button():
+    src = _memory_page_src()
+    assert "Generate summaries" in src, (
+        "MemoryPage.tsx header must offer a 'Generate summaries (N)' button"
+    )
+    assert "backfill-summaries" in src, (
+        "the button must POST /api/memory/backfill-summaries"
+    )


### PR DESCRIPTION
## What
Fixes the original "everything says Summarizing…" report. ~100 active memories had `summary=''` because the standalone summary worker is retired (summaries are only minted reactively on a `memory.written` event), so pre-pipeline memories sat summary-less forever while the tile face showed a permanent fake-progress placeholder.

- **Tile renders `entry.description` as real content** when `summary` is empty — the auto-summary is an optional upgrade, not the required face. No more "Summarizing…".
- **KPI reframed** from the misleading "Awaiting summary: N" to a truthful **"Summaries N/M"** coverage count.
- **New `POST /api/memory/backfill-summaries`** enqueues every active summary-less memory onto the `memory.written` bus so the budget-governed pipeline mints haiku one-liners for the backlog. A **"Generate summaries (N)"** header button triggers it. Idempotent (input-hash + near-dup gates; only summary-less active entries enqueue).

Built green through the conductor (task 2567758d); rebased onto main (v6.5.8) and re-stamped 6.5.9.

## Verification
- 9 integration tests (`test_memory_backfill_summaries.py`) green; tsc + SPA build clean.
- **Live on :8888 (v6.5.9)**: memory page shows real tile content (no "Summarizing…"), KPI reads "Summaries 54/108", "Generate summaries (54)" button present; `POST /api/memory/backfill-summaries` returned `{"queued": 54}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)