### PR TITLE
feat(v6.7.0): hosted OKF knowledge wiki + 4->2 Understand consolidation + task rename + MCP guide

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.4"
+PRISM_VERSION = "6.6.5"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.6.5: FIX customer bug (task 11040b39) — a task's TITLE is now editable. "
+    "Threaded `title` through the ONE task_update path across all three layers: "
+    "TaskService.update persists it (with a BLANK-TITLE GUARD — None/empty/"
+    "whitespace is ignored, never blanks an existing title), the MCP task_update "
+    "tool advertises + plumbs `title`, and PATCH /api/tasks/{id} accepts it. "
+    "TaskDetailPage gains a click-to-rename affordance on the title (Enter saves, "
+    "Esc cancels, blank ignored). Tests: tests/unit/test_task_title_rename.py "
+    "(service round-trip + blank guard, MCP dispatcher seam, API PATCH seam). "
     "v6.6.4: UNIFY the knowledge surfaces into TWO (task 89a1ddef). The four "
     "knowledge pages (Brain, Understand, Memory, OKF) collapse to Brain (the "
     "unchanged Sigma graphvis) + a UNIFIED Understand wiki modeled on Google's "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,27 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.1"
+PRISM_VERSION = "6.6.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.6.2: Browse PRISM knowledge as a live OKF wiki (task 09d61b68). The "
+    "pure OKF core lib (prism_service/okf) + read-only host projection "
+    "(services/okf_host.OkfHost — memory entries + indexed brain docs projected "
+    "into conformant OKF concept docs; NEVER writes brain.db/graph.db) now have "
+    "an HTTP + MCP + UI surface. HTTP: new api/okf.py router (GET /api/okf/index "
+    "manifest, /api/okf/concept?path= one typed concept, /api/okf/raw/{path} "
+    "conformant markdown as text/markdown), one OkfHost cached per project. MCP: "
+    "okf_index + okf_get read tools (interactive profile, beside memory_recall). "
+    "UI: new /okf page (Sidebar 'OKF' under Knowledge) renders sections + "
+    "type-colored frontmatter cards, each expandable to fetch its body via the "
+    "shared Hermes Markdown renderer (progressive disclosure, no raw <pre>JSON). "
+    "OkfHost.index() additively carries a compact per-concept manifest so the "
+    "UI colors cards without one request per concept. Tests: "
+    "tests/integration/test_okf_api.py (3) + tests/unit/test_okf_{concept,"
+    "validate,host}.py. NOTE: the integration test asserts the live prism store "
+    "(run with PRISM_DATA_DIR=services/prism-service/data, the documented dev "
+    "store; the sparse AppData default has no projected memory). "
     "v6.6.1: FIX the deadlock watchdog os._exit-ing a HEALTHY daemon. After "
     "#162 flipped PRISM_WATCHDOG_KILL default ON, the watchdog's HTTP self-probe "
     "false-positived whenever the single event loop was busy (model-load, "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,31 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.3"
+PRISM_VERSION = "6.6.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.6.4: UNIFY the knowledge surfaces into TWO (task 89a1ddef). The four "
+    "knowledge pages (Brain, Understand, Memory, OKF) collapse to Brain (the "
+    "unchanged Sigma graphvis) + a UNIFIED Understand wiki modeled on Google's "
+    "OKF visualizer. BACKEND (read-only, still NEVER writes brain.db/graph.db): "
+    "OkfHost.graph() projects a concept GRAPH — nodes are memory concepts "
+    "(carry id+title+type+section, colored by type) and directed edges are the "
+    "authored body cross-links between known concepts (parsed from the already-"
+    "rewritten /memory/<id> links; no dangling edges, no self-loops); "
+    "OkfHost.backlinks()/get() carry inbound 'cited_by' so the panel shows who "
+    "references a concept. New GET /api/okf/graph; /api/okf/concept now includes "
+    "a backlinks list. FRONTEND: UnderstandPage is REPLACED by the wiki — a "
+    "@xyflow/react concept graph (clustered-by-type layout, ~112 nodes legible, "
+    "no new heavy dep) on the left + a detail panel on the right (shared Hermes "
+    "Markdown body, type/tags, edit/retire/supersede via /api/memory/entry/:id/"
+    "action) with internal [[/memory/<id>]] links rewired to SELECT the target "
+    "node IN-PLACE (no route change), a search box, type-filter pills, and a "
+    "'Cited by' backlinks list. NAV: Sidebar KNOWLEDGE = Brain + Understand "
+    "only; /okf and /memory redirect to /understand, /memory/:id deep-links to "
+    "/understand?concept=:id (preselects that node). Old MemoryPage/OkfPage/"
+    "MemoryDetailPage files kept but unrouted. Tests: tests/unit/test_okf_graph"
+    ".py + extended tests/integration/test_okf_api.py (graph + backlinks). "
     "v6.6.3: REWORK the OKF wiki to match the oracle (task 09d61b68): memory, "
     "OKF, and understand are the SAME knowledge. The bundle now projects MEMORY "
     "ENTRIES ONLY — the junk brain-doc dump (_brain_concepts, empty /brain/*.md "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,23 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.5"
+PRISM_VERSION = "6.6.6"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.6.6: ALIGN the agent-facing MCP surface to the 4->2 knowledge "
+    "consolidation (task a4995b7a) — DESCRIPTION/GUIDE text + one read-through "
+    "tool, NO brain/memory/conductor behavior change. (1) prism_guide overview "
+    "+ tools sections rewritten: drop the 'four (tightly coupled) pillars' "
+    "framing for TWO surfaces — Brain = the code-graph VISUALIZATION (Sigma) + "
+    "brain_search/brain_understand retrieval; Understand = ONE unified wiki "
+    "over curated MEMORY projected as OKF concepts (concept graph + readable "
+    "bodies + cross-links + backlinks), reached via okf_index/okf_get/"
+    "okf_graph; memory is browsable AS that wiki. (2) NEW okf_graph MCP tool "
+    "(interactive profile) returns OkfHost.graph() {nodes, edges} — the agent-"
+    "facing concept graph. (3) okf_index/okf_get descriptions reframed as the "
+    "Understand wiki. (4) every understand_* tool description prefixed LEGACY "
+    "(behavior untouched). Tests: tests/unit/test_mcp_two_surface_model.py. "
     "v6.6.5: FIX customer bug (task 11040b39) — a task's TITLE is now editable. "
     "Threaded `title` through the ONE task_update path across all three layers: "
     "TaskService.update persists it (with a BLANK-TITLE GUARD — None/empty/"

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.2"
+PRISM_VERSION = "6.6.3"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.6.3: REWORK the OKF wiki to match the oracle (task 09d61b68): memory, "
+    "OKF, and understand are the SAME knowledge. The bundle now projects MEMORY "
+    "ENTRIES ONLY — the junk brain-doc dump (_brain_concepts, empty /brain/*.md "
+    "concepts) is removed, so sections() == ['memory']. Every concept carries "
+    "its real ExpertiseEntry `id`; clicking a card opens the REAL /memory/<id> "
+    "detail page; a [[wikilink]] rewrites to the target entry's /memory/<id> "
+    "route (links WORK — every concept is readable); code references (evidence "
+    "file_paths) link into /understand (the visual of the same connections). The "
+    "/okf page is woven into the Memory/Understand UI (no parallel renderer): it "
+    "uses the shared Hermes Markdown component — now with real <a> link support — "
+    "and intercepts /memory + /understand clicks via react-router navigate, plus "
+    "a 'raw .md' affordance. Read-only: still NEVER writes brain.db/graph.db. "
     "v6.6.2: Browse PRISM knowledge as a live OKF wiki (task 09d61b68). The "
     "pure OKF core lib (prism_service/okf) + read-only host projection "
     "(services/okf_host.OkfHost — memory entries + indexed brain docs projected "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.6.6"
+PRISM_VERSION = "6.7.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.0: MINOR bump capping the OKF epic — hosted OKF wiki read-path + "
+    "the 4->2 knowledge consolidation (Brain visualization + ONE Understand "
+    "wiki over curated memory) + the task-title rename fix + agent-facing "
+    "MCP/guide alignment, and now a prism_guide ORCHESTRATION PLAYBOOK (task "
+    "b9ddda5e): a new 'Working tasks the PRISM way' section teaches an "
+    "installed PRISM how the CALLING AGENT should orchestrate the conductor "
+    "(epic-as-root-task -> demonstrable subtasks via parent_id; drive the "
+    "review->story_gate->plan_gate->red->implement->green_gate SDLC; fan out "
+    "with subagents + DISTINCT-actor no-self-override gate verification; write "
+    "the WHY to memory_store(type=decision) at green_gate; prefer the "
+    "implement/prototype workflows) — guide TEXT only, no tool behavior "
+    "change. Tests: tests/unit/test_prism_guide_playbook.py. "
     "v6.6.6: ALIGN the agent-facing MCP surface to the 4->2 knowledge "
     "consolidation (task a4995b7a) — DESCRIPTION/GUIDE text + one read-through "
     "tool, NO brain/memory/conductor behavior change. (1) prism_guide overview "

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -22,6 +22,7 @@ from prism_service.api.graph import router as graph_router
 from prism_service.api.jobs import router as jobs_router
 from prism_service.api.learning import router as learning_router
 from prism_service.api.memory import router as memory_router
+from prism_service.api.okf import router as okf_router
 from prism_service.api.projects import router as projects_router
 from prism_service.api.retrievals import router as retrievals_router
 from prism_service.api.service_info import router as service_info_router
@@ -46,6 +47,7 @@ api_router.include_router(graph_router, prefix="/graph", tags=["graph"])
 api_router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 api_router.include_router(learning_router, prefix="/learning", tags=["learning"])
 api_router.include_router(memory_router, prefix="/memory", tags=["memory"])
+api_router.include_router(okf_router, prefix="/okf", tags=["okf"])
 api_router.include_router(projects_router, prefix="/projects", tags=["projects"])
 api_router.include_router(retrievals_router, prefix="/retrievals", tags=["retrievals"])
 api_router.include_router(service_info_router, prefix="/service-info", tags=["service-info"])

--- a/services/prism-service/prism_service/api/okf.py
+++ b/services/prism-service/prism_service/api/okf.py
@@ -35,6 +35,12 @@ def index(project: str = Query("default")) -> dict:
     return _host(project).index()
 
 
+@router.get("/graph")
+def graph(project: str = Query("default")) -> dict:
+    """Concept graph (nodes colored by type + directed cross-link edges)."""
+    return _host(project).graph()
+
+
 @router.get("/concept")
 def concept(project: str = Query("default"), path: str = Query(...)) -> dict:
     """One projected OKF concept (frontmatter + body + links) by path."""

--- a/services/prism-service/prism_service/api/okf.py
+++ b/services/prism-service/prism_service/api/okf.py
@@ -1,0 +1,53 @@
+"""OKF API — PRISM's stores projected as a live, read-only OKF wiki.
+
+Thin read-through to services/okf_host.OkfHost (which only READS the memory +
+brain stores; never writes brain.db / graph.db). One host is cached per project
+so the bundle isn't rebuilt on every request — OkfHost itself invalidates on a
+cheap content signature, so the cache stays correct across writes elsewhere.
+"""
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+
+from prism_service.project_context import get_project
+from prism_service.services.okf_host import OkfHost
+
+router = APIRouter()
+
+_HOSTS: dict[str, OkfHost] = {}
+
+
+def _host(project: str) -> OkfHost:
+    host = _HOSTS.get(project)
+    if host is None:
+        try:
+            p = get_project(project)
+        except Exception as exc:
+            raise HTTPException(404, f"unknown project: {project}: {exc}")
+        host = OkfHost(p.memory_svc, p.brain_svc)
+        _HOSTS[project] = host
+    return host
+
+
+@router.get("/index")
+def index(project: str = Query("default")) -> dict:
+    """OKF manifest: version, sections, concept count, index.md, paths."""
+    return _host(project).index()
+
+
+@router.get("/concept")
+def concept(project: str = Query("default"), path: str = Query(...)) -> dict:
+    """One projected OKF concept (frontmatter + body + links) by path."""
+    c = _host(project).get(path)
+    if c is None:
+        raise HTTPException(404, f"unknown concept: {path}")
+    return c
+
+
+@router.get("/raw/{path:path}", response_class=PlainTextResponse)
+def raw(path: str, project: str = Query("default")) -> PlainTextResponse:
+    """Conformant OKF markdown for a path ('index.md' serves the root index)."""
+    text = _host(project).raw("/" + path)
+    if text is None:
+        raise HTTPException(404, f"unknown path: {path}")
+    return PlainTextResponse(text, media_type="text/markdown")

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -260,6 +260,7 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
 
 
 class TaskUpdate(BaseModel):
+    title: Optional[str] = None
     status: Optional[str] = None
     priority: Optional[int] = None
     assigned_agent: Optional[str] = None

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -817,6 +817,35 @@ TOOLS: list[Tool] = [
         },
     ),
     # ------------------------------------------------------------------
+    # OKF — browse PRISM's stores as a live, read-only OKF wiki. Both
+    # tools are pure projections (never write brain.db / graph.db).
+    # ------------------------------------------------------------------
+    Tool(
+        name="okf_index",
+        description=(
+            "Return the OKF manifest for this project's knowledge: okf_version, "
+            "the top-level sections, the concept count, and every concept path. "
+            "PRISM's memory + brain stores projected as a conformant OKF bundle "
+            "(read-only)."
+        ),
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
+        name="okf_get",
+        description=(
+            "Fetch one OKF concept by path (e.g. '/memory/<domain>/<name>.md'). "
+            "Returns its type, frontmatter, body, and links. Paths come from "
+            "okf_index."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "path": {"type": "string", "description": "Concept path from okf_index"},
+            },
+            "required": ["path"],
+        },
+    ),
+    # ------------------------------------------------------------------
     # LL-08 — Janitor / Layer-B queue endpoints. PRISM schedules the
     # work; the caller's Claude does the LLM compute via the prism-
     # reflect sub-agent. See services/janitor_service.py for the
@@ -1428,6 +1457,8 @@ INTERACTIVE_TOOL_NAMES: set[str] = {
     "prism_guide",
     "memory_store",
     "memory_recall",
+    "okf_index",
+    "okf_get",
     "task_create",
     "task_list",
     "task_next",
@@ -3445,6 +3476,20 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
                 limit=arguments.get("limit", 5),
             )
             return [TextContent(type="text", text=_json(results))]
+
+        # ------------------------------------------------------------------
+        # OKF tools — read-only projection of memory + brain as an OKF wiki
+        # ------------------------------------------------------------------
+        if name in ("okf_index", "okf_get"):
+            from prism_service.services.okf_host import OkfHost
+
+            host = OkfHost(memory_svc, brain_svc)
+            if name == "okf_index":
+                return [TextContent(type="text", text=_json(host.index()))]
+            result = host.get(arguments["path"])
+            if result is None:
+                return [TextContent(type="text", text=_json({"error": f"unknown concept: {arguments['path']}"}))]
+            return [TextContent(type="text", text=_json(result))]
 
         # ------------------------------------------------------------------
         # Task tools

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -1808,7 +1808,7 @@ as navigable OKF concepts. Read-only; never writes brain.db / graph.db.
   adds `context_pack` with role card, rules, template, asset digests, and the
   same relevant context nested for model-agnostic clients.
 - `prism_guide(section?)` — this tool. Sections: overview | tools |
-  workflow | memory | graph | examples.
+  workflow | orchestration | memory | graph | examples.
 """,
     "workflow": """\
 # Daily workflow loop (coding agent)
@@ -1936,11 +1936,53 @@ Requires a maintenance profile such as `?tool_profile=all`.
 3. `context_bundle()` — full picture.
 4. Resume from the last known-good state.
 """,
+    "orchestration": """\
+# Working tasks the PRISM way
+
+PRISM does NOT auto-run your work — YOU (the calling agent) orchestrate the
+conductor through the `task_*` / `conductor_*` MCP tools. The pattern:
+
+## 1. Frame an EPIC as a ROOT task, decompose into demonstrable subtasks
+- `task_create(title=..., parent_id="")` — a ROOT task (empty parent_id) is an
+  EPIC tracked LIVE on /conductor. A task you want to WATCH animate on the
+  conductor MUST be root; child tasks are hidden from the tiles.
+- Break the epic into demonstrable-FEATURE subtasks with
+  `task_create(..., parent_id="<epic_id>")` — the parent_id hierarchy is what
+  the conductor renders. Title = the feature; mechanics go in the description.
+
+## 2. Drive each task through the conductor SDLC state machine
+review -> story_gate -> plan_gate -> red (write FAILING tests) -> implement
+-> green_gate, via `conductor_advance` / `conductor_gate`.
+- story_gate / plan_gate are RUBRIC-VERIFIED: the plan_doc needs a Summary,
+  Requirements, Acceptance Criteria (AC-ids WITH oracles), plus a mermaid
+  `plan_diagram` — a thin plan scores red.
+- red_gate / green_gate are PROOF-CARRYING: the artifact (failing-test trace
+  at the red commit; re-run green capture) is machine-validated.
+
+## 3. FAN OUT with subagents — and verify with a DISTINCT actor
+- A dev/qa subagent builds the slice. Parallelize INDEPENDENT subtasks across
+  subagents (fan-out) to move the epic faster.
+- An INDEPENDENT subagent (a DISTINCT actor — NO self-override) clears
+  red_gate/green_gate with REAL artifacts: it runs the failing test at the red
+  commit, then re-runs + captures green. A gate override by the SAME actor
+  that produced the work is rejected.
+
+## 4. Write the WHY back to memory at green_gate
+On green, `memory_store(type="decision", ...)` the DECISION + rationale +
+rejected alternatives + the file:line it lives at. It resurfaces in the
+Understand wiki so the next agent inherits the reasoning, not just the diff.
+
+## Prefer the skills
+- `implement` (workflow) DRIVES one task through this whole conductor SDLC.
+- `prototype` (workflow) PLANS one task (research -> PRD-style plan).
+Reach for them instead of hand-stepping every gate.
+""",
 }
 
 
 def _prism_guide(section: str | None) -> str:
-    order = ["overview", "tools", "workflow", "memory", "graph", "examples"]
+    order = ["overview", "tools", "workflow", "orchestration", "memory",
+             "graph", "examples"]
     if section and section in _GUIDE_SECTIONS:
         return _GUIDE_SECTIONS[section]
     return "\n\n".join(_GUIDE_SECTIONS[s] for s in order)

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -823,19 +823,20 @@ TOOLS: list[Tool] = [
     Tool(
         name="okf_index",
         description=(
-            "Return the OKF manifest for this project's knowledge: okf_version, "
-            "the top-level sections, the concept count, and every concept path. "
-            "PRISM's memory + brain stores projected as a conformant OKF bundle "
-            "(read-only)."
+            "Browse the Understand wiki: the OKF manifest of this project's "
+            "knowledge (curated memory as navigable concepts). Returns "
+            "okf_version, the top-level sections, the concept count, and every "
+            "concept path. Read-only projection (never writes brain/graph db)."
         ),
         inputSchema={"type": "object", "properties": {}},
     ),
     Tool(
         name="okf_get",
         description=(
-            "Fetch one OKF concept by path (e.g. '/memory/<domain>/<name>.md'). "
-            "Returns its type, frontmatter, body, and links. Paths come from "
-            "okf_index."
+            "Read one concept from the Understand wiki by path "
+            "(e.g. '/memory/<domain>/<name>.md'): its type, frontmatter, "
+            "markdown body, cross-links, and inbound backlinks. Paths come "
+            "from okf_index / okf_graph."
         ),
         inputSchema={
             "type": "object",
@@ -844,6 +845,15 @@ TOOLS: list[Tool] = [
             },
             "required": ["path"],
         },
+    ),
+    Tool(
+        name="okf_graph",
+        description=(
+            "Return the Understand wiki's concept GRAPH for this project — "
+            "nodes (concepts: id, title, type, domain) + edges (cross-links). "
+            "The agent-facing view of the unified Understand wiki."
+        ),
+        inputSchema={"type": "object", "properties": {}},
     ),
     # ------------------------------------------------------------------
     # LL-08 — Janitor / Layer-B queue endpoints. PRISM schedules the
@@ -1460,6 +1470,7 @@ INTERACTIVE_TOOL_NAMES: set[str] = {
     "memory_recall",
     "okf_index",
     "okf_get",
+    "okf_graph",
     "task_create",
     "task_list",
     "task_next",
@@ -1673,14 +1684,18 @@ _GUIDE_SECTIONS: dict[str, str] = {
     "overview": _version_banner() + "\n\n" + """\
 # PRISM — what it is
 
-An on-prem memory + knowledge layer for coding agents. Four tightly coupled
-pillars, all accessed via this MCP endpoint:
+An on-prem memory + knowledge layer for coding agents. Knowledge lives in TWO
+surfaces (plus Tasks + Workflow), all accessed via this MCP endpoint:
 
-- **Brain** — hybrid search over source files, docs, and architecture notes.
-  Combines BM25 (FTS5), dense vector search (sentence-transformers MiniLM by
-  default), and a code graph (graphify: tree-sitter + Leiden clustering).
-- **Memory** — durable project conventions, decisions, and failures. Survives
-  across sessions. Full-text-searchable with supersession semantics.
+- **Brain** — the code-graph VISUALIZATION (Sigma WebGL) plus retrieval over
+  source files, docs, and architecture notes. Retrieve with `brain_search`
+  (hybrid BM25 + dense vector + graph RRF) and `brain_understand`; the graph
+  itself is graphify (tree-sitter + Leiden clustering).
+- **Understand** — ONE unified wiki over the project's curated MEMORY,
+  projected as navigable OKF concepts: a concept graph, readable concept
+  bodies, cross-links, and backlinks. Browse it with `okf_index` /
+  `okf_get` / `okf_graph`. Memory is what you READ here; you still WRITE it
+  with `memory_store` and search the raw entries with `memory_recall`.
 - **Tasks** — kanban-style tracker with dependencies, priorities, personas.
 - **Workflow** — SDLC state machine (planning → RED → GREEN → review) with
   per-step gates.
@@ -1765,6 +1780,14 @@ change between calls. Cache it.
     memories are nearly useless.
 - `memory_recall(query, domain?, limit?)` — FTS search. Returns active,
   temporally valid entries sorted by importance.
+
+## Understand (the unified wiki over Memory)
+Curated memory is browsable as ONE Understand wiki — memory entries projected
+as navigable OKF concepts. Read-only; never writes brain.db / graph.db.
+- `okf_index()` — the wiki manifest: sections, concept count, every path.
+- `okf_get(path)` — read one concept (frontmatter + body + cross-links +
+  backlinks).
+- `okf_graph()` — the concept GRAPH: nodes (concepts) + cross-link edges.
 
 ## Tasks
 - `task_create(title, description?, priority?, dependencies?, tags?,
@@ -3481,12 +3504,14 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
         # ------------------------------------------------------------------
         # OKF tools — read-only projection of memory + brain as an OKF wiki
         # ------------------------------------------------------------------
-        if name in ("okf_index", "okf_get"):
+        if name in ("okf_index", "okf_get", "okf_graph"):
             from prism_service.services.okf_host import OkfHost
 
             host = OkfHost(memory_svc, brain_svc)
             if name == "okf_index":
                 return [TextContent(type="text", text=_json(host.index()))]
+            if name == "okf_graph":
+                return [TextContent(type="text", text=_json(host.graph()))]
             result = host.get(arguments["path"])
             if result is None:
                 return [TextContent(type="text", text=_json({"error": f"unknown concept: {arguments['path']}"}))]

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -1104,6 +1104,7 @@ TOOLS: list[Tool] = [
             "type": "object",
             "properties": {
                 "id": {"type": "string", "description": "Task ID to update"},
+                "title": {"type": "string", "description": "Rename the task. Blank/whitespace is ignored (never blanks an existing title)."},
                 "status": {
                     "type": "string",
                     "description": "New status: pending, in_progress, done, blocked",
@@ -3534,7 +3535,7 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
 
         if name == "task_update":
             update_kwargs: dict[str, Any] = {}
-            for key in ("status", "priority", "assigned_agent", "blocked_reason", "parent_id", "oracle", "proof_type", "completion_proof", "likely_misfire", "full_outcome_complete", "allowed_files", "verify", "stop_if", "plan_doc", "plan_diagram"):
+            for key in ("title", "status", "priority", "assigned_agent", "blocked_reason", "parent_id", "oracle", "proof_type", "completion_proof", "likely_misfire", "full_outcome_complete", "allowed_files", "verify", "stop_if", "plan_doc", "plan_diagram"):
                 if key in arguments:
                     update_kwargs[key] = arguments[key]
             task = task_svc.update(arguments["id"], **update_kwargs)

--- a/services/prism-service/prism_service/mcp/understand_tools.py
+++ b/services/prism-service/prism_service/mcp/understand_tools.py
@@ -161,6 +161,20 @@ _READ_TOOLS: list[Tool] = [
 ]
 UNDERSTAND_TOOLS.extend(_READ_TOOLS)
 
+# v6.6.x — the four-page knowledge model collapsed to TWO surfaces (Brain =
+# code-graph viz; Understand = ONE unified wiki over curated memory). The
+# understand_* analysis-queue tools predate that wiki; mark every one LEGACY so
+# agents reach for okf_index/okf_get/okf_graph + brain_understand first.
+# Behavior is unchanged — descriptions only.
+_LEGACY_PREFIX = (
+    "LEGACY (v5.1 analysis queue) — prefer okf_index/okf_get/okf_graph + "
+    "brain_understand: "
+)
+UNDERSTAND_TOOLS = [
+    t.model_copy(update={"description": _LEGACY_PREFIX + (t.description or "")})
+    for t in UNDERSTAND_TOOLS
+]
+
 UNDERSTAND_TOOL_NAMES: set[str] = {t.name for t in UNDERSTAND_TOOLS}
 
 

--- a/services/prism-service/prism_service/okf/__init__.py
+++ b/services/prism-service/prism_service/okf/__init__.py
@@ -1,0 +1,32 @@
+"""Open Knowledge Format (OKF v0.1) support for PRISM.
+
+OKF is Google Cloud's vendor-neutral standard (2026-06-12) for representing
+curated knowledge as a directory of markdown files with YAML frontmatter,
+cross-linked by markdown links. Spec: github.com/GoogleCloudPlatform/
+knowledge-catalog/blob/main/okf/SPEC.md
+
+This package is the PURE core (no daemon/db deps): a frontmatter codec, an
+in-memory bundle model, a conformance validator, and a cross-link rewriter.
+Producer/consumer/host layers build on top in services/okf_*.py.
+"""
+
+from prism_service.okf.concept import (
+    OKF_VERSION,
+    RESERVED_FILENAMES,
+    Concept,
+    dump_document,
+    parse_document,
+)
+from prism_service.okf.bundle import Bundle
+from prism_service.okf.validate import ValidationReport, validate
+
+__all__ = [
+    "OKF_VERSION",
+    "RESERVED_FILENAMES",
+    "Concept",
+    "parse_document",
+    "dump_document",
+    "Bundle",
+    "validate",
+    "ValidationReport",
+]

--- a/services/prism-service/prism_service/okf/bundle.py
+++ b/services/prism-service/prism_service/okf/bundle.py
@@ -1,0 +1,77 @@
+"""In-memory OKF bundle: a set of concepts plus reserved index.md / log.md.
+
+This is a pure data structure — no filesystem or db. The host/producer layers
+populate it (from projections or disk); the validator and serializers consume
+it. A bundle is a directory of concept docs whose paths are bundle-relative and
+root-absolute (begin with "/").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from prism_service.okf.concept import OKF_VERSION, Concept, dump_document
+
+
+@dataclass
+class Bundle:
+    """A collection of OKF concepts keyed by bundle-relative path."""
+
+    concepts: dict[str, Concept] = field(default_factory=dict)
+    okf_version: str = OKF_VERSION
+    # Optional rendered reserved files (auto-generated if absent).
+    index_md: str = ""
+    log_md: str = ""
+
+    def add(self, concept: Concept) -> None:
+        self.concepts[concept.path] = concept
+
+    def get(self, path: str) -> Concept | None:
+        return self.concepts.get(path)
+
+    def paths(self) -> list[str]:
+        return sorted(self.concepts.keys())
+
+    def sections(self) -> list[str]:
+        """Top-level sections (first path segment) present in the bundle."""
+        segs = set()
+        for p in self.concepts:
+            parts = p.strip("/").split("/")
+            if len(parts) > 1:
+                segs.add(parts[0])
+        return sorted(segs)
+
+    def render_index_md(self) -> str:
+        """Auto-generate the root index.md (progressive disclosure).
+
+        Reserved file: carries only `okf_version` frontmatter at the root, then
+        section headings with `* [Title](/path) - description` list entries.
+        """
+        if self.index_md:
+            return self.index_md
+        lines = [f"---\nokf_version: \"{self.okf_version}\"\n---\n", "# Knowledge", ""]
+        by_section: dict[str, list[Concept]] = {}
+        for path in self.paths():
+            section = path.strip("/").split("/")[0]
+            by_section.setdefault(section, []).append(self.concepts[path])
+        for section in sorted(by_section):
+            lines.append(f"## {section}")
+            for c in by_section[section]:
+                title = c.title or c.path.rsplit("/", 1)[-1]
+                desc = str(c.frontmatter.get("description", "") or "")
+                entry = f"* [{title}]({c.path})"
+                lines.append(f"{entry} - {desc}" if desc else entry)
+            lines.append("")
+        return "\n".join(lines).strip() + "\n"
+
+    def files(self) -> dict[str, str]:
+        """Render the whole bundle to {bundle_path: markdown_text} for raw HTTP.
+
+        Includes the auto-generated /index.md and (if present) /log.md.
+        """
+        out = {"/index.md": self.render_index_md()}
+        if self.log_md:
+            out["/log.md"] = self.log_md
+        for path, concept in self.concepts.items():
+            out[path] = dump_document(concept)
+        return out

--- a/services/prism-service/prism_service/okf/concept.py
+++ b/services/prism-service/prism_service/okf/concept.py
@@ -1,0 +1,89 @@
+"""OKF concept document: frontmatter + markdown body, and its codec.
+
+The single frontmatter codec for PRISM — generalizes the hand-rolled scanner
+that used to live at api/memory.py (_parse_claude_memory). A *concept* is any
+non-reserved .md file; OKF requires exactly one field: a non-empty `type`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+import yaml
+
+OKF_VERSION = "0.1"
+
+# Reserved filenames carry structure, not concept frontmatter (SPEC §reserved).
+RESERVED_FILENAMES = {"index.md", "log.md"}
+
+# Recommended frontmatter fields, in spec priority order.
+RECOMMENDED_FIELDS = ("title", "description", "resource", "tags", "timestamp")
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n?(.*)\Z", re.DOTALL)
+
+
+@dataclass
+class Concept:
+    """A single OKF concept document.
+
+    `path` is the bundle-relative identity (e.g. "/memory/conventions/x.md").
+    `frontmatter` preserves every key (unknown keys included, per SPEC: a
+    consumer MUST NOT drop them). `body` is the UTF-8 markdown after the block.
+    """
+
+    path: str = ""
+    frontmatter: dict = field(default_factory=dict)
+    body: str = ""
+
+    @property
+    def type(self) -> str:
+        return str(self.frontmatter.get("type", "") or "")
+
+    @property
+    def title(self) -> str:
+        return str(self.frontmatter.get("title", "") or "")
+
+    @property
+    def has_valid_type(self) -> bool:
+        """OKF's one hard per-concept rule: a non-empty string `type`."""
+        return bool(self.type.strip())
+
+
+class FrontmatterError(ValueError):
+    """Raised when a concept's YAML frontmatter cannot be parsed."""
+
+
+def parse_document(text: str, path: str = "") -> Concept:
+    """Parse raw .md text into a Concept.
+
+    A document with no leading `---` block parses to empty frontmatter (the
+    reserved index.md/log.md case) — never raises for that. Malformed YAML
+    inside a real block raises FrontmatterError so validate() can report it.
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return Concept(path=path, frontmatter={}, body=text.strip())
+    raw, body = m.group(1), m.group(2)
+    try:
+        fm = yaml.safe_load(raw) or {}
+    except yaml.YAMLError as exc:  # malformed frontmatter
+        raise FrontmatterError(f"{path or '<doc>'}: {exc}") from exc
+    if not isinstance(fm, dict):
+        raise FrontmatterError(f"{path or '<doc>'}: frontmatter is not a mapping")
+    return Concept(path=path, frontmatter=fm, body=body.strip())
+
+
+def dump_document(concept: Concept) -> str:
+    """Serialize a Concept back to conformant .md text (frontmatter + body).
+
+    Round-trips parse_document for concepts with frontmatter. Concepts with
+    empty frontmatter (reserved files) emit the body alone, no `---` block.
+    """
+    if not concept.frontmatter:
+        return concept.body.strip() + "\n"
+    fm = yaml.safe_dump(
+        concept.frontmatter, sort_keys=False, allow_unicode=True, default_flow_style=False
+    ).strip()
+    return f"---\n{fm}\n---\n\n{concept.body.strip()}\n"
+

--- a/services/prism-service/prism_service/okf/links.py
+++ b/services/prism-service/prism_service/okf/links.py
@@ -1,0 +1,39 @@
+"""Cross-link rewriting between PRISM's link forms and OKF markdown links.
+
+PRISM authors links two ways: memory `[[name]]` wikilinks and graph edges
+(source->target). OKF expresses a relationship as a normal markdown link,
+bundle-root-absolute by preference: `[label](/section/slug.md)`. These helpers
+convert in both directions and are deliberately tolerant — per SPEC a consumer
+MUST tolerate broken links, so resolution returns None rather than raising.
+"""
+
+from __future__ import annotations
+
+import re
+
+_WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+_MDLINK_RE = re.compile(r"\[([^\]]*)\]\(([^)]+)\)")
+
+
+def wikilinks_to_md(body: str, resolver) -> str:
+    """Rewrite `[[name]]` -> `[name](/path.md)` using resolver(name)->path|None.
+
+    Unresolved names are left as `[[name]]` text (tolerant; not an error).
+    """
+
+    def _sub(m: re.Match) -> str:
+        name = m.group(1).strip()
+        path = resolver(name)
+        return f"[{name}]({path})" if path else m.group(0)
+
+    return _WIKILINK_RE.sub(_sub, body)
+
+
+def extract_links(body: str) -> list[str]:
+    """Return every markdown link target (href) in a concept body, in order."""
+    return [m.group(2).strip() for m in _MDLINK_RE.finditer(body)]
+
+
+def edge_to_mdlink(label: str, target_path: str) -> str:
+    """Render a graph edge as a bundle-root-absolute markdown link."""
+    return f"[{label}]({target_path})"

--- a/services/prism-service/prism_service/okf/validate.py
+++ b/services/prism-service/prism_service/okf/validate.py
@@ -1,0 +1,68 @@
+"""OKF v0.1 conformance validator.
+
+Implements the SPEC's three HARD rules as errors and the recommended-field /
+link-health guidance as soft warnings (SPEC: consumers SHOULD treat everything
+beyond the hard rules as soft guidance). A bundle is conformant iff there are
+zero errors.
+
+Hard rules:
+  1. Every non-reserved .md has parseable YAML frontmatter.
+  2. Every frontmatter block has a non-empty `type`.
+  3. Reserved filenames (index.md/log.md) carry no concept frontmatter
+     (index.md may carry only `okf_version` at the bundle root).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from prism_service.okf.bundle import Bundle
+from prism_service.okf.concept import (
+    RECOMMENDED_FIELDS,
+    RESERVED_FILENAMES,
+    Concept,
+)
+from prism_service.okf.links import extract_links
+
+
+@dataclass
+class ValidationReport:
+    """Result of validating a bundle. `ok` is True iff no errors."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _is_reserved(path: str) -> bool:
+    return path.rsplit("/", 1)[-1] in RESERVED_FILENAMES
+
+
+def validate(bundle: Bundle) -> ValidationReport:
+    """Validate a Bundle against OKF v0.1. Returns a ValidationReport."""
+    rep = ValidationReport()
+    known = set(bundle.paths())
+    for path in bundle.paths():
+        concept = bundle.concepts[path]
+        if _is_reserved(path):
+            # Rule 3: reserved files don't carry concept frontmatter.
+            stray = set(concept.frontmatter) - {"okf_version"}
+            if stray:
+                rep.errors.append(f"{path}: reserved file carries frontmatter {sorted(stray)}")
+            continue
+        # Rule 2 (implies rule 1 parsed): non-empty type.
+        if not concept.has_valid_type:
+            rep.errors.append(f"{path}: missing or empty required `type` field")
+        # Soft: recommended fields.
+        missing = [f for f in RECOMMENDED_FIELDS if f not in concept.frontmatter]
+        if missing:
+            rep.warnings.append(f"{path}: missing recommended fields {missing}")
+        # Soft: broken intra-bundle links (consumers MUST tolerate; we warn).
+        for href in extract_links(concept.body):
+            if href.startswith("/") and href not in known:
+                rep.warnings.append(f"{path}: broken link -> {href}")
+    return rep
+

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -176,6 +176,75 @@ class OkfHost:
             "concepts": concepts,
         }
 
+    def _id_to_path(self) -> dict[str, str]:
+        """Map each concept's real memory id -> its bundle path (graph nodes)."""
+        out: dict[str, str] = {}
+        for path, c in self.bundle().concepts.items():
+            cid = str(c.frontmatter.get("id", "") or "")
+            if cid:
+                out[cid] = path
+        return out
+
+    def _edges(self) -> list[dict]:
+        """Directed edges = concept body cross-links between known concepts.
+
+        A [[wikilink]] is already rewritten to /memory/<id>; we keep only those
+        targeting a known concept id (no dangling edges, no /understand code
+        refs), deduped, never self-loops. Pure + read-only.
+        """
+        from prism_service.okf.links import extract_links
+
+        known = self._id_to_path()
+        edges: list[dict] = []
+        seen: set[tuple[str, str]] = set()
+        for c in self.bundle().concepts.values():
+            src = str(c.frontmatter.get("id", "") or "")
+            if not src:
+                continue
+            for href in extract_links(c.body):
+                if not href.startswith("/memory/"):
+                    continue
+                tgt = href[len("/memory/"):].strip("/").split("/")[0]
+                if tgt in known and tgt != src and (src, tgt) not in seen:
+                    seen.add((src, tgt))
+                    edges.append({"source": src, "target": tgt})
+        return edges
+
+    def graph(self) -> dict:
+        """Concept graph for the Understand wiki — nodes (memory concepts,
+        colored by type) + directed cross-link edges. Read-only projection."""
+        b = self.bundle()
+        nodes = []
+        for path in b.paths():
+            c = b.concepts[path]
+            cid = str(c.frontmatter.get("id", "") or "")
+            if not cid:
+                continue
+            nodes.append({
+                "id": cid,
+                "title": c.title or path.rsplit("/", 1)[-1],
+                "type": c.type,
+                "section": path.strip("/").split("/")[0],
+                "path": path,
+                "description": str(c.frontmatter.get("description", "") or ""),
+            })
+        return {"nodes": nodes, "edges": self._edges()}
+
+    def backlinks(self, target_id: str) -> list[dict]:
+        """Inbound 'cited by' = concepts whose body links to this concept."""
+        if not target_id:
+            return []
+        id_to_path = self._id_to_path()
+        b = self.bundle()
+        out: list[dict] = []
+        for e in self._edges():
+            if e["target"] != target_id:
+                continue
+            src_path = id_to_path.get(e["source"])
+            title = b.concepts[src_path].title if src_path else ""
+            out.append({"id": e["source"], "title": title or e["source"]})
+        return out
+
     def get(self, path: str) -> dict | None:
         if not path.startswith("/"):
             path = "/" + path
@@ -190,6 +259,7 @@ class OkfHost:
             "frontmatter": c.frontmatter,
             "body": c.body,
             "links": extract_links(c.body),
+            "backlinks": self.backlinks(str(c.frontmatter.get("id", "") or "")),
         }
 
     def raw(self, path: str) -> str | None:

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -1,12 +1,15 @@
-"""Project PRISM's stores into a live, conformant OKF bundle (READ-ONLY).
+"""Project PRISM's curated MEMORY into a live, conformant OKF bundle (READ-ONLY).
 
-Builds an in-memory Bundle from the existing memory (JSONL ExpertiseEntry) and
-brain (docs) stores so the daemon can serve PRISM's knowledge as an OKF wiki
-over MCP / HTTP / the /okf UI. This is the "host, read path" slice.
+Memory, OKF, and Understand are the SAME knowledge: OKF is the curated memory
+expressed as a navigable wiki, and the brain/understand graph is the visual of
+those same connections. So the bundle projects MEMORY ENTRIES ONLY — every
+concept is a real ExpertiseEntry. Clicking a concept opens its real
+/memory/<id> detail page; a [[wikilink]] rewrites to the target entry's
+/memory/<id> route; and code references (evidence file_paths) link into the
+/understand graph. No brain-file / fixture / empty junk concepts.
 
 AUGMENTATION, NOT REPLACEMENT: this only READS the substrate. brain.db vectors,
-graph.db, and the LSP tools are untouched; okf_search (later slice) routes
-through the existing hybrid retrieval rather than reimplementing it.
+graph.db, and the LSP tools are untouched.
 
 A small content-signature cache avoids rebuilding the bundle on every request
 (SPEC perf budget: never a full re-walk per read).
@@ -21,7 +24,6 @@ from prism_service.okf.concept import Concept
 from prism_service.okf.links import wikilinks_to_md
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
-_BRAIN_CAP = 400  # bound the brain projection for perf on large indexes
 
 
 def _slug(text: str) -> str:
@@ -44,7 +46,9 @@ def _memory_body(entry, evidence: dict) -> str:
         parts.append(entry.description)
     cites: list[str] = []
     for p in (evidence.get("file_paths") or []):
-        cites.append(f"- `{p}`")
+        # Code references navigate into the existing /understand graph (the
+        # visual of the same connections) rather than fabricating /brain md.
+        cites.append(f"- [`{p}`](/understand)")
     if evidence.get("commit"):
         cites.append(f"- commit `{evidence['commit']}`")
     if evidence.get("pr"):
@@ -54,21 +58,41 @@ def _memory_body(entry, evidence: dict) -> str:
     return "\n\n".join(parts) or "(no body)"
 
 
+def _name_resolver(name_to_id: dict[str, str]):
+    """Resolve a [[wikilink]] target name to its real /memory/<id> route.
+
+    Match the raw name first, then a slugged form (authors mix dash/underscore
+    spellings of the same entry name). Unknown names return None so the link
+    stays literal `[[name]]` text — tolerant, never an error.
+    """
+
+    def resolve(name: str) -> str | None:
+        target = name_to_id.get(name) or name_to_id.get(_slug(name))
+        return f"/memory/{target}" if target else None
+
+    return resolve
+
+
 def _memory_concepts(memory_svc) -> tuple[list[Concept], dict[str, str]]:
-    """Project active memory entries -> OKF concepts + a name->path link map."""
+    """Project active memory entries -> OKF concepts + a name->id link map."""
     rows: list[tuple[str, str, object]] = []
-    name_to_path: dict[str, str] = {}
+    name_to_id: dict[str, str] = {}
     for domain in memory_svc.list_domains():
         for e in memory_svc.list_entries(domain):  # active only by default
             path = f"/memory/{_slug(domain)}/{_slug(e.name or e.id)}.md"
             rows.append((path, domain, e))
-            if e.name:
-                name_to_path[e.name] = path
+            if e.name and e.id:
+                # Index both the raw and slugged name so cross-spelling
+                # wikilinks still resolve to the real /memory/<id> page.
+                name_to_id[e.name] = e.id
+                name_to_id.setdefault(_slug(e.name), e.id)
+    resolve = _name_resolver(name_to_id)
     concepts: list[Concept] = []
     for path, domain, e in rows:
         evidence = e.evidence if isinstance(e.evidence, dict) else {}
-        body = wikilinks_to_md(_memory_body(e, evidence), name_to_path.get)
+        body = wikilinks_to_md(_memory_body(e, evidence), resolve)
         fm = {
+            "id": e.id,  # the real ExpertiseEntry id -> /memory/<id> detail route
             "type": e.type or "note",
             "title": e.name or e.id,
             "description": e.summary or _first_sentence(e.description),
@@ -79,50 +103,19 @@ def _memory_concepts(memory_svc) -> tuple[list[Concept], dict[str, str]]:
         if evidence.get("pr"):
             fm["resource"] = str(evidence["pr"])
         concepts.append(Concept(path=path, frontmatter=fm, body=body))
-    return concepts, name_to_path
+    return concepts, name_to_id
 
 
-def _brain_concepts(brain_svc, cap: int = _BRAIN_CAP) -> list[Concept]:
-    """Project indexed brain docs -> one OKF concept per source file (bounded).
+def build_bundle(memory_svc, brain_svc=None) -> Bundle:
+    """Assemble the read-only projected OKF bundle — MEMORY ENTRIES ONLY.
 
-    doc_id is "<source_file>::<entity>"; we group entities under their file so
-    the projection is a navigable file listing, not 1000s of chunk fragments.
+    `brain_svc` is accepted (and ignored) for call-site compatibility: the brain
+    graph is surfaced as code-reference links into /understand, never as its own
+    junk concepts.
     """
-    try:
-        docs = brain_svc.list_docs(limit=cap)
-    except Exception:
-        return []
-    by_file: dict[str, dict] = {}
-    for d in docs:
-        doc_id = str(d.get("doc_id", ""))
-        src = doc_id.split("::", 1)[0] or doc_id
-        ent = by_file.setdefault(src, {"domain": d.get("domain") or "code", "entities": []})
-        tail = doc_id.split("::", 1)[1] if "::" in doc_id else ""
-        if tail and tail != "main":
-            ent["entities"].append(tail)
-    concepts: list[Concept] = []
-    for src, info in by_file.items():
-        ents = info["entities"]
-        schema = "\n".join(f"- `{e}`" for e in ents[:50]) if ents else "(file-level chunk)"
-        body = f"Indexed source file. Entities:\n\n# Schema\n{schema}"
-        fm = {
-            "type": info["domain"],
-            "title": src.rsplit("/", 1)[-1].rsplit("\\", 1)[-1],
-            "description": f"{len(ents)} indexed entit{'y' if len(ents) == 1 else 'ies'} from {src}",
-            "resource": src,
-            "tags": ["brain", info["domain"]],
-        }
-        concepts.append(Concept(path=f"/brain/{_slug(src)}.md", frontmatter=fm, body=body))
-    return concepts
-
-
-def build_bundle(memory_svc, brain_svc) -> Bundle:
-    """Assemble the read-only projected OKF bundle from the project's stores."""
     bundle = Bundle()
     mem_concepts, _ = _memory_concepts(memory_svc)
     for c in mem_concepts:
-        bundle.add(c)
-    for c in _brain_concepts(brain_svc):
         bundle.add(c)
     return bundle
 
@@ -130,27 +123,25 @@ def build_bundle(memory_svc, brain_svc) -> Bundle:
 class OkfHost:
     """Per-project read-only OKF projection with a content-signature cache.
 
-    The cache avoids rebuilding on every request; it invalidates when the
-    cheap signature (memory domain count + brain doc count) changes, so writes
+    The cache avoids rebuilding on every request; it invalidates when the cheap
+    memory signature (per-domain active entry counts) changes, so writes
     elsewhere refresh the view without a full re-walk on the hot path.
     """
 
-    def __init__(self, memory_svc, brain_svc):
+    def __init__(self, memory_svc, brain_svc=None):
         self._memory_svc = memory_svc
-        self._brain_svc = brain_svc
+        self._brain_svc = brain_svc  # kept for API compat; not projected
         self._sig: tuple | None = None
         self._bundle: Bundle | None = None
 
     def _signature(self) -> tuple:
         try:
-            domains = tuple(sorted(self._memory_svc.list_domains()))
+            domains = sorted(self._memory_svc.list_domains())
+            return tuple(
+                (d, len(self._memory_svc.list_entries(d))) for d in domains
+            )
         except Exception:
-            domains = ()
-        try:
-            ndocs = len(self._brain_svc.list_docs(limit=_BRAIN_CAP))
-        except Exception:
-            ndocs = 0
-        return (domains, ndocs)
+            return ()
 
     def bundle(self) -> Bundle:
         sig = self._signature()
@@ -169,6 +160,8 @@ class OkfHost:
             c = b.concepts[path]
             concepts.append({
                 "path": path,
+                # The real ExpertiseEntry id -> the UI opens /memory/<id>.
+                "id": str(c.frontmatter.get("id", "") or ""),
                 "section": path.strip("/").split("/")[0],
                 "type": c.type,
                 "title": c.title or path.rsplit("/", 1)[-1],

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -161,12 +161,26 @@ class OkfHost:
 
     def index(self) -> dict:
         b = self.bundle()
+        # Compact per-concept manifest so the /okf UI can render type-colored
+        # frontmatter cards without one request per concept; body stays lazy
+        # (fetched via .get on expand, progressive disclosure).
+        concepts = []
+        for path in b.paths():
+            c = b.concepts[path]
+            concepts.append({
+                "path": path,
+                "section": path.strip("/").split("/")[0],
+                "type": c.type,
+                "title": c.title or path.rsplit("/", 1)[-1],
+                "description": str(c.frontmatter.get("description", "") or ""),
+            })
         return {
             "okf_version": b.okf_version,
             "sections": b.sections(),
             "concept_count": len(b.concepts),
             "index_md": b.render_index_md(),
             "paths": b.paths(),
+            "concepts": concepts,
         }
 
     def get(self, path: str) -> dict | None:

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -1,0 +1,191 @@
+"""Project PRISM's stores into a live, conformant OKF bundle (READ-ONLY).
+
+Builds an in-memory Bundle from the existing memory (JSONL ExpertiseEntry) and
+brain (docs) stores so the daemon can serve PRISM's knowledge as an OKF wiki
+over MCP / HTTP / the /okf UI. This is the "host, read path" slice.
+
+AUGMENTATION, NOT REPLACEMENT: this only READS the substrate. brain.db vectors,
+graph.db, and the LSP tools are untouched; okf_search (later slice) routes
+through the existing hybrid retrieval rather than reimplementing it.
+
+A small content-signature cache avoids rebuilding the bundle on every request
+(SPEC perf budget: never a full re-walk per read).
+"""
+
+from __future__ import annotations
+
+import re
+
+from prism_service.okf.bundle import Bundle
+from prism_service.okf.concept import Concept
+from prism_service.okf.links import wikilinks_to_md
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+_BRAIN_CAP = 400  # bound the brain projection for perf on large indexes
+
+
+def _slug(text: str) -> str:
+    s = _SLUG_RE.sub("-", (text or "").lower()).strip("-")
+    return s or "untitled"
+
+
+def _first_sentence(text: str, limit: int = 200) -> str:
+    text = (text or "").strip().replace("\n", " ")
+    head = text.split(". ", 1)[0]
+    return (head[:limit] + "…") if len(head) > limit else head
+
+
+def _memory_body(entry, evidence: dict) -> str:
+    """Render an ExpertiseEntry as an OKF concept body (structured, not raw)."""
+    parts: list[str] = []
+    if entry.summary:
+        parts.append(entry.summary)
+    if entry.description:
+        parts.append(entry.description)
+    cites: list[str] = []
+    for p in (evidence.get("file_paths") or []):
+        cites.append(f"- `{p}`")
+    if evidence.get("commit"):
+        cites.append(f"- commit `{evidence['commit']}`")
+    if evidence.get("pr"):
+        cites.append(f"- PR {evidence['pr']}")
+    if cites:
+        parts.append("# Citations\n" + "\n".join(cites))
+    return "\n\n".join(parts) or "(no body)"
+
+
+def _memory_concepts(memory_svc) -> tuple[list[Concept], dict[str, str]]:
+    """Project active memory entries -> OKF concepts + a name->path link map."""
+    rows: list[tuple[str, str, object]] = []
+    name_to_path: dict[str, str] = {}
+    for domain in memory_svc.list_domains():
+        for e in memory_svc.list_entries(domain):  # active only by default
+            path = f"/memory/{_slug(domain)}/{_slug(e.name or e.id)}.md"
+            rows.append((path, domain, e))
+            if e.name:
+                name_to_path[e.name] = path
+    concepts: list[Concept] = []
+    for path, domain, e in rows:
+        evidence = e.evidence if isinstance(e.evidence, dict) else {}
+        body = wikilinks_to_md(_memory_body(e, evidence), name_to_path.get)
+        fm = {
+            "type": e.type or "note",
+            "title": e.name or e.id,
+            "description": e.summary or _first_sentence(e.description),
+            "tags": [t for t in (domain, e.classification, e.memory_type) if t],
+            "timestamp": e.recorded_at,
+            "importance": e.importance,
+        }
+        if evidence.get("pr"):
+            fm["resource"] = str(evidence["pr"])
+        concepts.append(Concept(path=path, frontmatter=fm, body=body))
+    return concepts, name_to_path
+
+
+def _brain_concepts(brain_svc, cap: int = _BRAIN_CAP) -> list[Concept]:
+    """Project indexed brain docs -> one OKF concept per source file (bounded).
+
+    doc_id is "<source_file>::<entity>"; we group entities under their file so
+    the projection is a navigable file listing, not 1000s of chunk fragments.
+    """
+    try:
+        docs = brain_svc.list_docs(limit=cap)
+    except Exception:
+        return []
+    by_file: dict[str, dict] = {}
+    for d in docs:
+        doc_id = str(d.get("doc_id", ""))
+        src = doc_id.split("::", 1)[0] or doc_id
+        ent = by_file.setdefault(src, {"domain": d.get("domain") or "code", "entities": []})
+        tail = doc_id.split("::", 1)[1] if "::" in doc_id else ""
+        if tail and tail != "main":
+            ent["entities"].append(tail)
+    concepts: list[Concept] = []
+    for src, info in by_file.items():
+        ents = info["entities"]
+        schema = "\n".join(f"- `{e}`" for e in ents[:50]) if ents else "(file-level chunk)"
+        body = f"Indexed source file. Entities:\n\n# Schema\n{schema}"
+        fm = {
+            "type": info["domain"],
+            "title": src.rsplit("/", 1)[-1].rsplit("\\", 1)[-1],
+            "description": f"{len(ents)} indexed entit{'y' if len(ents) == 1 else 'ies'} from {src}",
+            "resource": src,
+            "tags": ["brain", info["domain"]],
+        }
+        concepts.append(Concept(path=f"/brain/{_slug(src)}.md", frontmatter=fm, body=body))
+    return concepts
+
+
+def build_bundle(memory_svc, brain_svc) -> Bundle:
+    """Assemble the read-only projected OKF bundle from the project's stores."""
+    bundle = Bundle()
+    mem_concepts, _ = _memory_concepts(memory_svc)
+    for c in mem_concepts:
+        bundle.add(c)
+    for c in _brain_concepts(brain_svc):
+        bundle.add(c)
+    return bundle
+
+
+class OkfHost:
+    """Per-project read-only OKF projection with a content-signature cache.
+
+    The cache avoids rebuilding on every request; it invalidates when the
+    cheap signature (memory domain count + brain doc count) changes, so writes
+    elsewhere refresh the view without a full re-walk on the hot path.
+    """
+
+    def __init__(self, memory_svc, brain_svc):
+        self._memory_svc = memory_svc
+        self._brain_svc = brain_svc
+        self._sig: tuple | None = None
+        self._bundle: Bundle | None = None
+
+    def _signature(self) -> tuple:
+        try:
+            domains = tuple(sorted(self._memory_svc.list_domains()))
+        except Exception:
+            domains = ()
+        try:
+            ndocs = len(self._brain_svc.list_docs(limit=_BRAIN_CAP))
+        except Exception:
+            ndocs = 0
+        return (domains, ndocs)
+
+    def bundle(self) -> Bundle:
+        sig = self._signature()
+        if self._bundle is None or sig != self._sig:
+            self._bundle = build_bundle(self._memory_svc, self._brain_svc)
+            self._sig = sig
+        return self._bundle
+
+    def index(self) -> dict:
+        b = self.bundle()
+        return {
+            "okf_version": b.okf_version,
+            "sections": b.sections(),
+            "concept_count": len(b.concepts),
+            "index_md": b.render_index_md(),
+            "paths": b.paths(),
+        }
+
+    def get(self, path: str) -> dict | None:
+        if not path.startswith("/"):
+            path = "/" + path
+        c = self.bundle().get(path)
+        if c is None:
+            return None
+        from prism_service.okf.links import extract_links
+
+        return {
+            "path": c.path,
+            "type": c.type,
+            "frontmatter": c.frontmatter,
+            "body": c.body,
+            "links": extract_links(c.body),
+        }
+
+    def raw(self, path: str) -> str | None:
+        if not path.startswith("/"):
+            path = "/" + path
+        return self.bundle().files().get(path)

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -220,11 +220,21 @@ class OkfHost:
             cid = str(c.frontmatter.get("id", "") or "")
             if not cid:
                 continue
+            # The memory entry's domain groups the wiki's top-level drill: it's
+            # the first frontmatter tag (see _memory_concepts: tags == [domain,
+            # classification, memory_type]); fall back to the path's domain
+            # segment (/memory/<domain>/<name>.md) so a node always has a group.
+            tags = c.frontmatter.get("tags") or []
+            domain = str(tags[0]) if isinstance(tags, list) and tags else ""
+            if not domain:
+                segs = path.strip("/").split("/")
+                domain = segs[1] if len(segs) > 2 else "general"
             nodes.append({
                 "id": cid,
                 "title": c.title or path.rsplit("/", 1)[-1],
                 "type": c.type,
                 "section": path.strip("/").split("/")[0],
+                "domain": domain,
                 "path": path,
                 "description": str(c.frontmatter.get("description", "") or ""),
             })

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -394,6 +394,12 @@ class TaskService:
         for key, value in kwargs.items():
             if not hasattr(task, key) or key == "id":
                 continue
+            # Blank-title guard (customer bug 11040b39): a None / empty /
+            # whitespace-only title is ignored so a rename can never blank
+            # out a task's title. NOT NULL on the column would also reject
+            # None — this keeps the existing title instead of erroring.
+            if key == "title" and not (value or "").strip():
+                continue
             old_value = getattr(task, key)
             if old_value == value:
                 continue

--- a/services/prism-service/prism_service/web/package.json
+++ b/services/prism-service/prism_service/web/package.json
@@ -19,6 +19,7 @@
     "@xyflow/react": "^12.4.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "d3-force": "^3.0.0",
     "gsap": "^3.15.0",
     "leva": "^0.10.1",
     "lucide-react": "^0.577.0",
@@ -33,6 +34,7 @@
     "unicode-animations": "^1.0.3"
   },
   "devDependencies": {
+    "@types/d3-force": "^3.0.10",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -17,6 +17,7 @@ import DashboardPage from "@/pages/DashboardPage";
 const ExplorePage = lazy(() => import("@/pages/ExplorePage"));
 const MemoryPage = lazy(() => import("@/pages/MemoryPage"));
 const MemoryDetailPage = lazy(() => import("@/pages/MemoryDetailPage"));
+const OkfPage = lazy(() => import("@/pages/OkfPage"));
 const TasksPage = lazy(() => import("@/pages/TasksPage"));
 const TaskDetailPage = lazy(() => import("@/pages/TaskDetailPage"));
 const TaskTextPage = lazy(() => import("@/pages/TaskTextPage"));
@@ -60,6 +61,7 @@ export default function App() {
             <Route path="/graph" element={<Navigate to="/brain" replace />} />
             <Route path="/memory" element={<MemoryPage />} />
             <Route path="/memory/:id" element={<MemoryDetailPage />} />
+            <Route path="/okf" element={<OkfPage />} />
             <Route path="/tasks" element={<TasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetailPage />} />
             <Route path="/tasks/:id/:section" element={<TaskTextPage />} />

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, lazy, Suspense } from "react";
-import { Routes, Route, Navigate, useLocation } from "react-router-dom";
+import { Routes, Route, Navigate, useLocation, useParams } from "react-router-dom";
 import { AnimatePresence } from "motion/react";
 import { resolveInitialProject } from "@/lib/project";
 import Sidebar from "@/components/Sidebar";
@@ -15,9 +15,6 @@ import LiveStatusStrip from "@/components/LiveStatusStrip";
 // because it's the default route — lazy-loading it would only add a flash.
 import DashboardPage from "@/pages/DashboardPage";
 const ExplorePage = lazy(() => import("@/pages/ExplorePage"));
-const MemoryPage = lazy(() => import("@/pages/MemoryPage"));
-const MemoryDetailPage = lazy(() => import("@/pages/MemoryDetailPage"));
-const OkfPage = lazy(() => import("@/pages/OkfPage"));
 const TasksPage = lazy(() => import("@/pages/TasksPage"));
 const TaskDetailPage = lazy(() => import("@/pages/TaskDetailPage"));
 const TaskTextPage = lazy(() => import("@/pages/TaskTextPage"));
@@ -59,9 +56,16 @@ export default function App() {
             <Route path="/brain" element={<ExplorePage />} />
             <Route path="/explore" element={<Navigate to="/brain" replace />} />
             <Route path="/graph" element={<Navigate to="/brain" replace />} />
-            <Route path="/memory" element={<MemoryPage />} />
-            <Route path="/memory/:id" element={<MemoryDetailPage />} />
-            <Route path="/okf" element={<OkfPage />} />
+            {/* Knowledge collapsed to TWO surfaces (task 89a1ddef): Brain
+                (Sigma graphvis) + the unified Understand wiki. /memory and
+                /okf fold into Understand but stay deep-linkable via redirect;
+                /memory/:id preselects that concept node in the wiki. */}
+            <Route path="/memory" element={<Navigate to="/understand" replace />} />
+            <Route
+              path="/memory/:id"
+              element={<MemoryConceptRedirect />}
+            />
+            <Route path="/okf" element={<Navigate to="/understand" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetailPage />} />
             <Route path="/tasks/:id/:section" element={<TaskTextPage />} />
@@ -80,4 +84,11 @@ export default function App() {
       </main>
     </div>
   );
+}
+
+// /memory/:id deep-links now resolve a concept in the unified Understand wiki:
+// redirect to /understand?concept=:id so the wiki preselects that node.
+function MemoryConceptRedirect() {
+  const { id = "" } = useParams<{ id: string }>();
+  return <Navigate to={`/understand?concept=${encodeURIComponent(id)}`} replace />;
 }

--- a/services/prism-service/prism_service/web/src/components/Markdown.tsx
+++ b/services/prism-service/prism_service/web/src/components/Markdown.tsx
@@ -126,9 +126,12 @@ export function highlight(s: string): ReactNode[] {
 }
 
 
-// Inline renderer — `code` spans (teal mono chips), **bold**, and verdict-token
-// coloring on the remaining plain text. Code first so `**...**` inside backticks
-// stays literal; plain runs flow through highlight() for verdict tones.
+// Inline renderer — `code` spans (teal mono chips), **bold**, `[label](href)`
+// links, and verdict-token coloring on the remaining plain text. Code first so
+// `**...**` / `[..](..)` inside backticks stay literal; plain runs flow through
+// highlight() for verdict tones. Links render as real <a> anchors so callers can
+// intercept internal routes (e.g. OKF [[wikilinks]] -> /memory/<id>); http(s)
+// targets open in a new tab.
 export function renderInline(text: string): ReactNode {
   const parts: ReactNode[] = [];
   let rest = text;
@@ -136,7 +139,8 @@ export function renderInline(text: string): ReactNode {
   while (rest.length > 0) {
     const code = /`([^`]+)`/.exec(rest);
     const bold = /\*\*([^*]+)\*\*/.exec(rest);
-    const next = pickFirst(code, bold);
+    const link = /\[([^\]]+)\]\(([^)\s]+)\)/.exec(rest);
+    const next = pickFirst(code, bold, link);
     if (!next) { parts.push(<span key={key++}>{highlight(rest)}</span>); break; }
     if (next.index > 0) parts.push(<span key={key++}>{highlight(rest.slice(0, next.index))}</span>);
     if (next === code) {
@@ -144,6 +148,19 @@ export function renderInline(text: string): ReactNode {
         <code key={key++} className="text-[12px] font-mono px-1 py-0.5 rounded bg-[color:var(--accent-teal-bg)] text-[color:var(--accent-teal-fg)] break-all">
           {next[1]}
         </code>,
+      );
+    } else if (next === link) {
+      const href = next[2];
+      const external = /^https?:\/\//.test(href);
+      parts.push(
+        <a
+          key={key++}
+          href={href}
+          {...(external ? { target: "_blank", rel: "noreferrer" } : {})}
+          className="underline decoration-dotted underline-offset-2 text-[color:var(--accent-teal-fg)] hover:opacity-80 break-words"
+        >
+          {renderInline(next[1])}
+        </a>,
       );
     } else {
       parts.push(<strong key={key++} className="font-semibold">{next[1]}</strong>);

--- a/services/prism-service/prism_service/web/src/components/Sidebar.tsx
+++ b/services/prism-service/prism_service/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
-  Activity, AppWindow, BookOpen, Brain, Eye, FolderTree, Globe, Info,
+  Activity, AppWindow, Brain, Eye, FolderTree, Info,
   Layers, LayoutDashboard, ListChecks, MessageSquare, Plug,
   ScrollText, Search, Settings, Sparkles, Workflow,
   type LucideIcon,
@@ -43,18 +43,14 @@ const MAIN_SECTIONS: Section[] = [
   {
     label: "Knowledge",
     items: [
-      // Ultimate Graph merge (siegeon/.prism#50): Brain is now the ONE place
-      // to explore the knowledge — code connections (graph) + search over
-      // structured & unstructured knowledge + the context bundle. The old
-      // separate Graph + Brain-search pages folded in here; /graph and
-      // /explore redirect to /brain. Understand stays its own surface (it
-      // derives structure/domain from the repo and feeds the Brain).
+      // Knowledge collapsed to TWO surfaces (task 89a1ddef): Brain is the
+      // Sigma graphvis (code connections + search + context bundle; /graph +
+      // /explore redirect here). Understand is the unified wiki — memory + OKF
+      // + understanding as one OKF-style concept graph + read panel + links.
+      // The old /memory and /okf entries fold into Understand (still
+      // deep-linkable: /memory and /okf redirect, /memory/:id preselects).
       { to: "/brain", label: "Brain", icon: Brain, staleKey: "brain" },
       { to: "/understand", label: "Understand", icon: Eye, staleKey: "understand" },
-      { to: "/memory", label: "Memory", icon: BookOpen },
-      // OKF wiki: the same Memory + Brain knowledge projected as a live,
-      // read-only Open Knowledge Format bundle (concept docs over HTTP/MCP).
-      { to: "/okf", label: "OKF", icon: Globe },
     ],
   },
   {

--- a/services/prism-service/prism_service/web/src/components/Sidebar.tsx
+++ b/services/prism-service/prism_service/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
-  Activity, AppWindow, BookOpen, Brain, Eye, FolderTree, Info,
+  Activity, AppWindow, BookOpen, Brain, Eye, FolderTree, Globe, Info,
   Layers, LayoutDashboard, ListChecks, MessageSquare, Plug,
   ScrollText, Search, Settings, Sparkles, Workflow,
   type LucideIcon,
@@ -52,6 +52,9 @@ const MAIN_SECTIONS: Section[] = [
       { to: "/brain", label: "Brain", icon: Brain, staleKey: "brain" },
       { to: "/understand", label: "Understand", icon: Eye, staleKey: "understand" },
       { to: "/memory", label: "Memory", icon: BookOpen },
+      // OKF wiki: the same Memory + Brain knowledge projected as a live,
+      // read-only Open Knowledge Format bundle (concept docs over HTTP/MCP).
+      { to: "/okf", label: "OKF", icon: Globe },
     ],
   },
   {

--- a/services/prism-service/prism_service/web/src/pages/OkfPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/OkfPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
+import { useNavigate } from "react-router-dom";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import {
@@ -6,13 +7,16 @@ import {
 } from "@/components/ui";
 import Markdown from "@/components/Markdown";
 
-// OKF (Open Knowledge Format) wiki — PRISM's memory + brain stores projected
-// as a live, read-only OKF bundle (services/okf_host.py). Each concept is a
-// frontmatter doc; this page lists them as type-colored cards, expandable to
-// fetch the conformant body on demand (progressive disclosure). No raw JSON.
+// OKF (Open Knowledge Format) wiki — PRISM's curated MEMORY expressed as a
+// navigable bundle (services/okf_host.py). Memory, OKF, and Understand are the
+// SAME knowledge: every concept here is a real memory entry, clicking a card
+// opens its real /memory/<id> detail page, [[wikilinks]] navigate to the target
+// entry's /memory/<id> page, and code references open the /understand graph (the
+// visual of the same connections). Read-only — nothing here writes the stores.
 
 type ConceptMeta = {
   path: string;
+  id: string;
   section: string;
   type: string;
   title: string;
@@ -35,9 +39,9 @@ type Concept = {
   links: string[];
 };
 
-// OKF concept `type` is free-form (memory type or brain domain). Map the known
-// ones to Hermes accent tones; everything else hashes to a stable tone so the
-// card field still reads as a color-coded legend.
+// OKF concept `type` is a memory type. Map the known ones to Hermes accent
+// tones; everything else hashes to a stable tone so the card field still reads
+// as a color-coded legend.
 const TYPE_TONE: Record<string, PillTone> = {
   convention: "sage",
   decision: "amber",
@@ -46,7 +50,9 @@ const TYPE_TONE: Record<string, PillTone> = {
   failure: "rose",
   note: "slate",
   pattern: "teal",
-  code: "violet",
+  feedback: "violet",
+  project: "amber",
+  reference: "teal",
 };
 
 const HASH_TONES: PillTone[] = ["teal", "sage", "amber", "rose", "violet", "emerald"];
@@ -60,6 +66,7 @@ function typeTone(type: string): PillTone {
 
 export default function OkfPage() {
   const [project] = useProject();
+  const navigate = useNavigate();
   const [index, setIndex] = useState<OkfIndex | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [section, setSection] = useState<string>("all");
@@ -87,22 +94,29 @@ export default function OkfPage() {
   return (
     <Page>
       <p className="text-sm opacity-60">
-        PRISM's knowledge as a live, read-only{" "}
+        PRISM's curated{" "}
+        <button onClick={() => navigate("/memory")} className="opacity-80 underline">memory</button>{" "}
+        as a navigable{" "}
         <a href="https://openknowledgeformat.org" target="_blank" rel="noreferrer" className="opacity-80 underline">OKF</a>{" "}
-        wiki — memory entries and indexed brain docs projected into conformant
-        concept documents. Click any card to read its body; nothing here writes
-        back to the stores. Also served over MCP (<code className="opacity-80">okf_index</code>,{" "}
-        <code className="opacity-80">okf_get</code>) and <code className="opacity-80">/api/okf/raw/index.md</code>.
+        wiki — memory, OKF, and{" "}
+        <button onClick={() => navigate("/understand")} className="opacity-80 underline">understand</button>{" "}
+        are the same knowledge. Every card is a real memory entry: click it to
+        open its detail page, follow a <code className="opacity-80">[[wikilink]]</code> to
+        the entry it references, and code citations open the understand graph (the
+        visual of the same connections). Read-only — also served over MCP
+        (<code className="opacity-80">okf_index</code>,{" "}
+        <code className="opacity-80">okf_get</code>) and{" "}
+        <code className="opacity-80">/api/okf/raw/index.md</code>.
       </p>
 
       <section className="flex flex-wrap gap-3">
         <Kpi label="OKF version" value={index?.okf_version ?? "…"} />
         <Kpi label="Concepts" value={index?.concept_count ?? 0} />
-        <Kpi label="Sections" value={sections.length} />
+        <Kpi label="Domains" value={sections.length} />
       </section>
 
       <Card>
-        <SectionLabel>Section</SectionLabel>
+        <SectionLabel>Domain</SectionLabel>
         <div className="flex flex-wrap gap-2">
           <Pill active={section === "all"} onClick={() => setSection("all")} tone="slate">all</Pill>
           {sections.map((s) => (
@@ -114,7 +128,7 @@ export default function OkfPage() {
       {!loaded ? (
         <Card><Empty>Loading OKF bundle…</Empty></Card>
       ) : !index || index.concept_count === 0 ? (
-        <Card><Empty>No OKF concepts projected for this project yet.</Empty></Card>
+        <Card><Empty>No memory entries projected for this project yet.</Empty></Card>
       ) : (
         grouped.map((g) => (
           <Card key={g.section}>
@@ -126,7 +140,7 @@ export default function OkfPage() {
             </div>
             <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-3">
               {g.items.map((c) => (
-                <ConceptCard key={c.path} meta={c} project={project} />
+                <ConceptCard key={c.path} meta={c} project={project} navigate={navigate} />
               ))}
             </div>
           </Card>
@@ -136,16 +150,29 @@ export default function OkfPage() {
   );
 }
 
-// ConceptCard — type-colored frontmatter card. Collapsed: title + type pill +
-// description. Expand fetches the conformant body once (progressive disclosure)
-// and renders it with the shared Hermes Markdown renderer — never raw <pre>.
-function ConceptCard({ meta, project }: { meta: ConceptMeta; project: string }) {
+// ConceptCard — a real memory entry as a type-colored card. The title opens the
+// REAL /memory/<id> detail page (woven into the Memory UI, not a silo); a peek
+// toggle expands the conformant body inline (progressive disclosure), rendered
+// with the shared Hermes Markdown renderer. Internal links inside the body —
+// [[wikilink]] -> /memory/<id> and code refs -> /understand — are intercepted to
+// use react-router navigate so they actually navigate (no full page reload).
+function ConceptCard({
+  meta, project, navigate,
+}: {
+  meta: ConceptMeta;
+  project: string;
+  navigate: (to: string) => void;
+}) {
   const [open, setOpen] = useState(false);
   const [concept, setConcept] = useState<Concept | null>(null);
   const [busy, setBusy] = useState(false);
   const tone = typeTone(meta.type);
 
-  const toggle = () => {
+  const openDetail = () => {
+    if (meta.id) navigate(`/memory/${meta.id}`);
+  };
+
+  const togglePeek = () => {
     const next = !open;
     setOpen(next);
     if (next && !concept && !busy) {
@@ -162,9 +189,9 @@ function ConceptCard({ meta, project }: { meta: ConceptMeta; project: string }) 
       className="rounded-md border bg-[color:var(--surface-2)] p-3 flex flex-col gap-2"
       style={{ borderColor: open ? `var(--accent-${tone}-ring)` : "var(--border-default)" }}
     >
-      <button onClick={toggle} className="text-left flex flex-col gap-2">
+      <button onClick={openDetail} className="text-left flex flex-col gap-2" title={`Open /memory/${meta.id}`}>
         <div className="flex items-start gap-2">
-          <span className="text-[13px] leading-snug font-medium flex-1 min-w-0 text-[color:var(--text-primary)]">
+          <span className="text-[13px] leading-snug font-medium flex-1 min-w-0 text-[color:var(--text-primary)] underline decoration-dotted decoration-[color:var(--border-strong)] underline-offset-2">
             {meta.title}
           </span>
           {meta.type && (
@@ -185,27 +212,56 @@ function ConceptCard({ meta, project }: { meta: ConceptMeta; project: string }) 
             {meta.description}
           </div>
         )}
-        <div className="text-[10px] font-mono text-[color:var(--text-muted)] truncate">{meta.path}</div>
       </button>
+
+      <div className="flex items-center gap-3 text-[10px] uppercase tracking-wider font-mono">
+        <button onClick={togglePeek} className="opacity-60 hover:opacity-100">
+          {open ? "hide" : "peek"}
+        </button>
+        <button onClick={openDetail} className="opacity-60 hover:opacity-100">open ↗</button>
+        <a
+          href={`/api/okf/raw/${meta.path.replace(/^\//, "")}?project=${encodeURIComponent(project)}`}
+          target="_blank"
+          rel="noreferrer"
+          className="opacity-60 hover:opacity-100 ml-auto"
+        >
+          raw .md
+        </a>
+      </div>
 
       {open && (
         <div className="mt-1 border-t border-[color:var(--border-default)] pt-2">
           {busy ? (
             <div className="text-[12px] opacity-50">Loading concept…</div>
           ) : concept ? (
-            <>
-              <Markdown text={concept.body} className="space-y-3" />
-              {concept.links.length > 0 && (
-                <div className="mt-3 text-[10px] uppercase tracking-wider text-[color:var(--text-label)]">
-                  {concept.links.length} link{concept.links.length === 1 ? "" : "s"}
-                </div>
-              )}
-            </>
+            <WovenMarkdown text={concept.body} navigate={navigate} />
           ) : (
             <div className="text-[12px] text-[color:var(--accent-rose-fg)]">Failed to load concept body.</div>
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+// WovenMarkdown — render a concept body with the shared Markdown component, then
+// intercept clicks on internal links (/memory/<id>, /understand) so they route
+// via react-router instead of a full page reload. Capture-phase listener on the
+// wrapper keeps the shared renderer untouched (it has no link affordance of its
+// own) while making [[wikilinks]] and code refs genuinely navigable.
+function WovenMarkdown({ text, navigate }: { text: string; navigate: (to: string) => void }) {
+  const onClick = (e: MouseEvent<HTMLDivElement>) => {
+    const a = (e.target as HTMLElement).closest("a");
+    if (!a) return;
+    const href = a.getAttribute("href") ?? "";
+    if (href.startsWith("/memory/") || href.startsWith("/understand")) {
+      e.preventDefault();
+      navigate(href);
+    }
+  };
+  return (
+    <div onClickCapture={onClick}>
+      <Markdown text={text} className="space-y-3" />
     </div>
   );
 }

--- a/services/prism-service/prism_service/web/src/pages/OkfPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/OkfPage.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/lib/api";
+import { useProject } from "@/lib/project";
+import {
+  Page, Card, Kpi, SectionLabel, Pill, Empty, type PillTone,
+} from "@/components/ui";
+import Markdown from "@/components/Markdown";
+
+// OKF (Open Knowledge Format) wiki — PRISM's memory + brain stores projected
+// as a live, read-only OKF bundle (services/okf_host.py). Each concept is a
+// frontmatter doc; this page lists them as type-colored cards, expandable to
+// fetch the conformant body on demand (progressive disclosure). No raw JSON.
+
+type ConceptMeta = {
+  path: string;
+  section: string;
+  type: string;
+  title: string;
+  description: string;
+};
+
+type OkfIndex = {
+  okf_version: string;
+  sections: string[];
+  concept_count: number;
+  paths: string[];
+  concepts: ConceptMeta[];
+};
+
+type Concept = {
+  path: string;
+  type: string;
+  frontmatter: Record<string, unknown>;
+  body: string;
+  links: string[];
+};
+
+// OKF concept `type` is free-form (memory type or brain domain). Map the known
+// ones to Hermes accent tones; everything else hashes to a stable tone so the
+// card field still reads as a color-coded legend.
+const TYPE_TONE: Record<string, PillTone> = {
+  convention: "sage",
+  decision: "amber",
+  expertise: "teal",
+  "anti-pattern": "rose",
+  failure: "rose",
+  note: "slate",
+  pattern: "teal",
+  code: "violet",
+};
+
+const HASH_TONES: PillTone[] = ["teal", "sage", "amber", "rose", "violet", "emerald"];
+function typeTone(type: string): PillTone {
+  const t = (type || "").toLowerCase();
+  if (TYPE_TONE[t]) return TYPE_TONE[t];
+  let h = 0;
+  for (let i = 0; i < t.length; i++) h = (h * 31 + t.charCodeAt(i)) >>> 0;
+  return HASH_TONES[h % HASH_TONES.length];
+}
+
+export default function OkfPage() {
+  const [project] = useProject();
+  const [index, setIndex] = useState<OkfIndex | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [section, setSection] = useState<string>("all");
+
+  useEffect(() => {
+    setLoaded(false);
+    api.get<OkfIndex>(`/api/okf/index?project=${encodeURIComponent(project)}`)
+      .then((d) => { setIndex(d); setLoaded(true); })
+      .catch(() => { setIndex(null); setLoaded(true); });
+  }, [project]);
+
+  const sections = index?.sections ?? [];
+  const grouped = useMemo<{ section: string; items: ConceptMeta[] }[]>(() => {
+    const concepts = index?.concepts ?? [];
+    const buckets: Record<string, ConceptMeta[]> = {};
+    for (const c of concepts) {
+      if (section !== "all" && c.section !== section) continue;
+      (buckets[c.section] ??= []).push(c);
+    }
+    return Object.keys(buckets)
+      .sort()
+      .map((s) => ({ section: s, items: buckets[s].sort((a, b) => a.title.localeCompare(b.title)) }));
+  }, [index, section]);
+
+  return (
+    <Page>
+      <p className="text-sm opacity-60">
+        PRISM's knowledge as a live, read-only{" "}
+        <a href="https://openknowledgeformat.org" target="_blank" rel="noreferrer" className="opacity-80 underline">OKF</a>{" "}
+        wiki — memory entries and indexed brain docs projected into conformant
+        concept documents. Click any card to read its body; nothing here writes
+        back to the stores. Also served over MCP (<code className="opacity-80">okf_index</code>,{" "}
+        <code className="opacity-80">okf_get</code>) and <code className="opacity-80">/api/okf/raw/index.md</code>.
+      </p>
+
+      <section className="flex flex-wrap gap-3">
+        <Kpi label="OKF version" value={index?.okf_version ?? "…"} />
+        <Kpi label="Concepts" value={index?.concept_count ?? 0} />
+        <Kpi label="Sections" value={sections.length} />
+      </section>
+
+      <Card>
+        <SectionLabel>Section</SectionLabel>
+        <div className="flex flex-wrap gap-2">
+          <Pill active={section === "all"} onClick={() => setSection("all")} tone="slate">all</Pill>
+          {sections.map((s) => (
+            <Pill key={s} active={section === s} onClick={() => setSection(s)} tone="teal">{s}</Pill>
+          ))}
+        </div>
+      </Card>
+
+      {!loaded ? (
+        <Card><Empty>Loading OKF bundle…</Empty></Card>
+      ) : !index || index.concept_count === 0 ? (
+        <Card><Empty>No OKF concepts projected for this project yet.</Empty></Card>
+      ) : (
+        grouped.map((g) => (
+          <Card key={g.section}>
+            <div className="flex items-baseline gap-3 mb-3">
+              <span className="text-[11px] uppercase tracking-wider font-mono opacity-80">{g.section}</span>
+              <span className="text-[11px] opacity-50 font-mono">
+                {g.items.length} concept{g.items.length === 1 ? "" : "s"}
+              </span>
+            </div>
+            <div className="grid grid-cols-[repeat(auto-fill,minmax(300px,1fr))] gap-3">
+              {g.items.map((c) => (
+                <ConceptCard key={c.path} meta={c} project={project} />
+              ))}
+            </div>
+          </Card>
+        ))
+      )}
+    </Page>
+  );
+}
+
+// ConceptCard — type-colored frontmatter card. Collapsed: title + type pill +
+// description. Expand fetches the conformant body once (progressive disclosure)
+// and renders it with the shared Hermes Markdown renderer — never raw <pre>.
+function ConceptCard({ meta, project }: { meta: ConceptMeta; project: string }) {
+  const [open, setOpen] = useState(false);
+  const [concept, setConcept] = useState<Concept | null>(null);
+  const [busy, setBusy] = useState(false);
+  const tone = typeTone(meta.type);
+
+  const toggle = () => {
+    const next = !open;
+    setOpen(next);
+    if (next && !concept && !busy) {
+      setBusy(true);
+      api.get<Concept>(`/api/okf/concept?project=${encodeURIComponent(project)}&path=${encodeURIComponent(meta.path)}`)
+        .then((c) => setConcept(c))
+        .catch(() => setConcept(null))
+        .finally(() => setBusy(false));
+    }
+  };
+
+  return (
+    <div
+      className="rounded-md border bg-[color:var(--surface-2)] p-3 flex flex-col gap-2"
+      style={{ borderColor: open ? `var(--accent-${tone}-ring)` : "var(--border-default)" }}
+    >
+      <button onClick={toggle} className="text-left flex flex-col gap-2">
+        <div className="flex items-start gap-2">
+          <span className="text-[13px] leading-snug font-medium flex-1 min-w-0 text-[color:var(--text-primary)]">
+            {meta.title}
+          </span>
+          {meta.type && (
+            <span
+              className="text-[10px] uppercase tracking-wider font-mono px-1.5 py-0.5 rounded ring-1 shrink-0"
+              style={{
+                background: `var(--accent-${tone}-bg)`,
+                color: `var(--accent-${tone}-fg)`,
+                boxShadow: `inset 0 0 0 1px var(--accent-${tone}-ring)`,
+              }}
+            >
+              {meta.type}
+            </span>
+          )}
+        </div>
+        {meta.description && (
+          <div className="text-[12px] leading-relaxed line-clamp-2 text-[color:var(--text-secondary)]">
+            {meta.description}
+          </div>
+        )}
+        <div className="text-[10px] font-mono text-[color:var(--text-muted)] truncate">{meta.path}</div>
+      </button>
+
+      {open && (
+        <div className="mt-1 border-t border-[color:var(--border-default)] pt-2">
+          {busy ? (
+            <div className="text-[12px] opacity-50">Loading concept…</div>
+          ) : concept ? (
+            <>
+              <Markdown text={concept.body} className="space-y-3" />
+              {concept.links.length > 0 && (
+                <div className="mt-3 text-[10px] uppercase tracking-wider text-[color:var(--text-label)]">
+                  {concept.links.length} link{concept.links.length === 1 ? "" : "s"}
+                </div>
+              )}
+            </>
+          ) : (
+            <div className="text-[12px] text-[color:var(--accent-rose-fg)]">Failed to load concept body.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -408,6 +408,9 @@ export default function TaskDetailPage() {
   // POST /api/conductor/gate (the same path the MCP conductor_gate tool uses).
   const [gateReason, setGateReason] = useState("");
   const [gateOverride, setGateOverride] = useState(false);
+  // Inline title rename (customer bug 11040b39): click the title to edit.
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
   // Reduced-motion guard for the staggered Card stack, toast, and status flash.
   const reduced = useReducedMotion();
   // Status-chip flash: keyed on the task.status VALUE change (NOT the click).
@@ -473,6 +476,28 @@ export default function TaskDetailPage() {
       load();
     } catch (e) {
       setNotice(`Update failed: ${(e as Error).message ?? e}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // Rename the task. Blank/whitespace drafts are ignored (the server also
+  // guards) so a rename can never blank a title.
+  const renameTitle = async () => {
+    const next = titleDraft.trim();
+    setEditingTitle(false);
+    if (!next || next === (task?.title ?? "")) return;
+    setBusy(true);
+    try {
+      await fetch(`/api/tasks/${id}?project=${project}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ title: next }),
+      });
+      setNotice("Title updated.");
+      load();
+    } catch (e) {
+      setNotice(`Rename failed: ${(e as Error).message ?? e}`);
     } finally {
       setBusy(false);
     }
@@ -575,7 +600,27 @@ export default function TaskDetailPage() {
 
       <div className="flex items-baseline justify-between gap-4">
         <div>
-          <h1 className="font-serif text-3xl tracking-tight">{task.title ?? "Untitled task"}</h1>
+          {editingTitle ? (
+            <input
+              autoFocus
+              className="font-serif text-3xl tracking-tight bg-transparent border-b border-current outline-none w-full"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={renameTitle}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") renameTitle();
+                if (e.key === "Escape") setEditingTitle(false);
+              }}
+            />
+          ) : (
+            <h1
+              className="font-serif text-3xl tracking-tight cursor-text hover:opacity-70"
+              title="Click to rename"
+              onClick={() => { setTitleDraft(task.title ?? ""); setEditingTitle(true); }}
+            >
+              {task.title ?? "Untitled task"}
+            </h1>
+          )}
           <div className="flex items-center gap-2 mt-2 flex-wrap">
             <motion.span
               // Flash on the confirmed task.status value change (statusFlash

--- a/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
@@ -1,28 +1,39 @@
-import { useEffect, useMemo, useState, type MouseEvent } from "react";
+import { useEffect, useMemo, useState, type CSSProperties, type MouseEvent } from "react";
 import { useSearchParams } from "react-router-dom";
 import {
-  Background, BackgroundVariant, Controls, MiniMap,
+  Background, BackgroundVariant, Controls, Handle, MiniMap, Position,
   ReactFlow, ReactFlowProvider, useEdgesState, useNodesState,
   type Edge as RfEdge, type Node as RfNode,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
+import {
+  forceCenter, forceCollide, forceLink, forceManyBody, forceSimulation, forceX, forceY,
+} from "d3-force";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
-import { Card, Empty, Pill, type PillTone } from "@/components/ui";
+import { Card, Empty, type PillTone } from "@/components/ui";
+import { prismDomainColor } from "@/components/understand/PrismDomainNode";
 import Markdown from "@/components/Markdown";
 
 // Unified Understand wiki (task 89a1ddef) — PRISM's knowledge as ONE
 // interconnected wiki: memory + OKF + understanding, graph + read + links.
-// Modeled on Google's OKF visualizer: a force-ish concept graph (left) where
-// nodes are memory concepts colored by type and edges are authored cross-links,
-// plus a detail panel (right) that reads the selected concept, rewires internal
-// [[/memory/<id>]] links to SELECT a node in-place (no route change), shows
-// 'Cited by' backlinks, and folds in memory edit/retire/supersede. Read-only
-// projection over /api/okf/* — never writes brain.db/graph.db.
+// Follows the existing Understand DRILL-DOWN UX (see DomainsView/LayersView):
+//   LEVEL 1 — concepts grouped by DOMAIN, rendered as Hermes cluster cards
+//             (each shows its concept count). A global search jumps to any
+//             matching concept. No type-filter pills.
+//   LEVEL 2 — click a domain to drill into THAT domain's force-directed
+//             concept graph (visible cross-link edges, degree-sized colored
+//             dots, ≤~20 readable nodes) with a breadcrumb (Domains / <domain>)
+//             to go back. Clicking a node opens the detail panel (right) that
+//             reads the selected concept, rewires internal [[/memory/<id>]]
+//             links to SELECT a node in-place, shows 'Cited by' backlinks, and
+//             folds in memory edit/retire/supersede. Following a link to a
+//             concept in another domain drills into that domain too.
+// Read-only projection over /api/okf/* — never writes brain.db/graph.db.
 
 type GraphNode = {
   id: string; title: string; type: string;
-  section: string; path: string; description: string;
+  section: string; domain: string; path: string; description: string;
 };
 type GraphEdge = { source: string; target: string };
 type OkfGraph = { nodes: GraphNode[]; edges: GraphEdge[] };
@@ -52,61 +63,101 @@ function toneVar(tone: PillTone, slot: "bg" | "fg" | "ring"): string {
   return `var(--accent-${tone}-${slot})`;
 }
 
-// Concept node — a memory concept colored by type. Clicking selects it. The
-// selected node gets a bright ring so the panel<->graph stay visually linked.
+// Concept node — a memory concept rendered as a compact dot colored by type and
+// sized by connectivity (hubs read bigger). Clicking selects it; the selected
+// node gets a bright ring and a dimmed (non-neighbor) flag so the panel<->graph
+// stay visually linked. Hidden handles, centered on the dot, let edges anchor
+// dot-center to dot-center.
 type ConceptNodeData = {
-  title: string; type: string; selected: boolean;
+  title: string; type: string; selected: boolean; dim: boolean; size: number;
+};
+const HANDLE_STYLE: CSSProperties = {
+  top: "50%", left: "50%", transform: "translate(-50%, -50%)",
+  width: 1, height: 1, minWidth: 0, minHeight: 0,
+  opacity: 0, border: "none", background: "transparent", pointerEvents: "none",
 };
 function ConceptNode({ data }: { data: ConceptNodeData }) {
   const tone = typeTone(data.type);
+  const s = data.size;
   return (
     <div
-      className="rounded-md border px-2.5 py-1.5 max-w-[180px] cursor-pointer transition-shadow"
-      style={{
-        background: toneVar(tone, "bg"),
-        borderColor: data.selected ? "var(--text-primary)" : toneVar(tone, "ring"),
-        boxShadow: data.selected ? "0 0 0 2px var(--text-primary)" : "none",
-      }}
-      title={data.title}
+      className="relative cursor-pointer transition-opacity"
+      style={{ width: s, height: s, opacity: data.dim ? 0.3 : 1 }}
+      title={`${data.title} · ${data.type}`}
     >
-      <div className="text-[11px] leading-snug font-medium truncate" style={{ color: toneVar(tone, "fg") }}>
+      <Handle type="target" position={Position.Top} style={HANDLE_STYLE} isConnectable={false} />
+      <Handle type="source" position={Position.Bottom} style={HANDLE_STYLE} isConnectable={false} />
+      <div
+        className="rounded-full w-full h-full border transition-all"
+        style={{
+          background: toneVar(tone, "fg"),
+          borderColor: data.selected ? "var(--text-primary)" : toneVar(tone, "ring"),
+          borderWidth: data.selected ? 3 : 1.5,
+          boxShadow: data.selected
+            ? "0 0 0 4px var(--text-primary)"
+            : `0 0 0 1px ${toneVar(tone, "bg")}`,
+        }}
+      />
+      <div
+        className="absolute left-1/2 top-full mt-1 -translate-x-1/2 text-[10px] leading-tight text-center max-w-[140px] truncate font-medium pointer-events-none"
+        style={{ color: data.selected ? "var(--text-primary)" : "var(--text-secondary)" }}
+      >
         {data.title}
-      </div>
-      <div className="text-[9px] uppercase tracking-wider font-mono opacity-70" style={{ color: toneVar(tone, "fg") }}>
-        {data.type}
       </div>
     </div>
   );
 }
 const NODE_TYPES = { concept: ConceptNode };
 
-// Clustered layout: group nodes by type into vertical columns (a simple,
-// readable stand-in for a force layout — ~112 nodes stay legible, no extra
-// heavy dependency). Within a column, lay out in a wrapped grid.
-function layout(nodes: GraphNode[], selectedId: string | null): RfNode<ConceptNodeData>[] {
-  const byType = new Map<string, GraphNode[]>();
-  for (const n of nodes) {
-    const t = (n.type || "note").toLowerCase();
-    (byType.get(t) ?? byType.set(t, []).get(t)!).push(n);
+type Layout = {
+  pos: Map<string, { x: number; y: number }>;
+  degree: Map<string, number>;
+  maxDegree: number;
+};
+
+// Force-directed layout (d3-force): repulsion + edge springs + collision so the
+// 86 authored cross-links pull related concepts together and hubs separate from
+// the periphery. Computed once over the FULL graph (~113 nodes, 350 ticks ≈ a
+// few ms) so positions stay stable when the user searches/filters.
+function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): Layout {
+  const ids = new Set(nodes.map((n) => n.id));
+  const degree = new Map<string, number>();
+  for (const id of ids) degree.set(id, 0);
+  type SimNode = { id: string; x?: number; y?: number };
+  type SimLink = { source: string; target: string };
+  const links: SimLink[] = [];
+  for (const e of edges) {
+    if (!ids.has(e.source) || !ids.has(e.target)) continue;
+    links.push({ source: e.source, target: e.target });
+    degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
+    degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
   }
-  const COL_W = 230, ROW_H = 64, GROUP_GAP = 60;
-  const out: RfNode<ConceptNodeData>[] = [];
-  let x = 0;
-  for (const t of Array.from(byType.keys()).sort()) {
-    const items = byType.get(t)!;
-    const cols = Math.max(1, Math.ceil(Math.sqrt(items.length)));
-    items.forEach((n, i) => {
-      out.push({
-        id: n.id,
-        type: "concept",
-        position: { x: x + (i % cols) * COL_W, y: Math.floor(i / cols) * ROW_H },
-        data: { title: n.title, type: n.type, selected: n.id === selectedId },
-      });
-    });
-    x += cols * COL_W + GROUP_GAP;
-  }
-  return out;
+  let maxDegree = 1;
+  for (const d of degree.values()) if (d > maxDegree) maxDegree = d;
+  const simNodes: SimNode[] = nodes.map((n) => ({ id: n.id }));
+  const sim = forceSimulation<SimNode>(simNodes)
+    .force("charge", forceManyBody<SimNode>().strength(-260))
+    .force("link", forceLink<SimNode, SimLink>(links).id((d) => d.id).distance(95).strength(0.6))
+    .force("center", forceCenter(0, 0))
+    .force("collide", forceCollide<SimNode>().radius(34))
+    .force("x", forceX(0).strength(0.04))
+    .force("y", forceY(0).strength(0.04))
+    .stop();
+  for (let i = 0; i < 350; i++) sim.tick();
+  const pos = new Map<string, { x: number; y: number }>();
+  for (const n of simNodes) pos.set(n.id, { x: n.x ?? 0, y: n.y ?? 0 });
+  return { pos, degree, maxDegree };
 }
+
+// Degree-sized dot radius: hubs read larger, leaves stay compact (16px..44px).
+function nodeSize(deg: number, maxDeg: number): number {
+  const t = Math.sqrt(deg) / Math.sqrt(Math.max(1, maxDeg));
+  return Math.round(16 + t * 28);
+}
+
+type DomainGroup = { id: string; count: number; samples: string[] };
+
+const DOMAIN_FALLBACK = "general";
 
 export default function UnderstandPage() {
   const [project] = useProject();
@@ -114,7 +165,9 @@ export default function UnderstandPage() {
   const [graph, setGraph] = useState<OkfGraph | null>(null);
   const [loaded, setLoaded] = useState(false);
   const [query, setQuery] = useState("");
-  const [typeFilter, setTypeFilter] = useState<string>("all");
+  // Two-level drill: selectedDomain === null is the LEVEL 1 domain overview;
+  // a domain id drills into LEVEL 2 (that domain's concept graph + detail).
+  const [selectedDomain, setSelectedDomain] = useState<string | null>(null);
   const [selectedId, setSelectedId] = useState<string | null>(params.get("concept"));
   const [bump, setBump] = useState(0);
 
@@ -133,112 +186,287 @@ export default function UnderstandPage() {
     setParams(next, { replace: true });
   };
 
-  const types = useMemo(() => {
-    const s = new Set<string>();
-    for (const n of graph?.nodes ?? []) if (n.type) s.add(n.type);
-    return Array.from(s).sort();
-  }, [graph]);
-
-  const visible = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    return (graph?.nodes ?? []).filter((n) => {
-      if (typeFilter !== "all" && n.type !== typeFilter) return false;
-      if (!q) return true;
-      return (
-        n.title.toLowerCase().includes(q) ||
-        n.type.toLowerCase().includes(q) ||
-        n.section.toLowerCase().includes(q)
-      );
-    });
-  }, [graph, query, typeFilter]);
-
   const byId = useMemo(() => {
     const m = new Map<string, GraphNode>();
     for (const n of graph?.nodes ?? []) m.set(n.id, n);
     return m;
   }, [graph]);
 
+  // Concepts grouped by domain — the LEVEL 1 entry point.
+  const domainGroups = useMemo(() => {
+    const m = new Map<string, GraphNode[]>();
+    for (const n of graph?.nodes ?? []) {
+      const d = n.domain || DOMAIN_FALLBACK;
+      const arr = m.get(d) ?? [];
+      arr.push(n);
+      m.set(d, arr);
+    }
+    return m;
+  }, [graph]);
+
+  const domains = useMemo<DomainGroup[]>(
+    () => Array.from(domainGroups.entries())
+      .map(([id, ns]) => ({ id, count: ns.length, samples: ns.slice(0, 4).map((n) => n.title) }))
+      .sort((a, b) => b.count - a.count),
+    [domainGroups],
+  );
+
+  // Drill into the domain that owns a concept, then select it. Used by node
+  // clicks, [[link]] / backlink follows (even cross-domain), and search picks.
+  const goToConcept = (id: string | null) => {
+    if (!id) { setSelectedDomain(null); select(null); return; }
+    const n = byId.get(id);
+    if (n) setSelectedDomain(n.domain || DOMAIN_FALLBACK);
+    select(id);
+  };
+
+  // ?concept= deep-link: once the graph loads, resolve its domain and drill in.
+  useEffect(() => {
+    if (!graph || !selectedId || selectedDomain) return;
+    const n = byId.get(selectedId);
+    if (n) setSelectedDomain(n.domain || DOMAIN_FALLBACK);
+  }, [graph, selectedId, selectedDomain, byId]);
+
+  // Global search jumps to matching concepts regardless of the current drill.
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [] as GraphNode[];
+    return (graph?.nodes ?? []).filter((n) =>
+      n.title.toLowerCase().includes(q) ||
+      n.type.toLowerCase().includes(q) ||
+      (n.domain || "").toLowerCase().includes(q),
+    ).slice(0, 40);
+  }, [graph, query]);
+
   const selectedPath = selectedId ? byId.get(selectedId)?.path ?? null : null;
+  const drillNodes = selectedDomain ? domainGroups.get(selectedDomain) ?? [] : [];
+
+  // Per-domain force layout: ≤~20 nodes pack tightly so the drilled graph is
+  // readable. computeLayout keeps only edges among the present nodes.
+  const drillLayout = useMemo(
+    () => computeLayout(drillNodes, graph?.edges ?? []),
+    [drillNodes, graph],
+  );
+
+  const selectedDomainIdx = domains.findIndex((d) => d.id === selectedDomain);
+  const drillColor = prismDomainColor(selectedDomainIdx >= 0 ? selectedDomainIdx : 0);
+
+  const onPickSearch = (id: string) => { setQuery(""); goToConcept(id); };
 
   return (
     <div className="p-6 h-full flex flex-col gap-4 min-w-[720px]">
-      <p className="text-sm text-[color:var(--text-secondary)]">
-        PRISM knowledge as one interconnected wiki: memory + OKF + understanding,
-        graph + read + links.
-      </p>
+      <input
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Search concepts by title, type, or domain…"
+        className="text-[13px] rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-default)] px-3 py-1.5"
+      />
 
-      <div className="flex flex-wrap items-center gap-2">
-        <input
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search concepts by title, type, or domain…"
-          className="flex-1 min-w-[220px] text-[13px] rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-default)] px-3 py-1.5"
-        />
-        <div className="flex flex-wrap gap-1.5">
-          <Pill active={typeFilter === "all"} onClick={() => setTypeFilter("all")} tone="slate">all</Pill>
-          {types.map((t) => (
-            <Pill key={t} active={typeFilter === t} onClick={() => setTypeFilter(t)} tone={typeTone(t)}>{t}</Pill>
-          ))}
-        </div>
-      </div>
-
-      <div className="flex-1 min-h-[520px] grid grid-cols-[3fr_2fr] gap-4">
-        <Card className="p-0 overflow-hidden relative">
-          {!loaded ? (
-            <div className="p-6"><Empty>Loading concept graph…</Empty></div>
-          ) : !graph || graph.nodes.length === 0 ? (
-            <div className="p-6"><Empty>No memory concepts projected for this project yet.</Empty></div>
-          ) : (
-            <ReactFlowProvider>
-              <GraphView
-                nodes={visible}
-                edges={graph.edges}
-                selectedId={selectedId}
-                onSelect={select}
-              />
-            </ReactFlowProvider>
-          )}
-        </Card>
-
-        <Card className="overflow-y-auto">
-          <DetailPanel
-            path={selectedPath}
-            project={project}
-            onSelect={select}
-            onMutate={() => setBump((b) => b + 1)}
+      {query.trim() ? (
+        <SearchResults matches={matches} onPick={onPickSearch} />
+      ) : !selectedDomain ? (
+        <DomainOverview domains={domains} loaded={loaded} onSelect={setSelectedDomain} />
+      ) : (
+        <div className="flex-1 min-h-[520px] flex flex-col gap-3">
+          <DrillCrumb
+            domain={selectedDomain}
+            count={drillNodes.length}
+            color={drillColor.border}
+            onBack={() => goToConcept(null)}
           />
-        </Card>
+          <div className="flex-1 grid grid-cols-[3fr_2fr] gap-4 min-h-0">
+            <Card className="p-0 overflow-hidden relative">
+              <ReactFlowProvider>
+                <GraphView
+                  nodes={drillNodes}
+                  allEdges={graph?.edges ?? []}
+                  pos={drillLayout.pos}
+                  degree={drillLayout.degree}
+                  maxDegree={drillLayout.maxDegree}
+                  selectedId={selectedId}
+                  onSelect={goToConcept}
+                />
+              </ReactFlowProvider>
+            </Card>
+
+            <Card className="overflow-y-auto">
+              <DetailPanel
+                path={selectedPath}
+                project={project}
+                onSelect={goToConcept}
+                onMutate={() => setBump((b) => b + 1)}
+              />
+            </Card>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// LEVEL 1 — domains as Hermes cluster cards (mirrors PrismDomainNode's look and
+// the DomainsView overview), each showing its concept count. Click to drill in.
+function DomainOverview({
+  domains, loaded, onSelect,
+}: { domains: DomainGroup[]; loaded: boolean; onSelect: (id: string) => void }) {
+  if (!loaded) return <Card className="p-6"><Empty>Loading concepts…</Empty></Card>;
+  if (domains.length === 0) {
+    return <Card className="p-6"><Empty>No memory concepts projected for this project yet.</Empty></Card>;
+  }
+  const total = domains.reduce((a, d) => a + d.count, 0);
+  return (
+    <div className="flex-1 min-h-0 overflow-y-auto space-y-4">
+      <div className="text-[12px] text-[color:var(--text-secondary)]">
+        {domains.length} domain{domains.length === 1 ? "" : "s"} · {total} concept{total === 1 ? "" : "s"}.
+        {" "}Click a domain to explore its concept graph.
+      </div>
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(260px,1fr))] gap-3">
+        {domains.map((d, i) => {
+          const c = prismDomainColor(i);
+          return (
+            <button
+              key={d.id}
+              onClick={() => onSelect(d.id)}
+              className="text-left rounded-xl border-2 px-5 py-4 transition-all hover:brightness-110"
+              style={{ borderColor: c.border, background: c.bg }}
+            >
+              <div className="text-[9px] uppercase tracking-[0.18em] opacity-60 mb-1">Domain</div>
+              <div className="font-serif text-base tracking-tight capitalize">{d.id}</div>
+              <div className="mt-3 flex flex-wrap gap-1">
+                {d.samples.map((s) => (
+                  <span key={s} className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-[color:var(--background-base)]/40 truncate max-w-[180px]">
+                    {s}
+                  </span>
+                ))}
+              </div>
+              <div className="text-[10px] opacity-60 mt-3 inline-flex items-center gap-1">
+                <span className="inline-block w-1.5 h-1.5 rounded-full" style={{ background: c.dot }} />
+                {d.count} concept{d.count === 1 ? "" : "s"}
+              </div>
+            </button>
+          );
+        })}
       </div>
     </div>
   );
 }
 
+// Global search results — picking one jumps into its domain and selects it.
+function SearchResults({
+  matches, onPick,
+}: { matches: GraphNode[]; onPick: (id: string) => void }) {
+  return (
+    <Card className="flex-1 min-h-0 overflow-y-auto p-3">
+      {matches.length === 0 ? (
+        <Empty>No concepts match.</Empty>
+      ) : (
+        <ul className="space-y-1">
+          {matches.map((n) => (
+            <li key={n.id}>
+              <button
+                onClick={() => onPick(n.id)}
+                className="w-full text-left px-3 py-2 rounded-md hover:bg-[color:var(--surface-2)] flex items-center justify-between gap-3"
+              >
+                <span className="truncate">{n.title}</span>
+                <span className="text-[10px] opacity-60 font-mono shrink-0">{(n.domain || DOMAIN_FALLBACK)} · {n.type}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+// Breadcrumb (Domains / <domain>) — mirrors DomainsView/LayersView DrillCrumb.
+function DrillCrumb({
+  domain, count, color, onBack,
+}: { domain: string; count: number; color: string; onBack: () => void }) {
+  return (
+    <div
+      className="flex items-center gap-3 text-[12px] px-3 py-2 rounded-md bg-[color:var(--background-base)]/40 border border-[color:var(--midground-base)]/15"
+      style={{ borderLeftWidth: 3, borderLeftColor: color }}
+    >
+      <button onClick={onBack} className="uppercase tracking-wider text-[11px] opacity-70 hover:opacity-100">
+        ← Domains
+      </button>
+      <span className="opacity-40">/</span>
+      <span className="font-medium capitalize">{domain}</span>
+      <span className="opacity-50">— {count} concept{count === 1 ? "" : "s"}</span>
+    </div>
+  );
+}
+
 function GraphView({
-  nodes, edges, selectedId, onSelect,
+  nodes, allEdges, pos, degree, maxDegree, selectedId, onSelect,
 }: {
   nodes: GraphNode[];
-  edges: GraphEdge[];
+  allEdges: GraphEdge[];
+  pos: Map<string, { x: number; y: number }>;
+  degree: Map<string, number>;
+  maxDegree: number;
   selectedId: string | null;
   onSelect: (id: string) => void;
 }) {
-  const initial = useMemo(() => layout(nodes, selectedId), [nodes, selectedId]);
-  const [rfNodes, setRfNodes, onNodesChange] = useNodesState(initial);
+  const [rfNodes, setRfNodes, onNodesChange] = useNodesState<RfNode<ConceptNodeData>>([]);
   const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<RfEdge>([]);
 
-  useEffect(() => { setRfNodes(layout(nodes, selectedId)); }, [nodes, selectedId, setRfNodes]);
+  // Neighborhood of the selected node — used to highlight its edges and dim the
+  // rest so the selection's local structure pops.
+  const neighbors = useMemo(() => {
+    const s = new Set<string>();
+    if (selectedId) {
+      s.add(selectedId);
+      for (const e of allEdges) {
+        if (e.source === selectedId) s.add(e.target);
+        else if (e.target === selectedId) s.add(e.source);
+      }
+    }
+    return s;
+  }, [allEdges, selectedId]);
+
+  useEffect(() => {
+    setRfNodes(
+      nodes.map((n) => {
+        const p = pos.get(n.id) ?? { x: 0, y: 0 };
+        return {
+          id: n.id,
+          type: "concept",
+          position: { x: p.x, y: p.y },
+          data: {
+            title: n.title,
+            type: n.type,
+            selected: n.id === selectedId,
+            dim: !!selectedId && !neighbors.has(n.id),
+            size: nodeSize(degree.get(n.id) ?? 0, maxDegree),
+          },
+        };
+      }),
+    );
+  }, [nodes, pos, degree, maxDegree, selectedId, neighbors, setRfNodes]);
+
   useEffect(() => {
     const present = new Set(nodes.map((n) => n.id));
     setRfEdges(
-      edges
+      allEdges
         .filter((e) => present.has(e.source) && present.has(e.target))
-        .map((e) => ({
-          id: `${e.source}->${e.target}`,
-          source: e.source,
-          target: e.target,
-          style: { stroke: "var(--border-strong)", strokeWidth: 1 },
-        })),
+        .map((e) => {
+          const incident = !!selectedId && (e.source === selectedId || e.target === selectedId);
+          return {
+            id: `${e.source}->${e.target}`,
+            source: e.source,
+            target: e.target,
+            type: "straight",
+            zIndex: incident ? 10 : 0,
+            style: {
+              stroke: incident ? "var(--text-primary)" : "var(--border-strong)",
+              strokeWidth: incident ? 2 : 1,
+              opacity: selectedId ? (incident ? 0.9 : 0.08) : 0.3,
+            },
+          };
+        }),
     );
-  }, [edges, nodes, setRfEdges]);
+  }, [allEdges, nodes, selectedId, setRfEdges]);
 
   return (
     <div className="h-full w-full min-h-[520px]">
@@ -246,6 +474,7 @@ function GraphView({
         nodes={rfNodes}
         edges={rfEdges}
         nodeTypes={NODE_TYPES}
+        nodeOrigin={[0.5, 0.5]}
         onNodesChange={onNodesChange}
         onEdgesChange={onEdgesChange}
         onNodeClick={(_, n) => onSelect(n.id)}

--- a/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/UnderstandPage.tsx
@@ -1,291 +1,425 @@
-import { useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
-import { FolderTree, GitBranch, Settings as SettingsIcon } from "lucide-react";
+import { useEffect, useMemo, useState, type MouseEvent } from "react";
+import { useSearchParams } from "react-router-dom";
+import {
+  Background, BackgroundVariant, Controls, MiniMap,
+  ReactFlow, ReactFlowProvider, useEdgesState, useNodesState,
+  type Edge as RfEdge, type Node as RfNode,
+} from "@xyflow/react";
+import "@xyflow/react/dist/style.css";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
-import { Card, Empty, ErrorBanner, Kpi, Page, Pill, SectionLabel, type PillTone } from "@/components/ui";
-import TourView from "@/components/understand/TourView";
-import LayersView from "@/components/understand/LayersView";
-import DomainsView from "@/components/understand/DomainsView";
-import OnboardingView from "@/components/understand/OnboardingView";
-import ViolationsView from "@/components/understand/ViolationsView";
+import { Card, Empty, Pill, type PillTone } from "@/components/ui";
+import Markdown from "@/components/Markdown";
 
-type Status = {
-  project: string;
-  // v5.2.0 — projects can be folder-mode or clone-mode. Surfaced here so
-  // the empty-state copy can describe the right thing and the KPI row
-  // can show source_path instead of tracked_ref for folder projects.
-  mode?: "folder" | "clone" | "empty";
-  source_path?: string | null;
-  tracked_ref: string;
-  remote_url?: string | null;
-  current_sha: string | null;
-  last_analyzed_sha: string | null;
-  in_session_drain_enabled: boolean;
-  cached_shas: string[];
-  queue: {
-    pending: number; in_progress: number;
-    completed: number; failed: number;
-  };
+// Unified Understand wiki (task 89a1ddef) — PRISM's knowledge as ONE
+// interconnected wiki: memory + OKF + understanding, graph + read + links.
+// Modeled on Google's OKF visualizer: a force-ish concept graph (left) where
+// nodes are memory concepts colored by type and edges are authored cross-links,
+// plus a detail panel (right) that reads the selected concept, rewires internal
+// [[/memory/<id>]] links to SELECT a node in-place (no route change), shows
+// 'Cited by' backlinks, and folds in memory edit/retire/supersede. Read-only
+// projection over /api/okf/* — never writes brain.db/graph.db.
+
+type GraphNode = {
+  id: string; title: string; type: string;
+  section: string; path: string; description: string;
+};
+type GraphEdge = { source: string; target: string };
+type OkfGraph = { nodes: GraphNode[]; edges: GraphEdge[] };
+
+type Concept = {
+  path: string; type: string;
+  frontmatter: Record<string, unknown>;
+  body: string; links: string[];
+  backlinks: { id: string; title: string }[];
 };
 
-type ArtifactKind = "tour" | "layers" | "domains" | "onboarding" | "violations";
-
-// Each artifact tab gets a distinct accent so the strip reads as a
-// legend at-a-glance, matching the /memory chip pattern. Mapping is
-// loosely semantic: tour=walk-through (teal), layers=architecture
-// structure (amber), domains=glossary/concepts (violet), onboarding
-// =writeup (sage).
-const ARTIFACT_TONE: Record<ArtifactKind, PillTone> = {
-  tour: "teal",
-  layers: "amber",
-  domains: "violet",
-  onboarding: "sage",
-  // governance conformance (intended principles vs observed edges)
-  violations: "rose",
+const TYPE_TONE: Record<string, PillTone> = {
+  convention: "sage", decision: "amber", expertise: "teal",
+  "anti-pattern": "rose", failure: "rose", note: "slate",
+  pattern: "teal", feedback: "violet", project: "amber",
+  reference: "teal", user: "violet",
 };
+const HASH_TONES: PillTone[] = ["teal", "sage", "amber", "rose", "violet", "emerald"];
+function typeTone(type: string): PillTone {
+  const t = (type || "").toLowerCase();
+  if (TYPE_TONE[t]) return TYPE_TONE[t];
+  let h = 0;
+  for (let i = 0; i < t.length; i++) h = (h * 31 + t.charCodeAt(i)) >>> 0;
+  return HASH_TONES[h % HASH_TONES.length];
+}
+function toneVar(tone: PillTone, slot: "bg" | "fg" | "ring"): string {
+  return `var(--accent-${tone}-${slot})`;
+}
 
-type ArtifactResponse = {
-  data: unknown;
-  sha: string | null;
-  miss_reason?: string;
+// Concept node — a memory concept colored by type. Clicking selects it. The
+// selected node gets a bright ring so the panel<->graph stay visually linked.
+type ConceptNodeData = {
+  title: string; type: string; selected: boolean;
 };
+function ConceptNode({ data }: { data: ConceptNodeData }) {
+  const tone = typeTone(data.type);
+  return (
+    <div
+      className="rounded-md border px-2.5 py-1.5 max-w-[180px] cursor-pointer transition-shadow"
+      style={{
+        background: toneVar(tone, "bg"),
+        borderColor: data.selected ? "var(--text-primary)" : toneVar(tone, "ring"),
+        boxShadow: data.selected ? "0 0 0 2px var(--text-primary)" : "none",
+      }}
+      title={data.title}
+    >
+      <div className="text-[11px] leading-snug font-medium truncate" style={{ color: toneVar(tone, "fg") }}>
+        {data.title}
+      </div>
+      <div className="text-[9px] uppercase tracking-wider font-mono opacity-70" style={{ color: toneVar(tone, "fg") }}>
+        {data.type}
+      </div>
+    </div>
+  );
+}
+const NODE_TYPES = { concept: ConceptNode };
 
+// Clustered layout: group nodes by type into vertical columns (a simple,
+// readable stand-in for a force layout — ~112 nodes stay legible, no extra
+// heavy dependency). Within a column, lay out in a wrapped grid.
+function layout(nodes: GraphNode[], selectedId: string | null): RfNode<ConceptNodeData>[] {
+  const byType = new Map<string, GraphNode[]>();
+  for (const n of nodes) {
+    const t = (n.type || "note").toLowerCase();
+    (byType.get(t) ?? byType.set(t, []).get(t)!).push(n);
+  }
+  const COL_W = 230, ROW_H = 64, GROUP_GAP = 60;
+  const out: RfNode<ConceptNodeData>[] = [];
+  let x = 0;
+  for (const t of Array.from(byType.keys()).sort()) {
+    const items = byType.get(t)!;
+    const cols = Math.max(1, Math.ceil(Math.sqrt(items.length)));
+    items.forEach((n, i) => {
+      out.push({
+        id: n.id,
+        type: "concept",
+        position: { x: x + (i % cols) * COL_W, y: Math.floor(i / cols) * ROW_H },
+        data: { title: n.title, type: n.type, selected: n.id === selectedId },
+      });
+    });
+    x += cols * COL_W + GROUP_GAP;
+  }
+  return out;
+}
 
 export default function UnderstandPage() {
   const [project] = useProject();
-  const [status, setStatus] = useState<Status | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const [tab, setTab] = useState<ArtifactKind>("tour");
-  const [artifact, setArtifact] = useState<ArtifactResponse | null>(null);
-
-  const loadStatus = useCallback(() => {
-    api
-      .get<Status>(`/api/understand?project=${encodeURIComponent(project)}`)
-      .then((s) => {
-        setStatus(s);
-        setError(null);
-      })
-      .catch((e) => setError(String(e.message ?? e)));
-  }, [project]);
-
-  const loadArtifact = useCallback(() => {
-    api
-      .get<ArtifactResponse>(
-        `/api/understand/${tab}?project=${encodeURIComponent(project)}`,
-      )
-      .then(setArtifact)
-      .catch(() => setArtifact(null));
-  }, [project, tab]);
+  const [params, setParams] = useSearchParams();
+  const [graph, setGraph] = useState<OkfGraph | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<string>("all");
+  const [selectedId, setSelectedId] = useState<string | null>(params.get("concept"));
+  const [bump, setBump] = useState(0);
 
   useEffect(() => {
-    loadStatus();
-    const t = setInterval(loadStatus, 3000);
-    return () => clearInterval(t);
-  }, [loadStatus]);
+    setLoaded(false);
+    api.get<OkfGraph>(`/api/okf/graph?project=${encodeURIComponent(project)}`)
+      .then((g) => { setGraph(g); setLoaded(true); })
+      .catch(() => { setGraph(null); setLoaded(true); });
+  }, [project, bump]);
 
-  useEffect(() => { loadArtifact(); }, [loadArtifact]);
-
-
-  const [notice, setNotice] = useState<string | null>(null);
-
-  // Auto-dismiss the notice after 6 s so it doesn't haunt the screen.
-  useEffect(() => {
-    if (!notice) return;
-    const t = setTimeout(() => setNotice(null), 6000);
-    return () => clearTimeout(t);
-  }, [notice]);
-
-  const triggerRefresh = async () => {
-    setSubmitting(true);
-    setNotice(null);
-    try {
-      const res = await api.post<{
-        status: string;
-        queued: string[];
-        cached_hits: string[];
-        target_sha: string;
-        budget_used?: number;
-        budget_limit?: number;
-      }>(`/api/understand/refresh?project=${encodeURIComponent(project)}`, {});
-      setError(null);
-      if (res.status === "no_source") {
-        setNotice("This project has no git source configured. Open Settings to add one.");
-      } else if (res.status === "complete") {
-        setNotice(
-          `All ${res.cached_hits.length} analyzers up to date at ${res.target_sha.slice(0, 10)} — nothing to do.`,
-        );
-      } else if (res.status === "queued") {
-        setNotice(
-          `Queued ${res.queued.length} analyzer${res.queued.length === 1 ? "" : "s"}: ${res.queued.join(", ")}. ` +
-          `Run \`python -m prism_service.cli.understand_cli drain --project ${project} --budget-usd 2.0\` on the host to execute.`,
-        );
-      } else if (res.status === "budget_exceeded") {
-        setNotice(`Refused: estimated ${res.budget_used} tokens exceeds ${res.budget_limit} budget cap.`);
-      } else {
-        setNotice(`Refresh: ${res.status}`);
-      }
-      loadStatus();
-    } catch (e) {
-      setError(String((e as Error).message ?? e));
-    } finally {
-      setSubmitting(false);
-    }
+  // Keep the ?concept= deep-link in sync with the in-place selection.
+  const select = (id: string | null) => {
+    setSelectedId(id);
+    const next = new URLSearchParams(params);
+    if (id) next.set("concept", id); else next.delete("concept");
+    setParams(next, { replace: true });
   };
 
-  const shortSha = (sha: string | null | undefined): string =>
-    sha ? sha.slice(0, 10) : "—";
+  const types = useMemo(() => {
+    const s = new Set<string>();
+    for (const n of graph?.nodes ?? []) if (n.type) s.add(n.type);
+    return Array.from(s).sort();
+  }, [graph]);
 
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return (graph?.nodes ?? []).filter((n) => {
+      if (typeFilter !== "all" && n.type !== typeFilter) return false;
+      if (!q) return true;
+      return (
+        n.title.toLowerCase().includes(q) ||
+        n.type.toLowerCase().includes(q) ||
+        n.section.toLowerCase().includes(q)
+      );
+    });
+  }, [graph, query, typeFilter]);
+
+  const byId = useMemo(() => {
+    const m = new Map<string, GraphNode>();
+    for (const n of graph?.nodes ?? []) m.set(n.id, n);
+    return m;
+  }, [graph]);
+
+  const selectedPath = selectedId ? byId.get(selectedId)?.path ?? null : null;
 
   return (
-    <Page>
-      <div className="flex items-start justify-between gap-4">
-        <p className="text-sm text-[color:var(--text-secondary)] flex-1">
-          Generate tour, architecture, domain glossary, and onboarding doc
-          from this project's source. Point a project at a local folder
-          or a git remote in <span className="font-medium">Settings → Projects</span>.
-        </p>
-        <button
-          onClick={triggerRefresh}
-          disabled={submitting || !status?.current_sha}
-          className="px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider disabled:opacity-40 shrink-0"
-        >
-          {submitting ? "Working…" : "Refresh"}
-        </button>
-      </div>
+    <div className="p-6 h-full flex flex-col gap-4 min-w-[720px]">
+      <p className="text-sm text-[color:var(--text-secondary)]">
+        PRISM knowledge as one interconnected wiki: memory + OKF + understanding,
+        graph + read + links.
+      </p>
 
-      {error && <ErrorBanner>{error}</ErrorBanner>}
-
-      {notice && (
-        <div className="fixed bottom-6 right-6 z-40 max-w-[420px] rounded-md border border-[color:var(--midground-base)]/20 bg-[color:var(--background-base)]/95 backdrop-blur-sm shadow-lg px-4 py-3 text-[12px] flex items-start gap-3">
-          <span className="flex-1 opacity-90 leading-relaxed">{notice}</span>
-          <button
-            onClick={() => setNotice(null)}
-            className="text-[10px] uppercase tracking-wider opacity-60 hover:opacity-100 shrink-0"
-          >
-            dismiss
-          </button>
-        </div>
-      )}
-
-      <div className="flex gap-3 flex-wrap">
-        {status?.mode === "folder" ? (
-          <Kpi
-            label="Source folder"
-            value={status?.source_path ?? "—"}
-            hint="read where it lives"
-          />
-        ) : (
-          <Kpi label="Tracked ref" value={status?.tracked_ref ?? "—"} />
-        )}
-        <Kpi label="Current SHA" value={shortSha(status?.current_sha)} />
-        <Kpi label="Last analyzed" value={shortSha(status?.last_analyzed_sha)} />
-        <Kpi
-          label="Queue"
-          value={status?.queue?.pending ?? 0}
-          hint={`${status?.queue?.in_progress ?? 0} running · ${status?.queue?.completed ?? 0} done · ${status?.queue?.failed ?? 0} failed`}
+      <div className="flex flex-wrap items-center gap-2">
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search concepts by title, type, or domain…"
+          className="flex-1 min-w-[220px] text-[13px] rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-default)] px-3 py-1.5"
         />
-        <Kpi label="Cached SHAs" value={status?.cached_shas?.length ?? 0} />
+        <div className="flex flex-wrap gap-1.5">
+          <Pill active={typeFilter === "all"} onClick={() => setTypeFilter("all")} tone="slate">all</Pill>
+          {types.map((t) => (
+            <Pill key={t} active={typeFilter === t} onClick={() => setTypeFilter(t)} tone={typeTone(t)}>{t}</Pill>
+          ))}
+        </div>
       </div>
 
-      {!status?.current_sha && (
-        <Card>
-          <SectionLabel>No source configured for "{project}"</SectionLabel>
-          <p className="text-sm text-[color:var(--text-secondary)] mt-2">
-            Pick a source for this project in <span className="font-medium">Settings → Projects</span>{" "}
-            so PRISM can scan the code. Two shapes:
-          </p>
-          <ul className="text-sm text-[color:var(--text-secondary)] mt-2 space-y-1 list-disc pl-5">
-            <li className="leading-relaxed">
-              <FolderTree className="w-3.5 h-3.5 inline mr-1 -mt-0.5" />
-              <span className="font-medium">Local folder</span> — point at any
-              absolute path on this machine (native install) or a bind-mounted
-              path under <span className="font-mono">/code</span> (docker
-              install). Reads files where they live, no clone.
-            </li>
-            <li className="leading-relaxed">
-              <GitBranch className="w-3.5 h-3.5 inline mr-1 -mt-0.5" />
-              <span className="font-medium">Git URL</span> — PRISM clones the
-              repo. Falls through to your host's git auth (gh CLI, ssh keys,
-              credential manager) on native; needs a GitHub connection for
-              private repos in docker.
-            </li>
-          </ul>
-          <div className="mt-4">
-            <Link
-              to="/settings/projects"
-              className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-[color:var(--midground-base)] text-[color:var(--background-base)] text-xs uppercase tracking-wider"
-            >
-              <SettingsIcon className="w-3.5 h-3.5" />
-              Configure "{project}" →
-            </Link>
-          </div>
+      <div className="flex-1 min-h-[520px] grid grid-cols-[3fr_2fr] gap-4">
+        <Card className="p-0 overflow-hidden relative">
+          {!loaded ? (
+            <div className="p-6"><Empty>Loading concept graph…</Empty></div>
+          ) : !graph || graph.nodes.length === 0 ? (
+            <div className="p-6"><Empty>No memory concepts projected for this project yet.</Empty></div>
+          ) : (
+            <ReactFlowProvider>
+              <GraphView
+                nodes={visible}
+                edges={graph.edges}
+                selectedId={selectedId}
+                onSelect={select}
+              />
+            </ReactFlowProvider>
+          )}
         </Card>
-      )}
 
-      <Card>
-        <div className="flex items-center gap-2 mb-4">
-          <SectionLabel>Artifact</SectionLabel>
-          <div className="flex gap-2 ml-2">
-            {(["tour", "layers", "domains", "onboarding", "violations"] as ArtifactKind[]).map((k) => (
-              <Pill key={k} active={tab === k} onClick={() => setTab(k)} tone={ARTIFACT_TONE[k]}>
-                {k}
-              </Pill>
-            ))}
-          </div>
-        </div>
-        <ArtifactView tab={tab} artifact={artifact} />
-      </Card>
-    </Page>
+        <Card className="overflow-y-auto">
+          <DetailPanel
+            path={selectedPath}
+            project={project}
+            onSelect={select}
+            onMutate={() => setBump((b) => b + 1)}
+          />
+        </Card>
+      </div>
+    </div>
   );
 }
 
+function GraphView({
+  nodes, edges, selectedId, onSelect,
+}: {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  const initial = useMemo(() => layout(nodes, selectedId), [nodes, selectedId]);
+  const [rfNodes, setRfNodes, onNodesChange] = useNodesState(initial);
+  const [rfEdges, setRfEdges, onEdgesChange] = useEdgesState<RfEdge>([]);
 
-function ArtifactView({
-  tab, artifact,
-}: { tab: ArtifactKind; artifact: ArtifactResponse | null }) {
-  if (!artifact) {
-    return <Empty>Loading…</Empty>;
-  }
-  if (artifact.data == null) {
-    return (
-      <Empty>
-        No {tab} artifact yet.{" "}
-        {artifact.miss_reason ?? "Run a refresh and drain the queue to populate."}
-      </Empty>
+  useEffect(() => { setRfNodes(layout(nodes, selectedId)); }, [nodes, selectedId, setRfNodes]);
+  useEffect(() => {
+    const present = new Set(nodes.map((n) => n.id));
+    setRfEdges(
+      edges
+        .filter((e) => present.has(e.source) && present.has(e.target))
+        .map((e) => ({
+          id: `${e.source}->${e.target}`,
+          source: e.source,
+          target: e.target,
+          style: { stroke: "var(--border-strong)", strokeWidth: 1 },
+        })),
     );
+  }, [edges, nodes, setRfEdges]);
+
+  return (
+    <div className="h-full w-full min-h-[520px]">
+      <ReactFlow
+        nodes={rfNodes}
+        edges={rfEdges}
+        nodeTypes={NODE_TYPES}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onNodeClick={(_, n) => onSelect(n.id)}
+        nodesDraggable
+        nodesConnectable={false}
+        fitView
+        fitViewOptions={{ padding: 0.15 }}
+        proOptions={{ hideAttribution: true }}
+        minZoom={0.1}
+        maxZoom={2.5}
+      >
+        <Background variant={BackgroundVariant.Dots} color="rgba(200,180,140,0.10)" gap={24} size={1} />
+        <Controls showInteractive={false} position="bottom-left"
+          style={{ background: "rgba(0,0,0,0.65)", border: "1px solid rgba(255,255,255,0.18)", borderRadius: 6 }} />
+        <MiniMap pannable zoomable
+          nodeColor={(n) => `var(--accent-${typeTone((n.data as ConceptNodeData)?.type || "note")}-fg)`}
+          style={{ background: "rgba(0,0,0,0.55)", border: "1px solid rgba(255,255,255,0.15)", borderRadius: 6 }} />
+      </ReactFlow>
+    </div>
+  );
+}
+
+function DetailPanel({
+  path, project, onSelect, onMutate,
+}: {
+  path: string | null;
+  project: string;
+  onSelect: (id: string) => void;
+  onMutate?: () => void;
+}) {
+  const [concept, setConcept] = useState<Concept | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [actionBusy, setActionBusy] = useState(false);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    setConcept(null); setEditing(false); setNote(null);
+    if (!path) return;
+    setBusy(true);
+    api.get<Concept>(`/api/okf/concept?project=${encodeURIComponent(project)}&path=${encodeURIComponent(path)}`)
+      .then((c) => setConcept(c))
+      .catch(() => setConcept(null))
+      .finally(() => setBusy(false));
+  }, [path, project]);
+
+  if (!path) {
+    return <Empty>Select a concept in the graph to read it, follow its links, and edit it.</Empty>;
   }
-  // Unparseable payload (claude emitted non-JSON for a JSON analyzer)
-  if (typeof artifact.data === "object" && artifact.data !== null
-      && "error" in (artifact.data as Record<string, unknown>)
-      && "raw" in (artifact.data as Record<string, unknown>)) {
-    const raw = (artifact.data as { raw: string }).raw;
-    return (
-      <div className="space-y-2">
-        <div className="text-[11px] uppercase tracking-wider text-rose-300/80">
-          Analyzer output didn't parse as JSON — showing raw text
+  if (busy && !concept) return <Empty>Loading concept…</Empty>;
+  if (!concept) return <Empty>Failed to load concept.</Empty>;
+
+  const fm = concept.frontmatter;
+  const id = String(fm.id ?? "");
+  const title = String(fm.title ?? path);
+  const tone = typeTone(concept.type);
+  const tags = Array.isArray(fm.tags) ? (fm.tags as unknown[]).map(String) : [];
+
+  const doAction = async (action: "edit" | "retire" | "supersede", payload: Record<string, unknown> = {}) => {
+    if (!id) return;
+    setActionBusy(true);
+    try {
+      const r = await fetch(`/api/memory/entry/${encodeURIComponent(id)}/action?project=${project}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action, ...payload }),
+      });
+      const b = await r.json().catch(() => ({}));
+      if (!r.ok || b.ok === false) {
+        setNote(`${action} failed: ${b.detail ?? r.statusText}`);
+      } else {
+        setNote(`${action} ok.`);
+        setEditing(false);
+        onMutate?.();
+        if (action === "supersede" && b.entry?.id) onSelect(b.entry.id);
+      }
+    } catch (e) {
+      setNote(`${action} failed: ${(e as Error).message ?? e}`);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <header className="space-y-2">
+        <div className="flex items-start gap-2 flex-wrap">
+          <h1 className="font-serif text-2xl tracking-tight flex-1 min-w-0 break-words">{title}</h1>
+          <span className="text-[10px] uppercase tracking-wider font-mono px-1.5 py-0.5 rounded shrink-0"
+            style={{ background: toneVar(tone, "bg"), color: toneVar(tone, "fg"), boxShadow: `inset 0 0 0 1px ${toneVar(tone, "ring")}` }}>
+            {concept.type}
+          </span>
         </div>
-        <pre className="text-[12px] font-mono whitespace-pre-wrap leading-relaxed opacity-80 max-h-[60vh] overflow-auto">
-          {raw}
-        </pre>
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {tags.map((t) => (
+              <span key={t} className="text-[10px] uppercase tracking-wider font-mono px-1.5 py-0.5 rounded bg-[color:var(--surface-2)] text-[color:var(--text-muted)]">{t}</span>
+            ))}
+          </div>
+        )}
+      </header>
+
+      <div className="flex items-center gap-2">
+        {!editing && (
+          <button disabled={actionBusy} onClick={() => { setDraft(concept.body); setEditing(true); }}
+            className="text-[10px] uppercase tracking-wider px-2 py-1 rounded bg-[color:var(--midground-base)]/15 hover:bg-[color:var(--midground-base)]/30 disabled:opacity-40">Edit</button>
+        )}
+        <button disabled={actionBusy} onClick={() => doAction("retire")}
+          className="text-[10px] uppercase tracking-wider px-2 py-1 rounded disabled:opacity-40"
+          style={{ background: "var(--accent-amber-bg)", color: "var(--accent-amber-fg)" }}>Retire</button>
+        <a href={`/api/okf/raw/${path.replace(/^\//, "")}?project=${encodeURIComponent(project)}`}
+          target="_blank" rel="noreferrer"
+          className="text-[10px] uppercase tracking-wider px-2 py-1 rounded ml-auto opacity-60 hover:opacity-100">raw .md</a>
       </div>
-    );
-  }
-  if (tab === "onboarding" && typeof artifact.data === "string") {
-    return <OnboardingView text={artifact.data} />;
-  }
-  if (tab === "tour") {
-    return <TourView data={artifact.data as Parameters<typeof TourView>[0]["data"]} />;
-  }
-  if (tab === "layers") {
-    return <LayersView data={artifact.data as Parameters<typeof LayersView>[0]["data"]} />;
-  }
-  if (tab === "domains") {
-    return <DomainsView data={artifact.data as Parameters<typeof DomainsView>[0]["data"]} />;
-  }
-  if (tab === "violations") {
-    return <ViolationsView data={artifact.data as Parameters<typeof ViolationsView>[0]["data"]} />;
-  }
-  return null;
+      {note && <div className="text-[11px] opacity-70">{note}</div>}
+
+      {editing ? (
+        <div className="space-y-2">
+          <textarea value={draft} onChange={(e) => setDraft(e.target.value)} rows={10}
+            className="w-full text-[13px] rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-default)] p-3 leading-relaxed resize-y font-sans" />
+          <div className="flex gap-2">
+            <button disabled={actionBusy} onClick={() => doAction("edit", { description: draft })}
+              className="text-[10px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
+              style={{ background: "var(--accent-emerald-bg)", color: "var(--accent-emerald-fg)" }}>Save edit</button>
+            <button disabled={actionBusy} onClick={() => doAction("supersede", { description: draft })}
+              className="text-[10px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
+              style={{ background: "var(--accent-violet-bg)", color: "var(--accent-violet-fg)" }}
+              title="store a new generation under the same name (archives this one)">Supersede</button>
+            <button onClick={() => setEditing(false)}
+              className="text-[10px] uppercase tracking-wider px-3 py-1.5 rounded bg-[color:var(--midground-base)]/15">Cancel</button>
+          </div>
+        </div>
+      ) : (
+        <WovenMarkdown text={concept.body} onSelect={onSelect} />
+      )}
+
+      <div className="border-t border-[color:var(--border-default)] pt-3">
+        <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-label)] mb-2">
+          Cited by ({concept.backlinks.length})
+        </div>
+        {concept.backlinks.length === 0 ? (
+          <div className="text-[12px] opacity-50">No other concept links here yet.</div>
+        ) : (
+          <ul className="space-y-1">
+            {concept.backlinks.map((b) => (
+              <li key={b.id}>
+                <button onClick={() => onSelect(b.id)}
+                  className="text-[12px] underline decoration-dotted underline-offset-2 text-[color:var(--accent-teal-fg)] hover:opacity-80 text-left">
+                  {b.title}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// WovenMarkdown — render the concept body with the shared Hermes Markdown
+// component, then intercept internal link clicks. A /memory/<id> link SELECTS
+// that node in-place (no route change); /understand code refs navigate normally.
+function WovenMarkdown({ text, onSelect }: { text: string; onSelect: (id: string) => void }) {
+  const onClick = (e: MouseEvent<HTMLDivElement>) => {
+    const a = (e.target as HTMLElement).closest("a");
+    if (!a) return;
+    const href = a.getAttribute("href") ?? "";
+    const m = /^\/memory\/([^/]+)/.exec(href);
+    if (m) { e.preventDefault(); onSelect(m[1]); }
+  };
+  return (
+    <div onClickCapture={onClick}>
+      <Markdown text={text} className="space-y-3" />
+    </div>
+  );
 }

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -1,0 +1,44 @@
+"""Integration tests for the OKF host HTTP surface (api/okf.py).
+
+RED until api/okf.py is written and mounted in main.py. Exercises the real
+FastAPI router via TestClient against the live `prism` project stores.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+def test_okf_index_returns_manifest_with_version_and_sections(client):
+    r = client.get("/api/okf/index", params={"project": "prism"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("okf_version") == "0.1"
+    # memory is always present for the prism project; sections come from the
+    # projected bundle, not a hardcoded list.
+    assert "memory" in body.get("sections", [])
+    assert body.get("concept_count", 0) > 0
+
+
+def test_okf_raw_index_is_conformant_markdown(client):
+    r = client.get("/api/okf/raw/index.md", params={"project": "prism"})
+    assert r.status_code == 200, r.text
+    assert 'okf_version: "0.1"' in r.text
+
+
+def test_okf_concept_returns_typed_concept(client):
+    idx = client.get("/api/okf/index", params={"project": "prism"}).json()
+    # pick any projected concept path and fetch it
+    path = next(p for p in idx["paths"] if p.startswith("/memory/"))
+    r = client.get("/api/okf/concept", params={"project": "prism", "path": path})
+    assert r.status_code == 200, r.text
+    concept = r.json()
+    assert concept["type"]  # non-empty type (OKF hard rule)
+    assert "frontmatter" in concept and "body" in concept

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -1,7 +1,13 @@
 """Integration tests for the OKF host HTTP surface (api/okf.py).
 
-RED until api/okf.py is written and mounted in main.py. Exercises the real
-FastAPI router via TestClient against the live `prism` project stores.
+Exercises the real FastAPI router via TestClient against the live `prism`
+project stores. Run with PRISM_DATA_DIR=services/prism-service/data (the
+documented dev store) — the sparse AppData default has no projected memory.
+
+The OKF wiki is PRISM's curated MEMORY expressed as a navigable bundle: the
+only section is "memory", every concept carries its real id (for /memory/<id>
+navigation), and internal body links point only at /memory/<id> detail routes
+or the /understand graph — never at /brain or other junk.
 """
 
 import pytest
@@ -16,15 +22,19 @@ def client():
     return TestClient(app)
 
 
-def test_okf_index_returns_manifest_with_version_and_sections(client):
+def test_okf_index_sections_are_memory_only(client):
     r = client.get("/api/okf/index", params={"project": "prism"})
     assert r.status_code == 200, r.text
     body = r.json()
     assert body.get("okf_version") == "0.1"
-    # memory is always present for the prism project; sections come from the
-    # projected bundle, not a hardcoded list.
-    assert "memory" in body.get("sections", [])
+    # Memory IS the knowledge: the only projected section is "memory".
+    assert body.get("sections") == ["memory"], body.get("sections")
     assert body.get("concept_count", 0) > 0
+    # Every manifest concept carries its real memory id so a card click opens
+    # the REAL /memory/<id> detail page (not a standalone OKF silo).
+    concepts = body.get("concepts", [])
+    assert concepts
+    assert all(c.get("id") for c in concepts)
 
 
 def test_okf_raw_index_is_conformant_markdown(client):
@@ -33,12 +43,23 @@ def test_okf_raw_index_is_conformant_markdown(client):
     assert 'okf_version: "0.1"' in r.text
 
 
-def test_okf_concept_returns_typed_concept(client):
+def test_okf_concept_links_use_memory_id_and_understand_routes(client):
     idx = client.get("/api/okf/index", params={"project": "prism"}).json()
-    # pick any projected concept path and fetch it
-    path = next(p for p in idx["paths"] if p.startswith("/memory/"))
-    r = client.get("/api/okf/concept", params={"project": "prism", "path": path})
-    assert r.status_code == 200, r.text
-    concept = r.json()
-    assert concept["type"]  # non-empty type (OKF hard rule)
-    assert "frontmatter" in concept and "body" in concept
+    paths = [p for p in idx["paths"] if p.startswith("/memory/")]
+    assert paths
+    found_internal = False
+    # Walk concepts until we find one whose body carries an internal link; assert
+    # every internal link is a /memory/<id> route or /understand (no junk).
+    for path in paths[:60]:
+        r = client.get("/api/okf/concept", params={"project": "prism", "path": path})
+        assert r.status_code == 200, r.text
+        concept = r.json()
+        assert concept["type"]  # OKF hard rule: non-empty type
+        assert concept["frontmatter"].get("id")  # carries the real memory id
+        for href in concept.get("links", []):
+            if href.startswith("/"):
+                found_internal = True
+                assert href.startswith("/memory/") or href.startswith("/understand"), href
+        if found_internal:
+            break
+    assert found_internal, "no concept body produced a navigable /memory or /understand link"

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -43,6 +43,37 @@ def test_okf_raw_index_is_conformant_markdown(client):
     assert 'okf_version: "0.1"' in r.text
 
 
+def test_okf_graph_returns_nodes_and_edges(client):
+    r = client.get("/api/okf/graph", params={"project": "prism"})
+    assert r.status_code == 200, r.text
+    g = r.json()
+    nodes = g.get("nodes")
+    edges = g.get("edges")
+    assert isinstance(nodes, list) and nodes, g
+    assert isinstance(edges, list), g
+    # Every node carries its real memory id + a type (the graph colors by type).
+    ids = set()
+    for n in nodes:
+        assert n.get("id"), n
+        assert "type" in n, n
+        ids.add(n["id"])
+    # Every edge references ids that are present as nodes (no dangling edges).
+    for e in edges:
+        assert e.get("source") in ids, e
+        assert e.get("target") in ids, e
+
+
+def test_okf_concept_includes_backlinks_list(client):
+    idx = client.get("/api/okf/index", params={"project": "prism"}).json()
+    path = next(p for p in idx["paths"] if p.startswith("/memory/"))
+    r = client.get("/api/okf/concept", params={"project": "prism", "path": path})
+    assert r.status_code == 200, r.text
+    concept = r.json()
+    # 'Cited by' backlinks are always present (possibly empty) so the panel can
+    # render the section unconditionally.
+    assert isinstance(concept.get("backlinks"), list), concept
+
+
 def test_okf_concept_links_use_memory_id_and_understand_routes(client):
     idx = client.get("/api/okf/index", params={"project": "prism"}).json()
     paths = [p for p in idx["paths"] if p.startswith("/memory/")]

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -56,6 +56,8 @@ def test_okf_graph_returns_nodes_and_edges(client):
     for n in nodes:
         assert n.get("id"), n
         assert "type" in n, n
+        # Every node carries its domain so the wiki can group the top-level drill.
+        assert n.get("domain"), n
         ids.add(n["id"])
     # Every edge references ids that are present as nodes (no dangling edges).
     for e in edges:

--- a/services/prism-service/tests/unit/test_arc_governance_surfaces.py
+++ b/services/prism-service/tests/unit/test_arc_governance_surfaces.py
@@ -30,12 +30,22 @@ _REPO = _SERVICE_ROOT.parent.parent
 _WEB = _SERVICE_ROOT / "prism_service" / "web" / "src"
 
 
-# ── d2: violations card on the project page ────────────────────────────
+# ── d2: Understand is the consolidated OKF concept wiki (v6.7.0) ────────
+# The v6.7.0 4->2 knowledge consolidation replaced the old Understand
+# architecture-analysis TABS (tour/layers/domains/violations) with one
+# OKF concept wiki (graph + detail panel). The architecture-VIOLATIONS
+# governance card was retired alongside the deprecated understand_*
+# analysis surface; the ViolationsView component is kept (next test) for
+# the tracked follow-up that rehomes governance near /conductor. So the
+# Understand page is now the concept wiki, NOT a violations card host.
 
-def test_understand_page_offers_violations_card():
+def test_understand_page_is_the_okf_concept_wiki():
     src = (_WEB / "pages" / "UnderstandPage.tsx").read_text(encoding="utf-8")
-    assert "violations" in src, (
-        "the project page must surface the violations artifact")
+    assert "/api/okf/graph" in src, (
+        "Understand must be the OKF concept wiki (concept graph)")
+    assert "violations" not in src.lower(), (
+        "the legacy architecture-violations card was retired from the "
+        "consolidated wiki (v6.7.0); governance rehoming is a follow-up")
 
 
 def test_violations_view_renders_count_and_expands():

--- a/services/prism-service/tests/unit/test_mcp_tool_profiles.py
+++ b/services/prism-service/tests/unit/test_mcp_tool_profiles.py
@@ -27,8 +27,10 @@ def test_interactive_profile_exposes_core_agent_tools_only():
     # (v6.1.6 Ultimate Graph merge retrieval) + task_link_session
     # (v6.2.9 task<->session association — rides the task_* family)
     # + register_claude_source (v6.3.16 — Claude reports its own
-    # transcript source instead of slug-guessing; task b6650506).
-    assert len(names) == 32
+    # transcript source instead of slug-guessing; task b6650506)
+    # + okf_index / okf_get (v6.6.2 Understand wiki) + okf_graph
+    # (v6.6.6 — the wiki's concept graph; task a4995b7a).
+    assert len(names) == 35
     assert "brain_understand" in names
     assert "task_link_session" in names
     assert "register_claude_source" in names

--- a/services/prism-service/tests/unit/test_mcp_two_surface_model.py
+++ b/services/prism-service/tests/unit/test_mcp_two_surface_model.py
@@ -1,0 +1,94 @@
+"""Agent-facing MCP surface teaches the 4->2 knowledge consolidation.
+
+Two surfaces only: Brain = the code-graph VISUALIZATION + retrieval; Understand
+= ONE unified wiki over curated memory projected as OKF concepts (reached via
+okf_index / okf_get / okf_graph). This pins the GUIDE text + okf tool framing +
+the new okf_graph read-through tool + the LEGACY marking of understand_*.
+
+Conductor task: a4995b7a.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+# A pending consolidation candidate would prefix the JSON result with a nudge
+# header; disable it so okf_graph's payload stays parseable.
+os.environ["PRISM_MCP_AUGMENT_NUDGES"] = "false"
+
+
+def _call(tool_name, arguments=None, project_id="prism"):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool_name, arguments or {}, project_id=project_id))
+
+
+def _text(result):
+    assert len(result) >= 1
+    return result[0].text
+
+
+# ----------------------------------------------------------------------
+# AC-1 — prism_guide teaches the 2-surface model, not "four pillars".
+# ----------------------------------------------------------------------
+
+
+def test_prism_guide_drops_four_pillars_for_two_surfaces():
+    guide = _text(_call("prism_guide", {}))
+    # Collapse whitespace so a line-wrapped "four tightly coupled\npillars"
+    # is still caught.
+    low = " ".join(guide.split()).lower()
+    assert "understand" in low
+    assert "wiki" in low
+    assert "four pillars" not in low
+    assert "four tightly coupled pillars" not in low
+
+
+# ----------------------------------------------------------------------
+# AC-2 — okf_graph dispatches and returns a concept graph.
+# ----------------------------------------------------------------------
+
+
+def test_okf_graph_returns_nodes_and_edges():
+    result = json.loads(_text(_call("okf_graph", {})))
+    assert "nodes" in result
+    assert "edges" in result
+
+
+# ----------------------------------------------------------------------
+# AC-3 — okf_index / okf_get framed as the Understand wiki.
+# ----------------------------------------------------------------------
+
+
+def test_okf_tools_framed_as_understand_wiki():
+    from prism_service.mcp.tools import TOOLS
+    by_name = {t.name: t for t in TOOLS}
+    assert "okf_graph" in by_name, "okf_graph tool must be registered"
+
+    idx = by_name["okf_index"].description
+    assert "Understand" in idx
+    assert "wiki" in idx.lower()
+
+    get = by_name["okf_get"].description
+    assert "Understand" in get
+
+
+# ----------------------------------------------------------------------
+# AC-4 — every understand_* tool is marked LEGACY.
+# ----------------------------------------------------------------------
+
+
+def test_understand_tools_marked_legacy():
+    from prism_service.mcp.tools import TOOLS
+    legacy = [t for t in TOOLS if t.name.startswith("understand_")]
+    assert legacy, "expected understand_* tools registered in TOOLS"
+    for t in legacy:
+        assert "LEGACY" in t.description, f"{t.name} not marked LEGACY"

--- a/services/prism-service/tests/unit/test_okf_concept.py
+++ b/services/prism-service/tests/unit/test_okf_concept.py
@@ -1,0 +1,54 @@
+"""Unit tests for the OKF frontmatter codec and bundle model."""
+
+import pytest
+
+from prism_service.okf import Bundle, Concept, dump_document, parse_document
+from prism_service.okf.concept import OKF_VERSION, FrontmatterError
+
+
+def test_parse_roundtrip_preserves_type_and_unknown_keys():
+    text = (
+        "---\n"
+        "type: convention\n"
+        "title: Task titles\n"
+        "custom_x: keep-me\n"
+        "---\n\n"
+        "# Body\nFK to [customers](/brain/customers.md).\n"
+    )
+    c = parse_document(text, path="/memory/conventions/task-titles.md")
+    assert c.type == "convention"
+    assert c.title == "Task titles"
+    # Unknown keys MUST be preserved (SPEC: consumer MUST NOT drop them).
+    assert c.frontmatter["custom_x"] == "keep-me"
+    # Round-trips back to a parseable concept with the same fields.
+    again = parse_document(dump_document(c), path=c.path)
+    assert again.frontmatter == c.frontmatter
+    assert "FK to" in again.body
+
+
+def test_document_without_frontmatter_parses_empty():
+    c = parse_document("# Knowledge\n\n* item\n", path="/index.md")
+    assert c.frontmatter == {}
+    assert c.has_valid_type is False
+
+
+def test_missing_type_is_detectable():
+    c = parse_document("---\ntitle: x\n---\nbody\n")
+    assert c.type == ""
+    assert c.has_valid_type is False
+
+
+def test_malformed_frontmatter_raises():
+    with pytest.raises(FrontmatterError):
+        parse_document("---\ntype: : : bad\n  - oops\n---\nbody\n", path="/bad.md")
+
+
+def test_bundle_index_carries_okf_version_and_sections():
+    b = Bundle()
+    b.add(Concept(path="/memory/conv/a.md", frontmatter={"type": "convention", "title": "A"}, body="x"))
+    b.add(Concept(path="/brain/foo.py.md", frontmatter={"type": "code", "title": "foo"}, body="y"))
+    idx = b.render_index_md()
+    assert f'okf_version: "{OKF_VERSION}"' in idx
+    assert "## memory" in idx and "## brain" in idx
+    assert "[A](/memory/conv/a.md)" in idx
+    assert set(b.sections()) == {"memory", "brain"}

--- a/services/prism-service/tests/unit/test_okf_graph.py
+++ b/services/prism-service/tests/unit/test_okf_graph.py
@@ -1,0 +1,81 @@
+"""Unit tests for the OKF concept GRAPH projection (services/okf_host.py).
+
+The unified Understand wiki is modeled on Google's OKF visualizer: ONE
+force-directed concept graph where nodes are memory concepts (colored by type)
+and directed edges are the cross-links authored between them. OkfHost.graph()
+derives that graph purely (read-only) from the projected memory bundle, and a
+concept's get() carries inbound 'cited_by' backlinks so the detail panel can
+show who references it.
+"""
+
+from prism_service.models.memory import ExpertiseEntry
+from prism_service.services.okf_host import OkfHost
+
+
+class _FakeMemory:
+    def __init__(self, entries_by_domain):
+        self._d = entries_by_domain
+
+    def list_domains(self):
+        return list(self._d)
+
+    def list_entries(self, domain, **_):
+        return self._d.get(domain, [])
+
+
+def _mem():
+    a = ExpertiseEntry(
+        id="mx-1", name="task-titles", type="convention", classification="tactical",
+        domain="conventions", summary="Titles are human-friendly.",
+        description="See [[render-structured]] for the rule.",
+        recorded_at="2026-06-26T00:00:00Z", importance=7, memory_type="procedural",
+    )
+    b = ExpertiseEntry(
+        id="mx-2", name="render-structured", type="decision", classification="tactical",
+        domain="conventions", summary="Render structured, never raw.",
+        description="No pre/JSON dumps.", recorded_at="2026-06-26T00:00:00Z",
+    )
+    return _FakeMemory({"conventions": [a, b]})
+
+
+def test_graph_nodes_carry_id_title_type():
+    g = OkfHost(_mem()).graph()
+    assert "nodes" in g and "edges" in g
+    nodes = {n["id"]: n for n in g["nodes"]}
+    assert set(nodes) == {"mx-1", "mx-2"}
+    assert nodes["mx-1"]["title"] == "task-titles"
+    assert nodes["mx-1"]["type"] == "convention"
+    assert nodes["mx-2"]["type"] == "decision"
+
+
+def test_graph_edge_derived_from_body_crosslink():
+    g = OkfHost(_mem()).graph()
+    # mx-1's body [[render-structured]] -> /memory/mx-2, so an edge mx-1 -> mx-2.
+    edges = {(e["source"], e["target"]) for e in g["edges"]}
+    assert ("mx-1", "mx-2") in edges
+
+
+def test_graph_edges_only_reference_known_nodes():
+    g = OkfHost(_mem()).graph()
+    ids = {n["id"] for n in g["nodes"]}
+    for e in g["edges"]:
+        assert e["source"] in ids and e["target"] in ids
+
+
+def test_get_concept_carries_inbound_backlinks():
+    host = OkfHost(_mem())
+    got = host.get("/memory/conventions/render-structured.md")
+    assert got is not None
+    backlinks = got.get("backlinks")
+    assert backlinks is not None
+    cited_by_ids = {b["id"] for b in backlinks}
+    # mx-1 cites mx-2, so mx-2's backlinks include mx-1.
+    assert "mx-1" in cited_by_ids
+    assert any(b["title"] == "task-titles" for b in backlinks)
+
+
+def test_concept_with_no_inbound_links_has_empty_backlinks():
+    host = OkfHost(_mem())
+    got = host.get("/memory/conventions/task-titles.md")
+    assert got is not None
+    assert got.get("backlinks") == []

--- a/services/prism-service/tests/unit/test_okf_graph.py
+++ b/services/prism-service/tests/unit/test_okf_graph.py
@@ -48,6 +48,16 @@ def test_graph_nodes_carry_id_title_type():
     assert nodes["mx-2"]["type"] == "decision"
 
 
+def test_graph_nodes_carry_domain_for_grouping():
+    # The unified wiki groups concepts by domain for its top-level drill, so
+    # every node must carry its memory entry's domain (the first tag).
+    g = OkfHost(_mem()).graph()
+    nodes = {n["id"]: n for n in g["nodes"]}
+    assert nodes["mx-1"]["domain"] == "conventions"
+    assert nodes["mx-2"]["domain"] == "conventions"
+    assert all(n.get("domain") for n in g["nodes"])
+
+
 def test_graph_edge_derived_from_body_crosslink():
     g = OkfHost(_mem()).graph()
     # mx-1's body [[render-structured]] -> /memory/mx-2, so an edge mx-1 -> mx-2.

--- a/services/prism-service/tests/unit/test_okf_host.py
+++ b/services/prism-service/tests/unit/test_okf_host.py
@@ -1,4 +1,11 @@
-"""Unit tests for the read-only OKF host projection (services/okf_host.py)."""
+"""Unit tests for the read-only OKF host projection (services/okf_host.py).
+
+The host projects PRISM's curated MEMORY (and ONLY memory) into a navigable OKF
+wiki: every concept is a real ExpertiseEntry, carries its `id` so the UI can open
+the real /memory/<id> detail page, [[wikilinks]] rewrite to /memory/<id> routes,
+and code references (evidence file_paths) link into /understand. No brain-file or
+fixture junk in the bundle.
+"""
 
 from prism_service.models.memory import ExpertiseEntry
 from prism_service.okf import validate
@@ -17,6 +24,8 @@ class _FakeMemory:
 
 
 class _FakeBrain:
+    """Present only to prove build_bundle now IGNORES the brain store entirely."""
+
     def __init__(self, docs):
         self._docs = docs
 
@@ -30,6 +39,7 @@ def _mem():
         domain="conventions", summary="Titles are human-friendly.",
         description="See [[render-structured]] for the rule.", recorded_at="2026-06-26T00:00:00Z",
         importance=7, memory_type="procedural",
+        evidence={"file_paths": ["prism_service/api/track.py"]},
     )
     b = ExpertiseEntry(
         id="mx-2", name="render-structured", type="convention", classification="tactical",
@@ -39,28 +49,47 @@ def _mem():
     return _FakeMemory({"conventions": [a, b]})
 
 
+def _brain():
+    return _FakeBrain([{"doc_id": "svc/x.py::Foo", "domain": "code"}])
+
+
 def test_projected_bundle_is_conformant():
-    bundle = build_bundle(_mem(), _FakeBrain([{"doc_id": "svc/x.py::Foo", "domain": "code"}]))
-    rep = validate(bundle)
+    rep = validate(build_bundle(_mem(), _brain()))
     assert rep.ok, rep.errors
 
 
-def test_index_lists_memory_and_brain_sections():
-    host = OkfHost(_mem(), _FakeBrain([{"doc_id": "svc/x.py::Foo", "domain": "code"}]))
+def test_bundle_is_memory_only_no_brain_section():
+    # Memory IS the knowledge — zero brain-file / fixture / empty junk concepts.
+    bundle = build_bundle(_mem(), _brain())
+    assert bundle.sections() == ["memory"]
+    assert all(p.startswith("/memory/") for p in bundle.paths())
+
+
+def test_every_memory_concept_carries_nonempty_id():
+    host = OkfHost(_mem(), _brain())
     idx = host.index()
-    assert idx["okf_version"] == "0.1"
-    assert "memory" in idx["sections"] and "brain" in idx["sections"]
-    assert idx["concept_count"] >= 3
+    assert idx["sections"] == ["memory"]
+    assert idx["concepts"]
+    for c in idx["concepts"]:
+        assert c["id"], c
 
 
-def test_get_returns_concept_with_type_and_resolved_wikilink():
+def test_get_concept_carries_id_and_wikilink_resolves_to_memory_route():
     host = OkfHost(_mem(), _FakeBrain([]))
     got = host.get("/memory/conventions/task-titles.md")
     assert got is not None
     assert got["type"] == "convention"
-    # [[render-structured]] resolved to a real bundle path link.
-    assert "/memory/conventions/render-structured.md" in got["body"]
-    assert "/memory/conventions/render-structured.md" in got["links"]
+    assert got["frontmatter"]["id"] == "mx-1"
+    # [[render-structured]] -> the target entry's REAL /memory/<id> detail route.
+    assert "/memory/mx-2" in got["body"]
+    assert "/memory/mx-2" in got["links"]
+
+
+def test_code_reference_links_into_understand():
+    host = OkfHost(_mem(), _FakeBrain([]))
+    got = host.get("/memory/conventions/task-titles.md")
+    assert "/understand" in got["body"]
+    assert "/understand" in got["links"]
 
 
 def test_raw_serves_conformant_markdown_with_okf_version():

--- a/services/prism-service/tests/unit/test_okf_host.py
+++ b/services/prism-service/tests/unit/test_okf_host.py
@@ -1,0 +1,69 @@
+"""Unit tests for the read-only OKF host projection (services/okf_host.py)."""
+
+from prism_service.models.memory import ExpertiseEntry
+from prism_service.okf import validate
+from prism_service.services.okf_host import OkfHost, build_bundle
+
+
+class _FakeMemory:
+    def __init__(self, entries_by_domain):
+        self._d = entries_by_domain
+
+    def list_domains(self):
+        return list(self._d)
+
+    def list_entries(self, domain, **_):
+        return self._d.get(domain, [])
+
+
+class _FakeBrain:
+    def __init__(self, docs):
+        self._docs = docs
+
+    def list_docs(self, domain=None, limit=100):
+        return self._docs[:limit]
+
+
+def _mem():
+    a = ExpertiseEntry(
+        id="mx-1", name="task-titles", type="convention", classification="tactical",
+        domain="conventions", summary="Titles are human-friendly.",
+        description="See [[render-structured]] for the rule.", recorded_at="2026-06-26T00:00:00Z",
+        importance=7, memory_type="procedural",
+    )
+    b = ExpertiseEntry(
+        id="mx-2", name="render-structured", type="convention", classification="tactical",
+        domain="conventions", summary="Render structured, never raw.",
+        description="No pre/JSON dumps.", recorded_at="2026-06-26T00:00:00Z",
+    )
+    return _FakeMemory({"conventions": [a, b]})
+
+
+def test_projected_bundle_is_conformant():
+    bundle = build_bundle(_mem(), _FakeBrain([{"doc_id": "svc/x.py::Foo", "domain": "code"}]))
+    rep = validate(bundle)
+    assert rep.ok, rep.errors
+
+
+def test_index_lists_memory_and_brain_sections():
+    host = OkfHost(_mem(), _FakeBrain([{"doc_id": "svc/x.py::Foo", "domain": "code"}]))
+    idx = host.index()
+    assert idx["okf_version"] == "0.1"
+    assert "memory" in idx["sections"] and "brain" in idx["sections"]
+    assert idx["concept_count"] >= 3
+
+
+def test_get_returns_concept_with_type_and_resolved_wikilink():
+    host = OkfHost(_mem(), _FakeBrain([]))
+    got = host.get("/memory/conventions/task-titles.md")
+    assert got is not None
+    assert got["type"] == "convention"
+    # [[render-structured]] resolved to a real bundle path link.
+    assert "/memory/conventions/render-structured.md" in got["body"]
+    assert "/memory/conventions/render-structured.md" in got["links"]
+
+
+def test_raw_serves_conformant_markdown_with_okf_version():
+    host = OkfHost(_mem(), _FakeBrain([]))
+    raw = host.raw("/index.md")
+    assert raw is not None and 'okf_version: "0.1"' in raw

--- a/services/prism-service/tests/unit/test_okf_validate.py
+++ b/services/prism-service/tests/unit/test_okf_validate.py
@@ -1,0 +1,55 @@
+"""Unit tests for OKF v0.1 conformance validation."""
+
+from prism_service.okf import Bundle, Concept, validate
+
+
+def _concept(path, type_="convention", body="b", **fm):
+    fm["type"] = type_
+    fm.setdefault("title", "T")
+    fm.setdefault("description", "d")
+    fm.setdefault("resource", "https://x")
+    fm.setdefault("tags", ["t"])
+    fm.setdefault("timestamp", "2026-06-26T00:00:00Z")
+    return Concept(path=path, frontmatter=fm, body=body)
+
+
+def test_conformant_bundle_passes_with_no_errors():
+    b = Bundle()
+    b.add(_concept("/memory/conv/a.md", body="see [B](/memory/conv/b.md)"))
+    b.add(_concept("/memory/conv/b.md"))
+    rep = validate(b)
+    assert rep.ok
+    assert rep.errors == []
+
+
+def test_missing_type_is_an_error():
+    b = Bundle()
+    c = Concept(path="/memory/conv/x.md", frontmatter={"title": "x"}, body="b")
+    b.add(c)
+    rep = validate(b)
+    assert not rep.ok
+    assert any("type" in e for e in rep.errors)
+
+
+def test_broken_link_is_only_a_warning_not_an_error():
+    b = Bundle()
+    b.add(_concept("/memory/conv/a.md", body="see [gone](/memory/conv/missing.md)"))
+    rep = validate(b)
+    assert rep.ok  # tolerant: broken links never fail conformance
+    assert any("broken link" in w for w in rep.warnings)
+
+
+def test_missing_recommended_fields_is_warning_only():
+    b = Bundle()
+    b.add(Concept(path="/memory/conv/a.md", frontmatter={"type": "convention"}, body="b"))
+    rep = validate(b)
+    assert rep.ok
+    assert any("recommended" in w for w in rep.warnings)
+
+
+def test_reserved_file_with_stray_frontmatter_is_error():
+    b = Bundle()
+    b.add(Concept(path="/index.md", frontmatter={"okf_version": "0.1", "type": "x"}, body="i"))
+    rep = validate(b)
+    assert not rep.ok
+    assert any("reserved" in e for e in rep.errors)

--- a/services/prism-service/tests/unit/test_prism_guide_playbook.py
+++ b/services/prism-service/tests/unit/test_prism_guide_playbook.py
@@ -1,0 +1,109 @@
+"""prism_guide must teach an installed agent HOW to ORCHESTRATE PRISM.
+
+A self-documenting guide that only LISTS tools doesn't teach the calling
+agent the working pattern: epics-as-root-tasks decomposed into demonstrable
+subtasks, driven through the conductor SDLC gates, with subagent fan-out and
+DISTINCT-actor (no self-override) gate verification, the WHY written back to
+memory at green_gate, and the implement/prototype skills doing the drive.
+
+The AC tokens (epic / story_gate / self-override / ...) all appear elsewhere
+in the guide blob (the version-notes changelog mentions them), so each AC is
+asserted INSIDE the dedicated "Working tasks the PRISM way" playbook section,
+not against the whole guide.
+
+Conductor task: b9ddda5e.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+os.environ["PRISM_MCP_AUGMENT_NUDGES"] = "false"
+
+_TITLE = "working tasks the prism way"
+
+
+def _call(tool_name, arguments=None, project_id="prism"):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool_name, arguments or {}, project_id=project_id))
+
+
+def _guide_text():
+    result = _call("prism_guide", {})
+    assert len(result) >= 1
+    # Collapse whitespace so a line-wrapped phrase is still matched.
+    return " ".join(result[0].text.split()).lower()
+
+
+def _playbook_section():
+    """The "Working tasks the PRISM way" section text, isolated from the rest
+    of the guide (so version-notes mentions of the same tokens don't count)."""
+    g = _guide_text()
+    assert _TITLE in g, "guide lacks the 'Working tasks the PRISM way' playbook"
+    return g[g.index(_TITLE):]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — epics are ROOT tasks decomposed into subtasks via parent_id, the
+# hierarchy tracked live on the conductor.
+# ----------------------------------------------------------------------
+
+
+def test_playbook_teaches_epic_subtask_hierarchy_on_conductor():
+    s = _playbook_section()
+    assert "epic" in s
+    assert "subtask" in s or "sub-task" in s
+    assert "parent_id" in s
+    assert "root" in s
+    assert "conductor" in s
+
+
+# ----------------------------------------------------------------------
+# AC-2 — the conductor SDLC gate flow is named.
+# ----------------------------------------------------------------------
+
+
+def test_playbook_teaches_the_gate_flow():
+    s = _playbook_section()
+    assert "story_gate" in s
+    assert "plan_gate" in s
+    assert "red" in s
+    assert "green_gate" in s
+
+
+# ----------------------------------------------------------------------
+# AC-3 — subagent fan-out AND distinct-actor (no self-override) verification.
+# ----------------------------------------------------------------------
+
+
+def test_playbook_teaches_fanout_and_distinct_actor_verification():
+    s = _playbook_section()
+    assert "subagent" in s
+    assert "fan out" in s or "fan-out" in s or "parallel" in s
+    assert "distinct" in s or "independent" in s
+    assert "self-override" in s or "no self override" in s
+
+
+# ----------------------------------------------------------------------
+# AC-4 — write the decision/WHY back to memory at green_gate.
+# ----------------------------------------------------------------------
+
+
+def test_playbook_teaches_writing_decision_to_memory_at_green_gate():
+    s = _playbook_section()
+    assert "memory_store" in s
+    assert "decision" in s
+    assert "green_gate" in s
+    assert "rationale" in s or "why" in s
+
+
+# ----------------------------------------------------------------------
+# AC-5 — references the implement (and prototype) skill/workflow.
+# ----------------------------------------------------------------------
+
+
+def test_playbook_references_implement_and_prototype_skills():
+    s = _playbook_section()
+    assert "implement" in s
+    assert "prototype" in s

--- a/services/prism-service/tests/unit/test_task_title_rename.py
+++ b/services/prism-service/tests/unit/test_task_title_rename.py
@@ -1,0 +1,114 @@
+"""Task title rename — a task's TITLE must be editable (customer bug 11040b39).
+
+Pins, RED-first, that `title` threads through the ONE task_update path across
+all three layers, plus a BLANK-TITLE GUARD (None/empty/whitespace is ignored,
+never blanks an existing title):
+  * TaskService.update(id, title=...) persists; "   " leaves the title alone.
+  * The MCP dispatcher SEAM (handle_tool -> task_update) advertises `title`
+    in its schema AND plumbs it end-to-end (durable, not echo).
+  * The API SEAM (PATCH /api/tasks/{id}) accepts `title` and GET echoes it.
+
+These FAIL before the guard + schema/arg/model wiring exist.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _services(tmp_path):
+    from prism_service.services.task_service import TaskService
+
+    return TaskService(str(tmp_path / "tasks.db"))
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    """Isolated ProjectContext so handle_tool + the API router resolve the
+    SAME tmp-backed task_svc (mirrors test_full_outcome_complete)."""
+    from prism_service import config as cfg
+    from prism_service import project_context as pc
+    monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    pc._contexts.clear()
+    yield "test-title-rename"
+    pc._contexts.clear()
+
+
+# ---- service layer: round-trip + blank guard --------------------------
+
+def test_update_persists_new_title(tmp_path):
+    task_svc = _services(tmp_path)
+    t = task_svc.create(title="Original")
+    task_svc.update(t.id, title="Renamed")
+    assert task_svc.get(t.id).title == "Renamed"
+
+
+def test_update_blank_title_is_ignored(tmp_path):
+    task_svc = _services(tmp_path)
+    t = task_svc.create(title="Keep Me")
+    for blank in ("", "   ", "\t\n", None):
+        task_svc.update(t.id, title=blank)
+        assert task_svc.get(t.id).title == "Keep Me", blank
+
+
+# ---- MCP dispatcher SEAM (handle_tool, not the service method) ---------
+
+def _call(tool, args, project_id):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool, args, project_id=project_id))[0].text
+
+
+def test_task_update_schema_advertises_title():
+    from prism_service.mcp.tools import TOOLS
+    by_name = {t.name: t for t in TOOLS}
+    assert "title" in by_name["task_update"].inputSchema["properties"]
+
+
+def test_mcp_task_update_plumbs_title(project):
+    from prism_service.project_context import get_project
+
+    created = json.loads(_call(
+        "task_create", {"title": "via mcp original"}, project))
+    tid = created["id"]
+    json.loads(_call(
+        "task_update", {"id": tid, "title": "via mcp renamed"}, project))
+    # Survives a SEPARATE read through the project context (durable, not echo).
+    assert get_project(project).task_svc.get(tid).title == "via mcp renamed"
+
+
+# ---- API SEAM (real route, PATCH then GET) ----------------------------
+
+def _api_client(project_id):
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import tasks as tasks_api
+    app = FastAPI()
+    app.include_router(tasks_api.router, prefix="/api/tasks")
+    return TestClient(app), project_id
+
+
+def test_api_patch_renames_title(project):
+    client, pid = _api_client(project)
+    post = client.post(
+        "/api/tasks", params={"project": pid}, json={"title": "api original"})
+    assert post.status_code in (200, 201), post.text
+    tid = post.json()["task"]["id"]
+
+    patched = client.patch(
+        f"/api/tasks/{tid}", params={"project": pid},
+        json={"title": "Renamed via API"})
+    assert patched.status_code == 200, patched.text
+
+    got = client.get(f"/api/tasks/{tid}", params={"project": pid})
+    assert got.json()["task"]["title"] == "Renamed via API"


### PR DESCRIPTION
## v6.7.0 — Open Knowledge Format epic

Makes PRISM speak Google's **Open Knowledge Format** and consolidates the knowledge UI.

### Highlights
- **OKF core + read-path host** (`prism_service/okf/`, `services/okf_host.py`, `api/okf.py`): PRISM's curated memory projected as a conformant OKF v0.1 bundle (concepts + cross-links + backlinks). MCP: `okf_index`/`okf_get`/`okf_graph`; HTTP `/api/okf/*`.
- **Knowledge UI: 4 surfaces -> 2.** Brain (Sigma graphvis) + **Understand** = one interconnected wiki (Google-OKF-visualizer model): domain drill-down -> force-directed concept graph (visible cross-link edges) -> detail panel (markdown body + in-place [[link]] nav + 'Cited by' backlinks + edit). `/okf` and `/memory` redirect into `/understand`.
- **Task rename fixed** (customer bug): `title` now editable via service + MCP `task_update` + PATCH API + SPA click-to-rename, with a blank guard.
- **MCP + prism_guide aligned**: guide teaches the 2-surface model AND the 'Working tasks the PRISM way' orchestration playbook (epic+subtask+conductor SDLC, subagent fan-out, distinct-actor proof-carrying gates, memory write-back); `understand_*` analysis tools labeled LEGACY.

### Verification
- Full unit suite **863 passed, 0 failed**; `tsc -b` + `npm run build` clean.
- Read-only projection; brain.db/graph.db untouched (44 brain/memory augmentation tests green).
- Driven through PRISM's own conductor (epics+subtasks, gates green with distinct-actor verifiers, WHY in memory).

### Follow-ups (logged, out of scope)
- Rehome architecture-governance (violations/layers) near /conductor after the consolidation.
- Fully retire `understand_*` tools + `/api/understand/*` once no consumer remains.
- OKF write-path + export/import slices (epic 061b897d subtasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)