### PR TITLE
fix(#181): no more split-brain daemon after auto-update (v6.7.9)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,27 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.8"
+PRISM_VERSION = "6.7.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.9: NO MORE SPLIT-BRAIN DAEMON (GH #181) — a live auto-update could "
+    "leave TWO daemon families, each owning ONE port (new UI on :7778, orphaned "
+    "old worker squatting :7777/MCP) while prism status + /api/version reported "
+    "green. Fix: (1) NEW services/split_brain.py maps each port->owning pid "
+    "(netstat/ss/lsof, stdlib-only, best-effort) and flags 'two pids, one port "
+    "each' as split-brain (one pid owning both = healthy). (2) a TTL-bounded "
+    "restart sentinel (data_dir): auto_updater.perform_restart writes it BEFORE "
+    "draining, the re-exec'd server clears it on healthy boot, and the "
+    "out-of-process supervisor DEFERS its competing kill+respawn while it is "
+    "fresh (that competing recovery during the restart drain/cold-boot is what "
+    "stacked the 2nd family) — stale sentinel ignored so a crash can't wedge "
+    "recovery. (3) cmd_start gains a PORT-LEVEL guard (refuse if the UI already "
+    "answers or the MCP port is held, even with a stale/absent pidfile). (4) "
+    "prism status self-checks for split-brain, reports UNHEALTHY (non-zero) "
+    "instead of green, and self-heals by reaping the orphan; cmd_stop sweeps a "
+    "port-squatting orphan too, escalating SIGTERM->SIGKILL (the orphan ignored "
+    "SIGTERM). "
     "v6.7.8: SDLC METHODS for SAFE MAX FAN-OUT — fold the v6.7.6/6.7.7 "
     "primitives into the phase-router skills + orchestration playbook so an "
     "epic can fan out HETEROGENEOUS children safely. (1) prism_guide("

--- a/services/prism-service/prism_service/cli/prism_cli.py
+++ b/services/prism-service/prism_service/cli/prism_cli.py
@@ -118,6 +118,14 @@ def _daemon_http_alive(port: int | str) -> bool:
         return False
 
 
+def _port_owner_pid(port: int | str):
+    """PID owning the LISTEN socket on `port`, else None (GH #181). Thin,
+    monkeypatchable seam over services.split_brain.port_owner_pid; deferred
+    import keeps `prism --help` light."""
+    from prism_service.services.split_brain import port_owner_pid
+    return port_owner_pid(port)
+
+
 def _read_pid() -> int:
     p = _pid_file()
     if not p.exists():
@@ -151,6 +159,24 @@ def cmd_start(args: argparse.Namespace) -> int:
         # used to only happen on an explicit `prism stop`.
         print(f"removing stale pidfile (pid {existing} not alive)", file=sys.stderr)
         _pid_file().unlink(missing_ok=True)
+
+    # PORT-LEVEL GUARD (GH #181): the pidfile check above MISSES a live daemon
+    # when the pidfile is absent/stale/mid-rotation — exactly the auto-update
+    # window in which a second `prism start` stacked a second family and caused
+    # the split-brain. Refuse to start if a daemon already answers on the UI
+    # port, or if anything holds the MCP port, regardless of pidfile state.
+    ui_guard = str(args.ui_port or os.environ.get("PRISM_UI_PORT", "7778"))
+    mcp_guard = str(args.mcp_port or os.environ.get("PRISM_MCP_PORT", "7777"))
+    if _daemon_http_alive(ui_guard):
+        print(f"prism already running (UI :{ui_guard} is answering) — refusing "
+              f"to start a second daemon", file=sys.stderr)
+        return 1
+    _mcp_owner = _port_owner_pid(mcp_guard)
+    if _mcp_owner:
+        print(f"MCP port :{mcp_guard} already held by pid {_mcp_owner} — "
+              f"refusing to stack a second family (possible in-flight restart)",
+              file=sys.stderr)
+        return 1
 
     # Rotate the prior run's log BEFORE opening the append handle so the
     # file is size-bounded and the last run's tail (incl. any crash
@@ -284,6 +310,22 @@ def cmd_stop(_args: argparse.Namespace) -> int:
     except OSError as e:
         print(f"failed to stop pid {pid}: {e}", file=sys.stderr)
         return 1
+    # ORPHAN SWEEP (GH #181 fix #4): a split-brain orphan is a SEPARATE family
+    # squatting the OTHER port — the pidfile never named it, so the stop above
+    # didn't reach it, and (as observed) it IGNORED SIGTERM. Reap any remaining
+    # port-squatter with an escalating SIGTERM->SIGKILL so a graceful stop never
+    # leaves a zombie holding a port.
+    try:
+        mcp = os.environ.get("PRISM_MCP_PORT", "7777")
+        from prism_service.services import split_brain
+        rep = split_brain.detect_split_brain(
+            ui, mcp, pidfile_pid=pid, owner=_port_owner_pid)
+        if not rep.healthy and rep.orphan_pid and rep.orphan_pid != pid:
+            split_brain.heal_split_brain(rep)
+            print(f"reaped split-brain orphan pid {rep.orphan_pid} "
+                  f"(SIGTERM->SIGKILL)", file=sys.stderr)
+    except Exception:
+        pass
     print(f"prism stopped (was pid {pid})")
     return 0
 
@@ -312,6 +354,22 @@ def cmd_status(_args: argparse.Namespace) -> int:
     if responding:
         print(f"  ui:       http://localhost:{ui}/")
         print(f"  mcp:      http://localhost:{mcp}/mcp/")
+
+    # SPLIT-BRAIN SELF-CHECK (GH #181): two PIDs each owning ONE port is the
+    # silent failure the version/HTTP checks above MISS — UI reports the new
+    # version and looks green while MCP is stranded on the orphaned old daemon.
+    # Detect it (one pid owning both = healthy) and self-heal by reaping the
+    # orphan, surfacing UNHEALTHY (non-zero exit) instead of a false green.
+    from prism_service.services import split_brain
+    report = split_brain.detect_split_brain(
+        ui, mcp, pidfile_pid=pid, owner=_port_owner_pid)
+    if not report.healthy:
+        print(f"  health:   UNHEALTHY — {report.reason}")
+        reaped = split_brain.heal_split_brain(report)
+        if reaped:
+            print(f"  self-heal: reaped orphan pid {reaped} (SIGTERM->SIGKILL); "
+                  f"re-run 'prism status' to confirm a single owner")
+        return 1
     return 0
 
 

--- a/services/prism-service/prism_service/data_dir.py
+++ b/services/prism-service/prism_service/data_dir.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import os
 import sys
+import time
 from pathlib import Path
 
 
@@ -93,6 +94,52 @@ def rotate_log_on_start(path: Path | None = None) -> None:
         p.replace(p.with_name(f"{p.name}.1"))
     except OSError:
         pass  # best-effort; never block startup on log rotation
+
+
+# Restart-coordination sentinel (GH #181). The auto-updater writes it BEFORE
+# draining for an os.execv re-exec; the re-exec'd server clears it on a healthy
+# boot. While the sentinel is FRESH the out-of-process supervisor treats the
+# worker as in-grace and skips its competing kill+respawn — that competing
+# recovery (UI hung during the restart drain/cold-boot) is what spawned a
+# second daemon family and the split-brain. The TTL is the NFR-2 staleness
+# bound: a crash mid-restart leaves a sentinel behind, and a STALE one must NOT
+# disable supervisor recovery forever, so freshness is always re-checked.
+RESTART_SENTINEL_TTL_S = 120.0
+
+
+def restart_sentinel() -> Path:
+    """Path of the restart-in-progress sentinel (shared by auto_updater,
+    main, and supervisor so all three agree on the file)."""
+    return resolve_data_dir() / "prism.restarting"
+
+
+def write_restart_sentinel(pid: int | None = None) -> None:
+    """Mark a restart in progress (best-effort). Records the pid for diagnostics."""
+    p = restart_sentinel()
+    try:
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(str(pid if pid is not None else os.getpid()), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def clear_restart_sentinel() -> None:
+    """Clear the restart sentinel (called by the re-exec'd server on healthy boot)."""
+    try:
+        restart_sentinel().unlink(missing_ok=True)
+    except OSError:
+        pass
+
+
+def restart_in_progress(ttl_s: float = RESTART_SENTINEL_TTL_S) -> bool:
+    """True iff a FRESH restart sentinel exists (younger than ttl_s). A stale
+    sentinel (crash mid-restart) returns False so recovery is never disabled
+    forever (NFR-2). Absent file => False."""
+    try:
+        age = time.time() - restart_sentinel().stat().st_mtime
+    except OSError:
+        return False
+    return 0.0 <= age < max(0.0, ttl_s)
 
 
 def resolve_claude_home() -> Path:

--- a/services/prism-service/prism_service/data_dir.py
+++ b/services/prism-service/prism_service/data_dir.py
@@ -136,10 +136,14 @@ def restart_in_progress(ttl_s: float = RESTART_SENTINEL_TTL_S) -> bool:
     sentinel (crash mid-restart) returns False so recovery is never disabled
     forever (NFR-2). Absent file => False."""
     try:
-        age = time.time() - restart_sentinel().stat().st_mtime
+        # Clamp to >=0: a just-written file's st_mtime can read marginally
+        # AHEAD of time.time() (filesystem mtime resolution / clock skew),
+        # which would make a FRESH sentinel look negative-aged. Clamping keeps
+        # a fresh file fresh while ttl_s=0 still reads as stale (0 < 0 is False).
+        age = max(0.0, time.time() - restart_sentinel().stat().st_mtime)
     except OSError:
         return False
-    return 0.0 <= age < max(0.0, ttl_s)
+    return age < max(0.0, ttl_s)
 
 
 def resolve_claude_home() -> Path:

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -403,6 +403,16 @@ async def lifespan(_app: FastAPI):
     try:
         _LOCK_FILE.write_text(str(threading.get_ident()))
         _install_stackdump_handler()
+        # GH #181: this lifespan boot IS the healthy-boot signal for the
+        # re-exec'd image — clear the auto-update restart sentinel so the
+        # out-of-process supervisor resumes normal recovery now that the new
+        # process is up and about to bind both ports. (No-op when no restart
+        # was in flight.)
+        try:
+            from prism_service.data_dir import clear_restart_sentinel
+            clear_restart_sentinel()
+        except Exception:
+            pass
         threading.Thread(target=start_mcp_server, daemon=True).start()
         threading.Thread(target=start_drift_timer, daemon=True).start()
         from prism_service.services.understand_drainer import start_understand_drainer

--- a/services/prism-service/prism_service/services/auto_updater.py
+++ b/services/prism-service/prism_service/services/auto_updater.py
@@ -140,6 +140,20 @@ def perform_restart(server=None, drain_timeout_s: float = 10.0) -> None:
     """
     if _DEFER_RESTART:
         return
+    # SPLIT-BRAIN GUARD (GH #181): mark a restart in progress BEFORE we drain.
+    # The os.execv below re-execs IN PLACE (same pid) and closes both CLOEXEC
+    # sockets, so the re-exec'd image is the single owner of both ports. The
+    # risk is the out-of-process supervisor: it probes ONLY the UI port, sees it
+    # hang during the drain + cold-boot, and fires a COMPETING kill+respawn that
+    # stacks a second family. While this FRESH sentinel exists the supervisor
+    # defers recovery; the re-exec'd server clears it on a healthy boot
+    # (main._own_pidfile_write path). TTL-bounded so a crash can't wedge
+    # recovery off forever (NFR-2).
+    try:
+        from prism_service.data_dir import write_restart_sentinel
+        write_restart_sentinel(os.getpid())
+    except Exception:
+        pass
     if server is not None:
         # BOUNDED graceful-first drain (task 73ec7273, lineage of #66):
         # 1) should_exit -> uvicorn drains its loop + closes idle sockets;

--- a/services/prism-service/prism_service/services/split_brain.py
+++ b/services/prism-service/prism_service/services/split_brain.py
@@ -1,0 +1,243 @@
+"""Split-brain detection + healing for the PRISM daemon (GH #181).
+
+The healthy invariant is ONE process owning BOTH service ports: UI (7778) on
+the main-thread uvicorn and MCP (7777) on a daemon-thread uvicorn. A botched
+auto-update restart can leave TWO daemon families, each owning ONE port (new
+UI on :7778, orphaned old worker squatting :7777) — a silent split-brain that
+`prism status` / `/api/version` report as green while every MCP caller is
+stranded on the stale daemon.
+
+This module is the detective + the medic, deliberately stdlib-only and OS-tool
+based (no psutil dep): map each port to its owning pid, decide whether that is
+a split-brain, and reap the orphan with a SIGTERM->SIGKILL escalation (the
+#181 orphan ignored SIGTERM). Every lookup is best-effort and returns None on
+any failure so a detection NEVER raises a FALSE split-brain (NFR-1).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+
+def port_owner_pid(port: int | str) -> Optional[int]:
+    """Best-effort pid owning the LISTEN socket on `port`, else None.
+
+    Windows: `netstat -ano`. POSIX: `ss -ltnp`, then `lsof` fallback. Returns
+    None when undeterminable (never raises) so callers never see a FALSE
+    split-brain (NFR-1)."""
+    try:
+        port = int(port)
+    except (TypeError, ValueError):
+        return None
+    if port <= 0:
+        return None
+    try:
+        if sys.platform.startswith("win"):
+            return _win_port_owner(port)
+        return _posix_port_owner(port)
+    except (OSError, ValueError):
+        return None
+
+
+def _win_port_owner(port: int) -> Optional[int]:
+    out = subprocess.run(
+        ["netstat", "-ano", "-p", "TCP"],
+        capture_output=True, text=True, check=False,
+    )
+    for line in (out.stdout or "").splitlines():
+        parts = line.split()
+        # proto  local-addr  foreign-addr  state  pid
+        if len(parts) >= 5 and parts[0].upper().startswith("TCP") \
+                and parts[3].upper() == "LISTENING" \
+                and parts[1].rsplit(":", 1)[-1] == str(port):
+            try:
+                return int(parts[4])
+            except ValueError:
+                continue
+    return None
+
+
+def _posix_port_owner(port: int) -> Optional[int]:
+    ss = subprocess.run(
+        ["ss", "-ltnp"], capture_output=True, text=True, check=False,
+    )
+    if ss.returncode == 0 and ss.stdout:
+        for line in ss.stdout.splitlines():
+            if "LISTEN" not in line:
+                continue
+            cols = line.split()
+            # ... State Recv-Q Send-Q Local-Address:Port ...  users:(("p",pid=N,..))
+            local = cols[3] if len(cols) >= 4 else ""
+            if local.rsplit(":", 1)[-1] != str(port):
+                continue
+            m = re.search(r"pid=(\d+)", line)
+            if m:
+                return int(m.group(1))
+    lsof = subprocess.run(
+        ["lsof", f"-iTCP:{port}", "-sTCP:LISTEN", "-t", "-n", "-P"],
+        capture_output=True, text=True, check=False,
+    )
+    if lsof.returncode == 0 and lsof.stdout.strip():
+        try:
+            return int(lsof.stdout.split()[0])
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
+def _pid_alive(pid: int) -> bool:
+    """True iff PID names a live process. Mirrors cli._is_alive /
+    supervisor.server_process_alive (biases True on PermissionError)."""
+    if pid <= 0:
+        return False
+    if sys.platform.startswith("win"):
+        out = subprocess.run(
+            ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
+            capture_output=True, text=True, check=False,
+        )
+        import csv
+        for row in csv.reader((out.stdout or "").splitlines()):
+            if len(row) >= 2 and row[1].strip() == str(pid):
+                return True
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+
+
+_TASKKILL = "TASKKILL"
+# signal.SIGKILL is undefined on Windows; resolve via getattr so this module
+# stays importable + unit-testable (the POSIX branch can be exercised with
+# _win=False) on any host. Only the POSIX runtime path actually delivers these.
+_SIGTERM = getattr(signal, "SIGTERM", 15)
+_SIGKILL = getattr(signal, "SIGKILL", 9)
+
+
+def _default_signal(pid: int, sig) -> None:
+    """Deliver `sig` to `pid`. The sentinel _TASKKILL maps to a Windows hard
+    tree-kill (no POSIX-signal equivalent); everything else is os.kill."""
+    if sig == _TASKKILL:
+        subprocess.run(
+            ["taskkill", "/PID", str(pid), "/T", "/F"],
+            check=False, capture_output=True,
+        )
+        return
+    os.kill(pid, sig)
+
+
+def kill_pid_escalating(
+    pid: int,
+    term_timeout_s: float = 3.0,
+    *,
+    _kill: Optional[Callable] = None,
+    _alive: Optional[Callable[[int], bool]] = None,
+    _sleep: Callable[[float], None] = time.sleep,
+    _win: Optional[bool] = None,
+) -> list:
+    """SIGTERM, then SIGKILL after term_timeout_s if it survives — the orphan in
+    #181 IGNORED SIGTERM, so graceful-stop alone left a port-squatting zombie;
+    we ALWAYS escalate. Windows has no SIGTERM, so it is a single `taskkill /F`.
+    Returns the list of signals actually sent (test-observable). The injectable
+    seams keep the escalation logic unit-testable on any host."""
+    if pid <= 0:
+        return []
+    win = sys.platform.startswith("win") if _win is None else _win
+    kill = _kill or _default_signal
+    alive = _alive or _pid_alive
+    sent: list = []
+    if win:
+        kill(pid, _TASKKILL)
+        sent.append(_TASKKILL)
+        return sent
+    try:
+        kill(pid, _SIGTERM)
+        sent.append(_SIGTERM)
+    except ProcessLookupError:
+        return sent
+    deadline = time.monotonic() + max(0.0, term_timeout_s)
+    while time.monotonic() < deadline:
+        if not alive(pid):
+            return sent
+        _sleep(0.05)
+    try:
+        kill(pid, _SIGKILL)
+        sent.append(_SIGKILL)
+    except ProcessLookupError:
+        pass
+    return sent
+
+
+@dataclass
+class SplitBrainReport:
+    healthy: bool
+    ui_port: int
+    mcp_port: int
+    ui_pid: Optional[int]
+    mcp_pid: Optional[int]
+    pidfile_pid: Optional[int]
+    orphan_pid: Optional[int]
+    reason: str
+
+
+def detect_split_brain(
+    ui_port: int | str,
+    mcp_port: int | str,
+    pidfile_pid: Optional[int] = None,
+    owner: Optional[Callable] = None,
+) -> SplitBrainReport:
+    """A split-brain is two DISTINCT pids each owning one of the two ports.
+
+    Conservative by design (NFR-1): a port owned by no one / undeterminable, or
+    a single pid owning BOTH ports, is reported HEALTHY — only two different
+    live owners trip it, so a down or mid-boot daemon never false-positives.
+    The canonical keeper is the pidfile pid when it owns a port, else the UI
+    owner (the live /api/version responder); the OTHER pid is the orphan."""
+    _owner = owner or port_owner_pid
+    ui_pid = _owner(ui_port)
+    mcp_pid = _owner(mcp_port)
+
+    def _mk(healthy, orphan, reason):
+        return SplitBrainReport(
+            healthy=healthy, ui_port=int(ui_port), mcp_port=int(mcp_port),
+            ui_pid=ui_pid, mcp_pid=mcp_pid, pidfile_pid=pidfile_pid,
+            orphan_pid=orphan, reason=reason,
+        )
+
+    if ui_pid is None or mcp_pid is None:
+        return _mk(True, None, "ports unowned/undeterminable — no split detected")
+    if ui_pid == mcp_pid:
+        return _mk(True, None, f"single owner pid {ui_pid} holds both ports")
+    # Two distinct owners — split-brain.
+    if pidfile_pid == mcp_pid:
+        keeper, orphan = mcp_pid, ui_pid
+    else:
+        keeper, orphan = ui_pid, mcp_pid
+    return _mk(
+        False, orphan,
+        f"SPLIT-BRAIN: UI :{ui_port} owned by pid {ui_pid}, MCP :{mcp_port} "
+        f"owned by pid {mcp_pid} (keep {keeper}, orphan {orphan})",
+    )
+
+
+def heal_split_brain(
+    report: SplitBrainReport,
+    term_timeout_s: float = 3.0,
+    killer: Optional[Callable] = None,
+) -> Optional[int]:
+    """Reap the orphan pid (escalating SIGTERM->SIGKILL). No-op when healthy.
+    Returns the reaped pid, or None."""
+    if report.healthy or not report.orphan_pid:
+        return None
+    (killer or kill_pid_escalating)(report.orphan_pid, term_timeout_s)
+    return report.orphan_pid

--- a/services/prism-service/prism_service/services/supervisor.py
+++ b/services/prism-service/prism_service/services/supervisor.py
@@ -126,6 +126,20 @@ class SupervisorState:
         self.spawned_at = time.monotonic() if now is None else now
 
 
+def _restart_in_progress() -> bool:
+    """True iff an auto-update restart is in flight (a FRESH restart sentinel
+    exists). GH #181: during the re-exec drain + cold-boot the UI port hangs;
+    without this the supervisor would fire a COMPETING kill+respawn and stack a
+    second daemon family (the split-brain). We defer recovery while the sentinel
+    is fresh; the re-exec'd server clears it on healthy boot, and the sentinel's
+    TTL means a crashed restart can't disable recovery forever (NFR-2)."""
+    try:
+        from prism_service.data_dir import restart_in_progress
+        return restart_in_progress()
+    except Exception:
+        return False
+
+
 def _in_startup_grace(state: SupervisorState) -> bool:
     """True iff the freshly (re)spawned child is still inside its startup
     grace window. False when no spawn anchor is set (nothing to protect) or
@@ -308,6 +322,12 @@ def handle_probe_result(state: SupervisorState, alive: bool) -> bool:
     if _in_startup_grace(state):
         return False
 
+    # AUTO-UPDATE RESTART GRACE (GH #181): a fresh restart sentinel means the
+    # worker is mid re-exec; its UI hang is expected, NOT a wedge. Defer the
+    # competing kill+respawn that would otherwise stack a second daemon family.
+    if _restart_in_progress():
+        return False
+
     state.consecutive_failures += 1
     if state.consecutive_failures < failure_threshold():
         return False
@@ -347,6 +367,9 @@ def handle_liveness(state: SupervisorState, pid_alive: bool) -> bool:
     if pid_alive:
         return False
     if _in_startup_grace(state):
+        return False
+    # GH #181: don't respawn over a worker that is mid auto-update re-exec.
+    if _restart_in_progress():
         return False
     cap = max_restarts()
     if cap and state.restarts >= cap:

--- a/services/prism-service/tests/integration/test_auto_update_no_split_brain.py
+++ b/services/prism-service/tests/integration/test_auto_update_no_split_brain.py
@@ -1,0 +1,74 @@
+"""GH #181 (integration): an auto-update restart must leave ONE owner of both
+ports — never a second daemon family.
+
+This wires the three collaborators that together prevent the split-brain:
+  * auto_updater.perform_restart writes the restart sentinel BEFORE draining,
+    then os.execv re-execs IN PLACE (same pid -> single owner of both ports);
+  * data_dir exposes the TTL-bounded sentinel;
+  * supervisor.handle_probe_result DEFERS its competing kill+respawn while the
+    sentinel is fresh (the competing recovery is what stacked the 2nd family).
+
+os.execv is mocked so the test process is not replaced.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from prism_service.services import auto_updater as au
+from prism_service.services import supervisor as sup
+from prism_service import data_dir
+
+
+@pytest.fixture
+def data_dir_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _reset_au():
+    clear = getattr(au, "clear_restart_request", None)
+    if callable(clear):
+        clear()
+
+
+def test_perform_restart_writes_sentinel_before_exec(data_dir_tmp, monkeypatch):
+    events = []
+    # Record sentinel-state AT the moment of execv to prove ordering: the
+    # sentinel must already be present when the re-exec fires.
+    monkeypatch.setattr(
+        au.os, "execv",
+        lambda path, argv: events.append(("execv", data_dir.restart_in_progress())))
+    try:
+        au.perform_restart(server=None, drain_timeout_s=0.0)
+    finally:
+        _reset_au()
+    assert ("execv", True) in events, "sentinel must be set before the re-exec"
+    assert data_dir.restart_in_progress() is True
+
+
+def test_supervisor_defers_recovery_while_restart_sentinel_fresh(data_dir_tmp, monkeypatch):
+    # A real (file-backed) fresh sentinel — not a mock — must make the
+    # supervisor defer its competing recovery, so no 2nd family is spawned.
+    data_dir.write_restart_sentinel(os.getpid())
+    monkeypatch.setattr(sup, "_in_startup_grace", lambda state: False)
+    monkeypatch.setattr(sup, "failure_threshold", lambda: 3)
+    fired = {"respawns": 0}
+    monkeypatch.setattr(sup, "force_kill", lambda pid: None)
+    monkeypatch.setattr(sup, "respawn_server", lambda: fired.__setitem__("respawns", 1) or 999)
+
+    state = sup.SupervisorState(server_pid=123)
+    state.spawned_at = None
+    for _ in range(10):
+        sup.handle_probe_result(state, alive=False)
+    assert fired["respawns"] == 0, "supervisor must NOT respawn during a fresh restart"
+
+    # Once the re-exec'd server clears the sentinel (healthy boot), recovery resumes.
+    data_dir.clear_restart_sentinel()
+    recovered = False
+    for _ in range(3):
+        recovered = sup.handle_probe_result(state, alive=False) or recovered
+    assert recovered is True
+    assert fired["respawns"] == 1

--- a/services/prism-service/tests/integration/test_auto_update_restart_drain.py
+++ b/services/prism-service/tests/integration/test_auto_update_restart_drain.py
@@ -89,12 +89,17 @@ class _StuckServer:
 # hung on a clean drain.
 # ---------------------------------------------------------------------------
 
-def test_perform_restart_bounds_drain_then_force_exits(monkeypatch):
+def test_perform_restart_bounds_drain_then_force_exits(monkeypatch, tmp_path):
     """With a held-open (non-draining) connection, perform_restart must NOT
     hang: after drain_timeout_s it sets _server.force_exit so uvicorn drops the
     connection, then os.execv fires. Ordering must be graceful-first:
     should_exit BEFORE force_exit BEFORE execv (no in-flight-write force-kill).
     """
+    # GH #181: perform_restart now writes a restart sentinel into the data dir;
+    # isolate it to a tmp dir so the (execv-mocked) test never leaves a stale
+    # sentinel in the real data dir that would defer other tests' supervisor
+    # recovery.
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
     server = _StuckServer()
 
     def _fake_execv(path, argv):

--- a/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
+++ b/services/prism-service/tests/integration/test_auto_update_restart_handoff.py
@@ -141,10 +141,13 @@ def test_maybe_apply_requests_restart_without_self_exec(monkeypatch):
 # The MAIN-thread restart performer: graceful uvicorn stop, then os.execv.
 # ---------------------------------------------------------------------------
 
-def test_perform_restart_execs_from_main_thread(monkeypatch):
+def test_perform_restart_execs_from_main_thread(monkeypatch, tmp_path):
     """The actual process replacement lives in a main-thread performer that
     (1) gracefully stops the running uvicorn server, then (2) os.execv's into
     the new image. We assert it drains the server first and execs after."""
+    # GH #181: isolate the restart-sentinel write (execv is mocked here, so it
+    # would otherwise leak into the real data dir).
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
     perform = getattr(au, "perform_restart", None)
     assert callable(perform), \
         "auto_updater must expose perform_restart() — the main-thread re-exec"

--- a/services/prism-service/tests/unit/test_daemon_self_heal.py
+++ b/services/prism-service/tests/unit/test_daemon_self_heal.py
@@ -177,6 +177,11 @@ def test_cmd_start_breakaway_fallback_warns(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("PRISM_SUPERVISOR", "off")  # don't spawn the supervisor child
     cli = importlib.import_module("prism_service.cli.prism_cli")
     monkeypatch.setattr(cli, "_read_pid", lambda: 0)
+    # GH #181: isolate the new port-level start guard so it neither reads real
+    # host ports nor runs netstat via subprocess (which, with Popen monkeypatched
+    # below, would otherwise consume the first mocked Popen call).
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda p: False)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda p: None)
 
     calls = {"n": 0}
 

--- a/services/prism-service/tests/unit/test_pidfile_lifecycle.py
+++ b/services/prism-service/tests/unit/test_pidfile_lifecycle.py
@@ -42,6 +42,10 @@ def test_cmd_start_clears_confirmed_stale_pidfile(data_dir, monkeypatch, capsys)
     # An old, dead pid is sitting in the pidfile.
     cli._write_pid(999999)
     monkeypatch.setattr(cli, "_is_alive", lambda pid: False)
+    # GH #181 port-level guard: neutralize it so this stale-pidfile test still
+    # reaches the spawn path (no daemon answering, no port held).
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: False)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: None)
 
     launched = {}
 
@@ -73,6 +77,7 @@ def test_cmd_status_reports_stale_when_pid_alive_but_unresponsive(
     cli._write_pid(555)
     monkeypatch.setattr(cli, "_is_alive", lambda pid: True)
     monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: False)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: None)  # #181: no split-brain
     cli.cmd_status(argparse.Namespace())
     out = capsys.readouterr().out
     assert "stale pidfile" in out
@@ -83,6 +88,7 @@ def test_cmd_status_reports_running_when_responding(data_dir, monkeypatch, capsy
     cli._write_pid(555)
     monkeypatch.setattr(cli, "_is_alive", lambda pid: True)
     monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: True)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: None)  # #181: no split-brain
     cli.cmd_status(argparse.Namespace())
     out = capsys.readouterr().out
     assert "running (pid 555)" in out
@@ -109,3 +115,68 @@ def test_cmd_stop_refuses_to_kill_recycled_pid(data_dir, monkeypatch, capsys):
 def test_daemon_http_alive_false_on_dead_port(data_dir):
     # Nothing is listening on this port; probe must fail fast, not raise.
     assert cli._daemon_http_alive(59999) is False
+
+
+# ── GH #181: port-level start guard, status self-heal, stop orphan sweep ──────
+def test_cmd_start_refuses_when_ui_already_answering(data_dir, monkeypatch, capsys):
+    # No pidfile at all (mid-rotation/absent), but a daemon IS answering on the
+    # UI port — cmd_start must refuse to stack a second family (AC-2).
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: True)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: None)
+    spawned = {"called": False}
+    monkeypatch.setattr(cli.subprocess, "Popen",
+                        lambda *a, **k: spawned.__setitem__("called", True))
+    rc = cli.cmd_start(argparse.Namespace(daemon=True, ui_port=None, mcp_port=None))
+    assert rc == 1
+    assert spawned["called"] is False
+    assert "already running" in capsys.readouterr().err
+
+
+def test_cmd_start_refuses_when_mcp_port_held(data_dir, monkeypatch, capsys):
+    # UI not answering, but the MCP port is held by another pid (an in-flight
+    # restart / orphan) — still refuse (AC-2).
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: False)
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: 49019)
+    spawned = {"called": False}
+    monkeypatch.setattr(cli.subprocess, "Popen",
+                        lambda *a, **k: spawned.__setitem__("called", True))
+    rc = cli.cmd_start(argparse.Namespace(daemon=True, ui_port=None, mcp_port=None))
+    assert rc == 1
+    assert spawned["called"] is False
+    assert "already held by pid 49019" in capsys.readouterr().err
+
+
+def test_cmd_status_reports_unhealthy_and_self_heals_split_brain(data_dir, monkeypatch, capsys):
+    # Two pids each own one port -> UNHEALTHY + reap the orphan, exit non-zero (AC-3).
+    cli._write_pid(26138)
+    monkeypatch.setattr(cli, "_is_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: True)
+    owners = {"7778": 26138, "7777": 49019}
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: owners.get(str(port)))
+    killed = []
+    from prism_service.services import split_brain
+    monkeypatch.setattr(split_brain, "kill_pid_escalating",
+                        lambda pid, *a, **k: killed.append(pid))
+    rc = cli.cmd_status(argparse.Namespace())
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "UNHEALTHY" in out
+    assert killed == [49019]              # orphan reaped, keeper (UI pid) spared
+
+
+def test_cmd_stop_reaps_split_brain_orphan(data_dir, monkeypatch, capsys):
+    cli._write_pid(26138)
+    monkeypatch.setattr(cli, "_is_alive", lambda pid: True)
+    monkeypatch.setattr(cli, "_daemon_http_alive", lambda port: True)
+    monkeypatch.setattr(cli.subprocess, "run", lambda *a, **k: None)
+    monkeypatch.setattr(cli.os, "kill", lambda *a, **k: None)
+    owners = {"7778": 26138, "7777": 49019}
+    monkeypatch.setattr(cli, "_port_owner_pid", lambda port: owners.get(str(port)))
+    killed = []
+    from prism_service.services import split_brain
+    monkeypatch.setattr(split_brain, "kill_pid_escalating",
+                        lambda pid, *a, **k: killed.append(pid))
+    rc = cli.cmd_stop(argparse.Namespace())
+    assert rc == 0
+    assert killed == [49019]             # the SIGTERM-ignoring orphan is reaped
+    assert "reaped split-brain orphan pid 49019" in capsys.readouterr().err

--- a/services/prism-service/tests/unit/test_split_brain_detector.py
+++ b/services/prism-service/tests/unit/test_split_brain_detector.py
@@ -1,0 +1,129 @@
+"""GH #181 — split-brain detector + healer + restart sentinel (unit).
+
+Healthy = ONE pid owns BOTH service ports. Split-brain = two DISTINCT pids each
+owning one port (the orphaned old daemon squatting :7777 while the new one owns
+:7778). These pin detection (conservative — never a FALSE split), the
+SIGTERM->SIGKILL escalation the orphan forced (it ignored SIGTERM), and the
+TTL-bounded restart sentinel that stops the supervisor's competing recovery.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from prism_service.services import split_brain as sb
+from prism_service import data_dir
+
+
+# ── port_owner_pid: never raises, None on bad input ──────────────────────────
+@pytest.mark.parametrize("bad", [0, -1, "x", None])
+def test_port_owner_pid_bad_input_is_none(bad):
+    assert sb.port_owner_pid(bad) is None
+
+
+# ── detect_split_brain ───────────────────────────────────────────────────────
+def _owner_map(mapping):
+    return lambda port: mapping.get(int(port))
+
+
+def test_single_owner_both_ports_is_healthy():
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({7778: 100, 7777: 100}))
+    assert rep.healthy is True
+    assert rep.orphan_pid is None
+
+
+def test_two_owners_one_per_port_is_split_brain():
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({7778: 26138, 7777: 49019}))
+    assert rep.healthy is False
+    # No pidfile hint: the UI responder is canonical, MCP squatter is the orphan.
+    assert rep.orphan_pid == 49019
+    assert "SPLIT-BRAIN" in rep.reason
+
+
+def test_pidfile_pid_decides_the_keeper():
+    # When the pidfile names the MCP owner, the UI owner is the orphan instead.
+    rep = sb.detect_split_brain(
+        7778, 7777, pidfile_pid=49019, owner=_owner_map({7778: 26138, 7777: 49019}))
+    assert rep.healthy is False
+    assert rep.orphan_pid == 26138
+
+
+def test_one_port_unowned_is_not_split_brain():
+    # A down/mid-boot daemon (one port unowned) must NOT false-positive (NFR-1).
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({7778: 100, 7777: None}))
+    assert rep.healthy is True
+    assert rep.orphan_pid is None
+
+
+def test_both_ports_unowned_is_healthy():
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({}))
+    assert rep.healthy is True
+
+
+# ── kill_pid_escalating: SIGTERM then SIGKILL when ignored (AC-4) ─────────────
+def test_escalates_to_sigkill_when_sigterm_ignored():
+    sent = []
+    sb.kill_pid_escalating(
+        4321, term_timeout_s=0.0, _win=False,
+        _kill=lambda pid, sig: sent.append(sig),
+        _alive=lambda pid: True,          # never dies on SIGTERM
+        _sleep=lambda s: None,
+    )
+    assert sent == [sb._SIGTERM, sb._SIGKILL]
+
+
+def test_no_sigkill_when_sigterm_works():
+    sent = []
+    sb.kill_pid_escalating(
+        4321, term_timeout_s=5.0, _win=False,
+        _kill=lambda pid, sig: sent.append(sig),
+        _alive=lambda pid: False,         # died on SIGTERM
+        _sleep=lambda s: None,
+    )
+    assert sent == [sb._SIGTERM]
+
+
+def test_windows_is_single_taskkill():
+    sent = []
+    sb.kill_pid_escalating(4321, _win=True, _kill=lambda pid, sig: sent.append(sig))
+    assert sent == [sb._TASKKILL]
+
+
+# ── heal_split_brain reaps the orphan, no-op when healthy (AC-3) ──────────────
+def test_heal_reaps_orphan():
+    killed = []
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({7778: 26138, 7777: 49019}))
+    reaped = sb.heal_split_brain(rep, killer=lambda pid, t: killed.append(pid))
+    assert reaped == 49019
+    assert killed == [49019]
+
+
+def test_heal_healthy_is_noop():
+    killed = []
+    rep = sb.detect_split_brain(7778, 7777, owner=_owner_map({7778: 100, 7777: 100}))
+    assert sb.heal_split_brain(rep, killer=lambda pid, t: killed.append(pid)) is None
+    assert killed == []
+
+
+# ── restart sentinel: fresh vs stale (NFR-2) ─────────────────────────────────
+@pytest.fixture
+def data_dir_tmp(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    return tmp_path
+
+
+def test_restart_sentinel_fresh_then_cleared(data_dir_tmp):
+    assert data_dir.restart_in_progress() is False        # absent
+    data_dir.write_restart_sentinel(1234)
+    assert data_dir.restart_in_progress() is True         # fresh
+    data_dir.clear_restart_sentinel()
+    assert data_dir.restart_in_progress() is False        # cleared
+
+
+def test_stale_sentinel_is_ignored(data_dir_tmp):
+    data_dir.write_restart_sentinel(1234)
+    # ttl_s=0 models a sentinel older than its TTL: a crash mid-restart must NOT
+    # disable recovery forever (NFR-2).
+    assert data_dir.restart_in_progress(ttl_s=0.0) is False

--- a/services/prism-service/tests/unit/test_supervisor.py
+++ b/services/prism-service/tests/unit/test_supervisor.py
@@ -1,0 +1,64 @@
+"""GH #181 — the supervisor must NOT fire a competing recovery during an
+auto-update restart (AC-5).
+
+The out-of-process supervisor probes ONLY the UI port. During the auto-update
+re-exec the UI hangs (drain + cold boot); without a guard the supervisor would
+SIGKILL + respawn the worker and stack a SECOND daemon family — the split-brain.
+A fresh restart sentinel makes it DEFER; a stale/cleared sentinel lets normal
+wedge recovery resume.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prism_service.services import supervisor as sup
+
+
+@pytest.fixture
+def no_grace_state(monkeypatch):
+    # Disable the unrelated cold-boot startup grace so we isolate the restart
+    # sentinel behaviour, and stop real kills/respawns from ever running.
+    monkeypatch.setattr(sup, "_in_startup_grace", lambda state: False)
+    monkeypatch.setattr(sup, "failure_threshold", lambda: 3)
+    fired = {"kills": 0, "respawns": 0}
+    monkeypatch.setattr(sup, "force_kill", lambda pid: fired.__setitem__("kills", fired["kills"] + 1))
+
+    def _respawn():
+        fired["respawns"] += 1
+        return 999
+
+    monkeypatch.setattr(sup, "respawn_server", _respawn)
+    state = sup.SupervisorState(server_pid=123)
+    state.spawned_at = None
+    return state, fired
+
+
+def test_hung_probes_during_restart_do_not_recover(no_grace_state, monkeypatch):
+    state, fired = no_grace_state
+    monkeypatch.setattr(sup, "_restart_in_progress", lambda: True)  # fresh sentinel
+    # Far more hung probes than the failure threshold — must NEVER recover.
+    for _ in range(10):
+        assert sup.handle_probe_result(state, alive=False) is False
+    assert fired["respawns"] == 0
+    assert fired["kills"] == 0
+    assert state.consecutive_failures == 0   # streak not even accrued
+
+
+def test_recovery_resumes_when_no_restart_in_progress(no_grace_state, monkeypatch):
+    state, fired = no_grace_state
+    monkeypatch.setattr(sup, "_restart_in_progress", lambda: False)  # no sentinel
+    recovered = False
+    for _ in range(3):                        # threshold == 3
+        recovered = sup.handle_probe_result(state, alive=False) or recovered
+    assert recovered is True
+    assert fired["respawns"] == 1
+    assert fired["kills"] == 1
+
+
+def test_dead_process_not_respawned_during_restart(no_grace_state, monkeypatch):
+    # A worker mid os.execv re-exec must not be respawned over (handle_liveness).
+    state, fired = no_grace_state
+    monkeypatch.setattr(sup, "_restart_in_progress", lambda: True)
+    assert sup.handle_liveness(state, pid_alive=False) is False
+    assert fired["respawns"] == 0


### PR DESCRIPTION
Closes #181.

## Problem
A successful live auto-update left **two daemon families**, each owning ONE port (new UI on `:7778`, orphaned old worker squatting `:7777`/MCP) while `prism status` + `/api/version` reported green — every MCP caller silently stranded on the stale daemon.

**Root cause:** one healthy process owns BOTH ports — UI on the main-thread uvicorn, MCP on a daemon-thread uvicorn (`main.py run_mcp_server`). `perform_restart` drains only the UI server and the out-of-process supervisor probes only the UI port, so during the re-exec drain + cold-boot the UI hangs, the supervisor fires a **competing** `force_kill`+respawn (or a 2nd `prism start` slips the pidfile guard), stacking a second family.

## Fix (4 layers, addresses all 4 asks in the issue)
1. **NEW `services/split_brain.py`** — stdlib-only `port_owner_pid` (Windows `netstat -ano`, POSIX `ss`/`lsof`), `detect_split_brain` (two distinct pids one-per-port = split; one pid owning both = healthy; conservative — never a false positive), `kill_pid_escalating` (SIGTERM→SIGKILL; the orphan **ignored SIGTERM**), `heal_split_brain`.
2. **Restart sentinel (`data_dir.py`, TTL-bounded)** — `perform_restart` writes it before draining, the re-exec'd server clears it on healthy boot (`main.py`), and the **supervisor defers its competing recovery while it's fresh** (the seam that prevents the 2nd family); a stale sentinel is ignored so a crash can't wedge recovery forever.
3. **`cmd_start` port-level guard** — refuses to start if the UI port already answers or the MCP port is held, regardless of pidfile state (the absent/mid-rotation window).
4. **`cmd_status` self-check** → reports UNHEALTHY + reaps the orphan + non-zero exit instead of false-green; **`cmd_stop`** sweeps a port-squatting orphan with the escalating kill.

Disabling auto-update was explicitly not acceptable — the fix lives in the application.

## Verification
- `pytest tests/unit` = **940 passed, 0 failed**; 105 touched-area tests green incl. all existing auto-update/supervisor/pidfile suites (no regressions).
- RED proven pre-impl (ImportError without `split_brain.py`).
- **Real host:** live `prism status` (v6.7.9) vs the running dev daemon → exit 0, no UNHEALTHY; detector → `single owner pid 5556 holds both ports` (Windows `netstat` port→pid mapping confirmed on the actual host).

Driven through the PRISM conductor SDLC (task 3fc005c5; story/plan rubric gates passed without override; decision recorded mx-f7783e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)