### PR TITLE
fix(understand): real symbol kinds + lines in the artifact/ContextRail outline

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,14 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.21"
+PRISM_VERSION = "6.7.22"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.22: artifact/understand OUTLINE now shows REAL symbol kinds + lines (class/function, "
+    ":line) from the Brain index instead of the graph entities table, which stored "
+    "kind=unknown/line=0 and listed imported names. build_understanding now sources the "
+    "per-file outline from brain.outline(); graph entities are a fallback only. "
     "v6.7.21: xref resolver strips a trailing :line / :line-range from file citations "
     "(the ubiquitous path:NN form, e.g. models/task.py:60) so they resolve to the file "
     "instead of reading as unresolved. "

--- a/services/prism-service/prism_service/services/understand_view.py
+++ b/services/prism-service/prism_service/services/understand_view.py
@@ -119,7 +119,7 @@ def build_understanding(
     central_all = graph.top_central_entities(limit=200)
 
     if seed_files:
-        return _focus_files(graph, communities, central_all, seed_files,
+        return _focus_files(brain, graph, communities, central_all, seed_files,
                             label or "selected cluster", limit, depth)
     q = (query or "").strip()
     if not q:
@@ -217,11 +217,11 @@ def _focus(brain, graph, communities, central_all, q: str,
         if f and f not in seen_files:
             seen_files.add(f)
             seed_files.append(f)
-    return _assemble(graph, communities, central_all, seed_files, ranked,
+    return _assemble(brain, graph, communities, central_all, seed_files, ranked,
                      q, depth)
 
 
-def _focus_files(graph, communities, central_all, files: list[str],
+def _focus_files(brain, graph, communities, central_all, files: list[str],
                  label: str, limit: int, depth: int) -> dict:
     """Cluster/selection-seeded view — the canvas posts a set of files (a
     clicked community/super-node, or a single node) and we drive the full
@@ -251,11 +251,30 @@ def _focus_files(graph, communities, central_all, files: list[str],
             ranked.append({"entity_id": f, "name": _basename(f),
                            "kind": "file", "file": f, "score": 0.0,
                            "why": f"in {label}"})
-    return _assemble(graph, communities, central_all, want, ranked,
+    return _assemble(brain, graph, communities, central_all, want, ranked,
                      label, depth)
 
 
-def _assemble(graph, communities, central_all, seed_files: list[str],
+def _file_outline(brain, f: str, fd: dict) -> list[dict]:
+    """Defined-symbol outline with REAL kinds + lines from the Brain
+    ({name, kind, line}); the graph entities table stores kind='unknown'/line=0
+    and includes referenced imports, so it is only the fallback when the Brain
+    has nothing indexed for this file."""
+    try:
+        rows = brain.outline(f) if brain is not None else []
+    except Exception:
+        rows = []
+    if rows:
+        return [
+            {"name": r.get("entity_name") or "",
+             "kind": r.get("entity_kind") or "",
+             "line": r.get("line_start") or 0}
+            for r in rows[:30]
+        ]
+    return fd.get("entities", [])[:30]
+
+
+def _assemble(brain, graph, communities, central_all, seed_files: list[str],
               ranked: list[dict], query: str, depth: int) -> dict:
     """Shared subgraph + context assembly for both focus paths. Given the
     seed files and a ranked list, expands 1-hop neighbors, builds the
@@ -362,7 +381,7 @@ def _assemble(graph, communities, central_all, seed_files: list[str],
             "entity_id": f,
             "file": f,
             "community": file_comm.get(f),
-            "outline": fd.get("entities", [])[:30],
+            "outline": _file_outline(brain, f, fd),
             "references": fd.get("inbound", []),
             "call_chain": fd.get("outbound", []),
             "chunks": chunks,

--- a/services/prism-service/prism_service/web/src/pages/ArtifactPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ArtifactPage.tsx
@@ -393,7 +393,7 @@ function ContextSpine({ sel, loading }: { sel?: Ctx; loading: boolean }) {
                 {sel.outline.map((o, i) => (
                   <li key={i} className="flex items-baseline gap-2 text-xs">
                     <span className="font-mono truncate">{o.name}</span>
-                    <span className="opacity-40">{o.kind}{o.line ? ` :${o.line}` : ""}</span>
+                    <span className="opacity-40">{o.kind && o.kind !== "unknown" ? o.kind : ""}{o.line ? ` :${o.line}` : ""}</span>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Problem
The `/artifact` (and `/brain` ContextRail) **OUTLINE** showed every symbol as `unknown` with `:0` lines — e.g. `Conductor unknown` — and listed referenced imports (`Path`, `ValueError`, `Counter`), not the file's real symbols.

## Cause
The outline read `graph.file_detail()`'s `entities` table, which graphify populated with `kind="unknown"` / `line=0`. The **Brain index** had the clean data all along.

## Fix
`build_understanding` now sources the per-file outline from `brain.outline()` (`entity_name`/`entity_kind`/`line_start` → `name`/`kind`/`line`): **defined symbols only, real `class`/`function` kinds + line numbers**. Graph entities remain the fallback. `ArtifactPage` also defensively hides any residual `unknown`/`:0`.

## Validation
- Full unit suite **954 passed**.
- Live-verified on dev 6.7.22: `is_weak_proof function :30`, `board_health function :175`, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)