### PR TITLE
fix(tasks): WHAT'S NEXT card unwraps the {task, reason} envelope

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,19 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.22"
+PRISM_VERSION = "6.7.23"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.23: tasks board WHAT'S NEXT card no longer renders as a blank "
+    "bordered box. /api/tasks/next wraps the recommendation in a "
+    "{task, reason} envelope (task_next claim/lease) but TasksPage still "
+    "consumed d.next as the task row itself — truthy envelope, undefined "
+    "title/id, empty card. The SPA now unwraps the envelope (tolerating the "
+    "legacy bare-task shape), treats only a task WITH an id as a "
+    "recommendation (anything else falls through to the explicit 'Queue is "
+    "clear.' empty state), and surfaces the recommendation reason line on "
+    "the card. "
     "v6.7.22: artifact/understand OUTLINE now shows REAL symbol kinds + lines (class/function, "
     ":line) from the Brain index instead of the graph entities table, which stored "
     "kind=unknown/line=0 and listed imported names. build_understanding now sources the "

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -66,10 +66,25 @@ export default function TasksPage() {
   const reduced = useReducedMotion();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [next, setNext] = useState<Task | null>(null);
+  const [nextReason, setNextReason] = useState("");
 
   const load = useCallback(() => {
     api.get<{ tasks: Task[] }>(`/api/tasks?project=${project}`).then((d) => setTasks(d.tasks)).catch(() => setTasks([]));
-    api.get<{ next: Task | null }>(`/api/tasks/next?project=${project}`).then((d) => setNext(d.next)).catch(() => setNext(null));
+    // /api/tasks/next wraps the recommendation in a {task, reason} envelope
+    // (task_next claim/lease); older builds returned the bare task. Accept
+    // both — and only a task carrying an id counts as a recommendation, so
+    // anything else falls through to the explicit Empty state, never a
+    // blank card.
+    type NextEnvelope = { task?: Task | null; reason?: string };
+    api.get<{ next: NextEnvelope | Task | null }>(`/api/tasks/next?project=${project}`)
+      .then((d) => {
+        const raw = d.next;
+        const t = raw && typeof raw === "object" && "task" in raw ? (raw as NextEnvelope).task : (raw as Task | null);
+        setNext(t?.id ? t : null);
+        const reason = raw && typeof raw === "object" && "reason" in raw ? (raw as NextEnvelope).reason : "";
+        setNextReason(reason || "");
+      })
+      .catch(() => { setNext(null); setNextReason(""); });
   }, [project]);
 
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
@@ -99,6 +114,7 @@ export default function TasksPage() {
             className="text-sm text-left hover:opacity-100 w-full"
           >
             <div className="font-medium hover:underline decoration-dotted underline-offset-2">{next.title ?? next.id}</div>
+            {nextReason && <div className="text-xs opacity-70 mt-1">{nextReason}</div>}
             <div className="text-xs opacity-60 mt-1 font-mono">{next.id}</div>
           </button>
         ) : (


### PR DESCRIPTION
## Summary
The tasks board **What's next** card rendered as a blank bordered box: `/api/tasks/next` wraps the recommendation in a `{task, reason}` envelope (task_next claim/lease), but `TasksPage.tsx` consumed `d.next` as the task row itself — a truthy envelope with undefined `title`/`id` rendered an empty card instead of the recommendation or the `Empty` fallback.

- Unwrap the envelope tolerantly (legacy bare-task shape still accepted)
- Only a task carrying an `id` counts as a recommendation; anything else falls through to the explicit "Queue is clear." empty state
- Surface the recommendation `reason` line on the card
- `PRISM_VERSION` 6.7.22 → 6.7.23

Driven through the conductor SDLC as task `a511cf06` (PRISM hardening backlog / stress-loop); story_gate, plan_gate, red_gate, and green_gate all passed mechanically (proof_type=artifact, before/after screenshots against the live API).

## Proof
- **Before**: WHAT'S NEXT is an empty bordered box while the API returns a full envelope
- **After**: card shows "G0 - PRISM-score metric + enforced verifier boundary" + "Highest priority unblocked task: priority=10" + task id, rendered against live board data
- **Empty queue**: explicit "Queue is clear." state
- `npm run build` (tsc -b && vite build) exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)