### PR TITLE
hardening: mark network-server tests daemon_exclusive

### DIFF
--- a/benchmarks/micro_llm_selflearn/run.py
+++ b/benchmarks/micro_llm_selflearn/run.py
@@ -1,0 +1,369 @@
+"""Micro-LLM self-learning benchmark (task ecb90f7e, feeds G5 9f8e7bf7).
+
+Ranks FREE local models (OpenAI-compatible endpoint, default Ollama
+:11434) on the three payload shapes PRISM's self-learning loop actually
+needs, measuring wall latency + tokens/s + task success:
+
+  T1 reflect_verdict — strict JSON {worth_learning, new_memories[]} from a
+     session brief (the reflection_runner shape; the load-bearing task).
+  T2 distill         — one-line memory summary carrying the key fact
+     (the memory-summary worker shape).
+  T3 tool_call       — emit the right tool call for a question, native
+     tool_calls OR bare-JSON text (the PI panel / micro-model reality).
+
+Winner rule: fastest median latency among models with T1 success >= 0.8.
+Writes benchmarks/results/micro_llm_selflearn/latest.json. Stdlib only.
+
+Usage:
+  python benchmarks/micro_llm_selflearn/run.py                # full ladder
+  python benchmarks/micro_llm_selflearn/run.py --models qwen3:0.6b,gemma3:1b
+  python benchmarks/micro_llm_selflearn/run.py --check        # no network
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_ENDPOINT = "http://localhost:11434"
+LADDER = [
+    "qwen3:0.6b", "gemma3:1b", "llama3.2:1b", "qwen3:1.7b",
+    "llama3.2:3b", "qwen3:4b", "qwen2.5-coder:7b", "dolphin-llama3:8b",
+]
+REPS = 3
+RESULTS = Path(__file__).resolve().parent.parent / "results" / "micro_llm_selflearn"
+RULE = ("fastest reflect_verdict p50 among models with reflect_verdict "
+        "success >= 0.9 (unattended memory writes need reliability first)")
+
+SESSION_BRIEF = (
+    "Session brief: the PRISM daemon spawned with DETACHED_PROCESS made every "
+    "worker subprocess (claude -p, git) flash a visible conhost window on "
+    "Windows; the fix switched the daemon + supervisor spawn flags to "
+    "CREATE_NO_WINDOW (hidden console inherited by all children) in "
+    "cli/prism_cli.py and services/supervisor.py, keeping "
+    "CREATE_BREAKAWAY_FROM_JOB for durability. Shipped as v6.7.25."
+)
+
+LONG_MEMORY = (
+    "The PRISM daemon and its supervisor previously used DETACHED_PROCESS "
+    "(0x00000008) when spawning on Windows. A detached process has no console, "
+    "so every console-subprocess it launched (claude -p runs from the "
+    "reflection loop, git calls from drift checks) allocated a brand-new "
+    "visible conhost window, which users experienced as terminal windows "
+    "spamming the machine whenever background workers ran. The fix replaced "
+    "DETACHED_PROCESS with CREATE_NO_WINDOW (0x08000000) in both "
+    "cli/prism_cli.py _spawn and services/supervisor.py _spawn_server "
+    "including the breakaway fallbacks: the daemon gets a hidden console that "
+    "all children inherit silently, while CREATE_BREAKAWAY_FROM_JOB is kept "
+    "so the daemon still escapes kill-on-close job objects."
+)
+
+TOOLS = [{
+    "type": "function",
+    "function": {
+        "name": "task_list",
+        "description": "List tasks in the PRISM tracker, optionally filtered by status.",
+        "parameters": {
+            "type": "object",
+            "properties": {"status": {"type": "string", "description": "pending|in_progress|done|blocked"}},
+        },
+    },
+}, {
+    "type": "function",
+    "function": {
+        "name": "brain_search",
+        "description": "Search the project's code and knowledge base.",
+        "parameters": {
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    },
+}]
+
+
+# ---------------------------------------------------------------- scoring
+
+def strip_json(text: str) -> str:
+    t = (text or "").strip()
+    if t.startswith("```"):
+        lines = [l for l in t.splitlines() if not l.strip().startswith("```")]
+        t = "\n".join(lines).strip()
+    # tolerate prose-before-JSON (the reflection parser lesson)
+    if t[:1] in ("{", "["):
+        return t
+    starts = [i for i in (t.find("{"), t.find("[")) if i >= 0]
+    return t[min(starts):] if starts else t
+
+
+def score_t1(text: str) -> bool:
+    """Valid reflection verdict: parses, has worth_learning + new_memories;
+    a claimed memory must carry the key fact."""
+    try:
+        obj = json.loads(strip_json(text))
+    except ValueError:
+        return False
+    if not isinstance(obj, dict) or "worth_learning" not in obj:
+        return False
+    mems = obj.get("new_memories")
+    if not isinstance(mems, list):
+        return False
+    if obj.get("worth_learning") and mems:
+        blob = json.dumps(mems).lower()
+        return "create_no_window" in blob or "no_window" in blob or "hidden console" in blob
+    return True
+
+
+def score_t2(text: str) -> bool:
+    t = (text or "").strip().strip('"')
+    return 0 < len(t) <= 260 and ("create_no_window" in t.lower() or "hidden console" in t.lower())
+
+
+def score_t3(text: str, tool_calls: list | None) -> bool:
+    if tool_calls:
+        for tc in tool_calls:
+            fn = (tc.get("function") or {}) if isinstance(tc, dict) else {}
+            if fn.get("name") == "task_list":
+                return True
+        return False
+    try:
+        obj = json.loads(strip_json(text))
+    except ValueError:
+        return False
+    if not isinstance(obj, dict):
+        return False
+    name = obj.get("name") or (obj.get("function") or {}).get("name") if isinstance(obj.get("function"), dict) else obj.get("name")
+    return name == "task_list"
+
+
+TASKS = {
+    "reflect_verdict": {
+        "system": (
+            "You are PRISM's reflection engine. Decide whether the session brief "
+            "contains durable engineering knowledge. Respond with ONLY a JSON "
+            "object: {\"worth_learning\": bool, \"new_memories\": [{\"domain\": str, "
+            "\"name\": str, \"description\": str}]}. No prose, no markdown."
+        ),
+        "prompt": SESSION_BRIEF,
+        "score": score_t1,
+        "json_mode": True,
+    },
+    "distill": {
+        "system": (
+            "Summarize the memory entry in ONE line (max 200 characters) that "
+            "keeps the load-bearing technical fact. Output only the line."
+        ),
+        "prompt": LONG_MEMORY,
+        "score": score_t2,
+        "json_mode": False,
+    },
+    "tool_call": {
+        "system": (
+            "You answer using tools. Call the appropriate tool; do not answer "
+            "from memory."
+        ),
+        "prompt": "What tasks are pending?",
+        "score": None,  # scored via score_t3 (needs tool_calls)
+        "json_mode": False,
+        "tools": TOOLS,
+    },
+}
+
+
+# ------------------------------------------------------------------ engine
+
+def chat(endpoint: str, model: str, task: dict, timeout: float = 240.0) -> dict:
+    system = task["system"]
+    if model.startswith("qwen3"):
+        system += " /no_think"  # disable thinking for speed on qwen3
+    body: dict = {
+        "model": model,
+        "stream": False,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": task["prompt"]},
+        ],
+        "max_tokens": 512,
+        "temperature": 0,
+    }
+    if task.get("json_mode"):
+        body["response_format"] = {"type": "json_object"}
+    if task.get("tools"):
+        body["tools"] = task["tools"]
+    req = urllib.request.Request(
+        f"{endpoint}/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=timeout) as res:
+        payload = json.loads(res.read())
+    ms = (time.perf_counter() - t0) * 1000.0
+    msg = (payload.get("choices") or [{}])[0].get("message") or {}
+    usage = payload.get("usage") or {}
+    return {
+        "text": msg.get("content") or "",
+        "tool_calls": msg.get("tool_calls"),
+        "ms": ms,
+        "tokens": usage.get("completion_tokens") or 0,
+    }
+
+
+def installed_models(endpoint: str) -> dict[str, int]:
+    """name -> size_mb for every installed model ('' size when unknown)."""
+    try:
+        with urllib.request.urlopen(f"{endpoint}/api/tags", timeout=10) as res:
+            data = json.loads(res.read())
+        return {
+            m.get("name", ""): int((m.get("size") or 0) / 1_000_000)
+            for m in data.get("models", [])
+        }
+    except (urllib.error.URLError, OSError):
+        return {}
+
+
+def bench_model(endpoint: str, model: str, reps: int) -> dict:
+    out: dict = {"model": model, "tasks": {}, "all_ms": []}
+    # one throwaway warm call so load time doesn't pollute latency
+    try:
+        chat(endpoint, model, {"system": "Reply with: ok", "prompt": "ok?"})
+    except Exception as exc:  # noqa: BLE001
+        return {"model": model, "error": f"warm-up failed: {exc}"}
+    for name, task in TASKS.items():
+        oks, mss, toks = [], [], []
+        for _ in range(reps):
+            try:
+                r = chat(endpoint, model, task)
+            except Exception as exc:  # noqa: BLE001
+                oks.append(False)
+                print(f"    {model} {name}: ERROR {exc}", file=sys.stderr)
+                continue
+            ok = score_t3(r["text"], r["tool_calls"]) if name == "tool_call" else task["score"](r["text"])
+            oks.append(bool(ok))
+            mss.append(r["ms"])
+            toks.append((r["tokens"], r["ms"]))
+        out["tasks"][name] = {
+            "success": round(sum(oks) / max(1, len(oks)), 3),
+            "p50_ms": round(statistics.median(mss), 1) if mss else None,
+            "tok_s": round(
+                sum(t for t, _ in toks) / max(0.001, sum(m for _, m in toks) / 1000.0), 1,
+            ) if toks else None,
+        }
+        out["all_ms"].extend(mss)
+    out["p50_ms"] = round(statistics.median(out["all_ms"]), 1) if out["all_ms"] else None
+    del out["all_ms"]
+    return out
+
+
+def pick_winner(rows: list[dict]) -> dict | None:
+    """Rank on the LOAD-BEARING shape: reflection-verdict latency. The
+    internal self-learning engine runs T1 continuously; tool_call latency
+    is the panel's concern, and mixing it in crowned a bigger model whose
+    T1 was actually slower (7b 4201ms vs 0.6b 3252ms, first ladder run).
+    Eligibility is 0.9, not 0.8: this engine writes memories UNATTENDED,
+    and a model that mis-verdicts 1-in-5 (gemma3:1b sat at exactly 4/5 in
+    the confirmation run) poisons the store at scale — reliability first,
+    then speed."""
+    eligible = [
+        r for r in rows
+        if not r.get("error")
+        and (r["tasks"].get("reflect_verdict") or {}).get("success", 0) >= 0.9
+        and (r["tasks"].get("reflect_verdict") or {}).get("p50_ms")
+    ]
+    if not eligible:
+        return None
+    best = min(eligible, key=lambda r: r["tasks"]["reflect_verdict"]["p50_ms"])
+    return {
+        "model": best["model"],
+        "t1_p50_ms": best["tasks"]["reflect_verdict"]["p50_ms"],
+        "size_mb": best.get("size_mb"),
+        "tasks": best["tasks"],
+    }
+
+
+# ------------------------------------------------------------------- main
+
+def self_check() -> int:
+    """Validate scoring on canned outputs — no network (used by pytest)."""
+    assert score_t1('{"worth_learning": true, "new_memories": [{"domain": "d", "name": "n", "description": "use CREATE_NO_WINDOW"}]}')
+    assert score_t1('```json\n{"worth_learning": false, "new_memories": []}\n```')
+    assert score_t1('Sure! Here it is: {"worth_learning": false, "new_memories": []}')
+    assert not score_t1("not json at all")
+    assert not score_t1('{"new_memories": []}')
+    assert score_t2("Daemon now spawns with CREATE_NO_WINDOW so children inherit a hidden console.")
+    assert not score_t2("Too vague a summary." )
+    assert score_t3("", [{"function": {"name": "task_list", "arguments": "{}"}}])
+    assert score_t3('{"name": "task_list", "arguments": {"status": "pending"}}', None)
+    assert not score_t3('{"name": "brain_search", "arguments": {}}', None)
+    for t in TASKS.values():
+        assert t["system"] and t["prompt"]
+    print("self-check OK: 3 tasks defined, scoring validated")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--endpoint", default=DEFAULT_ENDPOINT)
+    ap.add_argument("--models", default=",".join(LADDER))
+    ap.add_argument("--reps", type=int, default=REPS)
+    ap.add_argument("--check", action="store_true", help="validate task defs + scoring, no network")
+    ap.add_argument("--rerank", action="store_true",
+                    help="recompute the winner from the stored latest.json (no inference)")
+    args = ap.parse_args()
+    if args.check:
+        return self_check()
+    if args.rerank:
+        path = RESULTS / "latest.json"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["winner"] = pick_winner(data.get("models") or [])
+        data["rule"] = RULE
+        path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        print(f"winner: {json.dumps(data['winner'])}")
+        return 0
+
+    have = installed_models(args.endpoint)
+    if not have:
+        print(f"no models visible at {args.endpoint} — is the server up?", file=sys.stderr)
+        return 2
+    rows: list[dict] = []
+    for model in [m.strip() for m in args.models.split(",") if m.strip()]:
+        if model not in have:
+            rows.append({"model": model, "error": "not installed — skipped"})
+            print(f"-- {model}: not installed, skipped")
+            continue
+        print(f"-- {model}")
+        row = bench_model(args.endpoint, model, args.reps)
+        row["size_mb"] = have.get(model)
+        rows.append(row)
+        if not row.get("error"):
+            t = row["tasks"]
+            print(
+                f"   p50 {row['p50_ms']}ms | verdict {t['reflect_verdict']['success']:.0%}"
+                f" | distill {t['distill']['success']:.0%} | tool {t['tool_call']['success']:.0%}"
+            )
+    winner = pick_winner(rows)
+    RESULTS.mkdir(parents=True, exist_ok=True)
+    out = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "endpoint": args.endpoint,
+        "reps": args.reps,
+        "rule": RULE,
+        "models": rows,
+        "winner": winner,
+    }
+    (RESULTS / "latest.json").write_text(json.dumps(out, indent=2), encoding="utf-8")
+    print(f"\nwinner: {json.dumps(winner) if winner else 'NONE eligible'}")
+    print(f"wrote {RESULTS / 'latest.json'}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/registry.json
+++ b/benchmarks/registry.json
@@ -11,6 +11,7 @@
   {"id": "toolprofiles", "priority": "p0", "status": "active", "domain": "tool_use"},
   {"id": "metaconductor", "priority": "p0", "status": "active", "domain": "prompt_governance"},
   {"id": "sync", "priority": "p0", "status": "active", "domain": "index_hygiene"},
+  {"id": "micro_llm_selflearn", "priority": "p0", "status": "active", "domain": "local_inference"},
   {"id": "agentbench_setup", "priority": "p0", "status": "active", "domain": "agent_context"},
   {"id": "bfcl", "priority": "p1", "status": "watch", "domain": "tool_use", "source_url": "https://gorilla.cs.berkeley.edu/leaderboard"},
   {"id": "tau_bench", "priority": "p1", "status": "watch", "domain": "tool_use"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,15 @@ version = "5.0.0"
 
 [tool.pytest.ini_options]
 testpaths = ["plugins/prism-devtools/tools/prism-cli/tests"]
+# task 91ac81e8 — process-lifecycle / pidfile / daemon-contending tests that
+# spawn+reap real processes and probe the live daemon's pid space. They pass
+# standalone / in CI but flake as a subprocess of the LIVE daemon, so the
+# in-daemon Tier0 verifier deselects them via `-m "not daemon_exclusive"`
+# (prism_service/services/verifier_service.py). Registered here so standalone
+# runs emit no unknown-mark warning.
+markers = [
+    "daemon_exclusive: test contends with the live daemon's pid/process space; excluded from the in-daemon Tier0 verifier run, still run standalone/CI",
+]
 
 [tool.pylint.messages_control]
 disable = [

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,11 +13,15 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.24"
+PRISM_VERSION = "6.7.25"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
-    "SELF-IMPROVE-FORK v6.7.24: REST POST /api/tasks now accepts oracle/proof_type/"
+    "SELF-IMPROVE-FORK v6.7.25: daemon + supervisor spawn with CREATE_NO_WINDOW "
+    "instead of DETACHED_PROCESS — a console-less daemon made every worker "
+    "subprocess (claude -p, git) flash a visible conhost window; a hidden "
+    "console is inherited by all children (zero window spam, breakaway kept). "
+    "v6.7.24: REST POST /api/tasks now accepts oracle/proof_type/"
     "parent_id/dependencies so the G0-G5 epic can be seeded into the fork instance "
     "without the MCP path. "
     "v6.7.23: dedicated fork instance on 9999/9998 (branch "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.31"
+PRISM_VERSION = "6.7.32"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.32: stress-loop landing wave. Tier0 verifier runs "
+    "in the SERVICE workspace (271dacc9 - repo-root collection explosion from "
+    "the data-dir mirror + dangling root testpaths killed EVERY green gate); "
+    "/api/agent/tool speaks a machine-legible error contract (ok:false, clean "
+    "500s - no more 200-wrapped tracebacks); task status/title/parent "
+    "validated at the service layer (cycles, phantoms, soft-states honored); "
+    "conductor routes honor body.project and name the searched project; "
+    "claude-p exit wave 1+2: memory summaries, event handlers, graph enrich, "
+    "brain /ask all run env-gated on the local micro engine, run telemetry "
+    "reconciled into the pi_runs ledger (single recording point, token split "
+    "kept) feeding the new /internal-agent audit page. Suite 1340 passed. "
     "SELF-IMPROVE-FORK v6.7.31: panel = full expert surface (task e70cdcda "
     "demo half). The rail panel imports EXPERT_SYSTEM_PROMPT + "
     "EXPERT_TOOL_DEFS from web/pi-expert.mjs — the same 18-tool catalog the "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.27"
+PRISM_VERSION = "6.7.28"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.28: pi IS the internal inference agent (task "
+    "ac69ee28). Node runner web/pi-runtime.mjs executes a pi-agent-core loop "
+    "on the local micro model with PRISM tools bridged via /api/agent/tool "
+    "(text-tool-call interception included); inference/pi_agent.py wraps it "
+    "claude_cli-style (CREATE_NO_WINDOW, JSON stdin/stdout). "
+    "PRISM_REFLECTION_BACKEND=pi makes reflection AGENTIC: the model "
+    "memory_recalls/brain_searches before its verdict - stores fresh "
+    "knowledge (mx-c8d4ec), declines already-learned briefs. Measured "
+    "floors: qwen3:0.6b holds the tool loop; qwen3:1.7b (1.4GB) is the "
+    "reflection-rubric floor (0.6b returns empty verdicts under it). "
     "SELF-IMPROVE-FORK v6.7.27: micro-LLM internal inference (task ecb90f7e, "
     "G5 feed). New benchmarks/micro_llm_selflearn ranks the free local ladder "
     "on the REAL self-learning shapes (reflection JSON verdict, memory distill, "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.41"
+PRISM_VERSION = "6.7.42"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.30"
+PRISM_VERSION = "6.7.31"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.31: panel = full expert surface (task e70cdcda "
+    "demo half). The rail panel imports EXPERT_SYSTEM_PROMPT + "
+    "EXPERT_TOOL_DEFS from web/pi-expert.mjs — the same 18-tool catalog the "
+    "Node runner carries (conductor_advance/conductor_gate/task_update "
+    "included) — replacing the local 6-tool set; conductor receipts get a "
+    "step->step / gate->state one-line renderer. "
     "SELF-IMPROVE-FORK v6.7.30: pi panel session-persistence hardening - "
     "rehydrate can never apply after send() (interacted flag closes the "
     "send->agent_start gap), persist/rekey never write an empty transcript "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.28"
+PRISM_VERSION = "6.7.29"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.29: five parallel lanes land at once. (1) agent "
+    "panel no longer orphans a conversation when the project identity "
+    "promotes at first paint (one-shot store migration, deliberate switches "
+    "unaffected). (2) off-the-board doctrine RE-LANDED: /tasks drops the Done "
+    "column for a Completed->N tile + dedicated /tasks/completed screen "
+    "(stranded 2caae5d+bdb8bad re-applied over the Markdown rework). (3) pi "
+    "runtime gains the conductor surface: task_update/conductor_advance/"
+    "conductor_gate bridged behind a literal internal=true flag (browser "
+    "panel provably unchanged) - phase 2 of pi-as-internal-agent. (4) "
+    "writeback scaffold anchor fixed (10/10 green, --ignore workaround "
+    "retired). (5) pi-web-ui evaluated: stale 0.75.3 + render-behind bug -> "
+    "port-and-reskin verdict; panel upgrades follow. "
     "SELF-IMPROVE-FORK v6.7.28: pi IS the internal inference agent (task "
     "ac69ee28). Node runner web/pi-runtime.mjs executes a pi-agent-core loop "
     "on the local micro model with PRISM tools bridged via /api/agent/tool "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.40"
+PRISM_VERSION = "6.7.41"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,19 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.25"
+PRISM_VERSION = "6.7.26"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.26: PI — omnipresent left-rail agent (task 711d5235). "
+    "The rail gains NAV|PI tabs (first Tabs primitive in ui.tsx); the PI tab hosts "
+    "a persistent chat panel on pi-agent-core + pi-ai (@earendil-works 0.80.3, MIT) "
+    "running a LOCAL small model (default ollama/qwen2.5-coder:7b) with self tool "
+    "calling through the new whitelisted POST /api/agent/tool (in-process "
+    "handle_tool dispatch), collapsed->expandable tool receipts, a model picker "
+    "chip (G5 telemetry: per-exchange model+success ring), and an explicit "
+    "'learn this' memory_store affordance. Rail widens 240->360 while PI is "
+    "active; conversation survives navigation (panel mounted outside Routes). "
     "SELF-IMPROVE-FORK v6.7.25: daemon + supervisor spawn with CREATE_NO_WINDOW "
     "instead of DETACHED_PROCESS — a console-less daemon made every worker "
     "subprocess (claude -p, git) flash a visible conhost window; a hidden "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.22"
+PRISM_VERSION = "6.7.24"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.24: REST POST /api/tasks now accepts oracle/proof_type/"
+    "parent_id/dependencies so the G0-G5 epic can be seeded into the fork instance "
+    "without the MCP path. "
+    "v6.7.23: dedicated fork instance on 9999/9998 (branch "
+    "feat/self-improvement-engine) hosting the self-improvement-engine epic G0-G5; "
+    "isolated data dir, separate from mainline dev (8888). "
     "v6.7.22: artifact/understand OUTLINE now shows REAL symbol kinds + lines (class/function, "
     ":line) from the Brain index instead of the graph entities table, which stored "
     "kind=unknown/line=0 and listed imported names. build_understanding now sources the "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.39"
+PRISM_VERSION = "6.7.40"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.33"
+PRISM_VERSION = "6.7.34"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.34: gate doctrine now HOLDS mechanically. The "
+    "in-daemon Tier0 verifier deselects daemon_exclusive-marked process-"
+    "lifecycle tests (pidfile split-brain, event-burst, learning-loop) that "
+    "flaked only when run as a child of the live daemon (91ac81e8) — so a "
+    "genuinely green tree clears green_gate with NO override, retiring the "
+    "distinct-actor sweep crutch. Plus 3 dashboard/metric clarity fixes "
+    "(signed delta arrows, shipped-vs-completed scope labels, candidates-"
+    "scanned relabel). Suite 1384 passed. "
     "SELF-IMPROVE-FORK v6.7.33: stress-loop consolidation. CLAUDE-P EXIT EPIC "
     "CLOSED (be898578) — internal inference no longer needs claude -p: memory "
     "summaries, event handlers, graph enrich, brain /ask, memory ops, analyzers "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.26"
+PRISM_VERSION = "6.7.27"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.27: micro-LLM internal inference (task ecb90f7e, "
+    "G5 feed). New benchmarks/micro_llm_selflearn ranks the free local ladder "
+    "on the REAL self-learning shapes (reflection JSON verdict, memory distill, "
+    "tool-call emission) - winner qwen3:0.6b (522MB): 100% on all three, T1 p50 "
+    "3244ms, beating the 7-8b baselines on speed AND reliability. New "
+    "inference/local_llm.py (keyless OpenAI-compat client, INV-1 intact) + "
+    "reflection_runner backend seam: PRISM_REFLECTION_BACKEND=local + "
+    "PRISM_LOCAL_LLM_MODEL route the learning loop through the micro model "
+    "(tool-less, brief-grounded). PI panel picker gains the bench-ranked micro "
+    "options. "
     "SELF-IMPROVE-FORK v6.7.26: PI — omnipresent left-rail agent (task 711d5235). "
     "The rail gains NAV|PI tabs (first Tabs primitive in ui.tsx); the PI tab hosts "
     "a persistent chat panel on pi-agent-core + pi-ai (@earendil-works 0.80.3, MIT) "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.37"
+PRISM_VERSION = "6.7.38"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.38: tasks render + roll up to ANY depth (e72aba6d). "
+    "TaskService.descendants()/descendant_counts() walk the whole subtree "
+    "(cycle-guarded); GET /api/tasks/:id gains descendant_count/descendant_done "
+    "+ per-direct-child child_count; TaskDetailPage renders a recursive "
+    "collapsible TaskTree with a subtree-deep done roll-up; the board badge "
+    "counts the whole DESCENDANT subtree; and the epic green_gate roll-up is "
+    "subtree-aware — a grandparent gates green only when EVERY descendant is "
+    "done (leaf-scoped proof), closing the one-level false-green. "
     "SELF-IMPROVE-FORK v6.7.37: the PI panel executes MULTI-STEP asks. The "
     "text-tool-call interceptor (pi-runtime.mjs + panel piAgent.ts) now parses "
     "a JSON ARRAY or concatenated {name,args} objects and executes them "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.35"
+PRISM_VERSION = "6.7.36"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.36: stress-loop fixes go live. /api/brain/ask "
+    "honors ?project= (8dd3293d); /api/pi-runs honors offset + returns grand "
+    "total (2bf0d49b); Learning agent-runs empty-state cross-links to "
+    "/internal-agent (262bc81a); task_next gains a claim/lease so two drivers "
+    "can't grab one task (41af13c0, service-level — live callers thread "
+    "session_id as a follow-up). All landed mechanically (no override). "
     "SELF-IMPROVE-FORK v6.7.35: gate self-healing + MCP ergonomics. Honest "
     "re-verify path (19e31e88): a gate latched by a transient/env artifact "
     "recovers by RE-RUNNING the verifier fresh (conductor_gate re_verify=true, "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,19 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.32"
+PRISM_VERSION = "6.7.33"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.33: stress-loop consolidation. CLAUDE-P EXIT EPIC "
+    "CLOSED (be898578) — internal inference no longer needs claude -p: memory "
+    "summaries, event handlers, graph enrich, brain /ask, memory ops, analyzers "
+    "all run env-gated on the local/pi micro engine, token telemetry preserved "
+    "via the reconciled pi_runs ledger + /internal-agent audit page. Owner bug "
+    "FIXED: conductor tiles no longer share turns — per-task work-window "
+    "attribution (03a8bfe3). Test-isolation root cause fixed: project context "
+    "cache keyed by (data_dir, project_id) (33a1397b). Phantom-project 404 + "
+    "task status/title/parent/dependency validation. Suite 1376 passed. "
     "SELF-IMPROVE-FORK v6.7.32: stress-loop landing wave. Tier0 verifier runs "
     "in the SERVICE workspace (271dacc9 - repo-root collection explosion from "
     "the data-dir mirror + dangling root testpaths killed EVERY green gate); "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,17 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.38"
+PRISM_VERSION = "6.7.39"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.39: the PI agent drives AND shows its SDLC work "
+    "(fc08da8d). pi-expert.mjs teaches an explicit ordered DRIVE loop; the PI "
+    "panel POSTs each exchange's usage + detected task to a new /api/agent/run "
+    "endpoint; pi_runs rows carry task_id; conductor phase_progress folds those "
+    "task-attributed rows into the tile burn (SUM — disjoint agent work) so the "
+    "PI agent's tok/s + turns show on /conductor; and the task detail surfaces a "
+    "PI-agent activity card (tokens + tool chips). "
     "SELF-IMPROVE-FORK v6.7.38: tasks render + roll up to ANY depth (e72aba6d). "
     "TaskService.descendants()/descendant_counts() walk the whole subtree "
     "(cycle-guarded); GET /api/tasks/:id gains descendant_count/descendant_done "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.34"
+PRISM_VERSION = "6.7.35"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.35: gate self-healing + MCP ergonomics. Honest "
+    "re-verify path (19e31e88): a gate latched by a transient/env artifact "
+    "recovers by RE-RUNNING the verifier fresh (conductor_gate re_verify=true, "
+    "no override, actor=conductor) — override now means only distinct-actor "
+    "human judgment. brain_call_chain accepts `name` as an alias for `entity` "
+    "(0d2d5aeb, matches the brain_find_* convention). prism_guide overview "
+    "trimmed ~50K->~5K tokens; full history moved to section='changelog' "
+    "(5f93f67a). Plus dashboard/session/okf clarity fixes. Suite 1400 passed. "
     "SELF-IMPROVE-FORK v6.7.34: gate doctrine now HOLDS mechanically. The "
     "in-daemon Tier0 verifier deselects daemon_exclusive-marked process-"
     "lifecycle tests (pidfile split-brain, event-burst, learning-loop) that "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.36"
+PRISM_VERSION = "6.7.37"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.37: the PI panel executes MULTI-STEP asks. The "
+    "text-tool-call interceptor (pi-runtime.mjs + panel piAgent.ts) now parses "
+    "a JSON ARRAY or concatenated {name,args} objects and executes them "
+    "SEQUENTIALLY with per-call receipts (c4bb21f8) — a 'search X then create "
+    "a task' ask runs both tools instead of dumping raw JSON. The owner-"
+    "reported 'panel does not behave like I hoped' multi-tool gap, closed. "
     "SELF-IMPROVE-FORK v6.7.36: stress-loop fixes go live. /api/brain/ask "
     "honors ?project= (8dd3293d); /api/pi-runs honors offset + returns grand "
     "total (2bf0d49b); Learning agent-runs empty-state cross-links to "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,15 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.29"
+PRISM_VERSION = "6.7.30"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "SELF-IMPROVE-FORK v6.7.30: pi panel session-persistence hardening - "
+    "rehydrate can never apply after send() (interacted flag closes the "
+    "send->agent_start gap), persist/rekey never write an empty transcript "
+    "over a real saved session, and the first-paint rescue also adopts the "
+    "conversation when the target store exists but is empty. "
     "SELF-IMPROVE-FORK v6.7.29: five parallel lanes land at once. (1) agent "
     "panel no longer orphans a conversation when the project identity "
     "promotes at first paint (one-shot store migration, deliberate switches "

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -24,6 +24,7 @@ from prism_service.api.jobs import router as jobs_router
 from prism_service.api.learning import router as learning_router
 from prism_service.api.memory import router as memory_router
 from prism_service.api.okf import router as okf_router
+from prism_service.api.pi_runs import router as pi_runs_router
 from prism_service.api.projects import router as projects_router
 from prism_service.api.retrievals import router as retrievals_router
 from prism_service.api.service_info import router as service_info_router
@@ -51,6 +52,7 @@ api_router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 api_router.include_router(learning_router, prefix="/learning", tags=["learning"])
 api_router.include_router(memory_router, prefix="/memory", tags=["memory"])
 api_router.include_router(okf_router, prefix="/okf", tags=["okf"])
+api_router.include_router(pi_runs_router, prefix="/pi-runs", tags=["pi-runs"])
 api_router.include_router(projects_router, prefix="/projects", tags=["projects"])
 api_router.include_router(retrievals_router, prefix="/retrievals", tags=["retrievals"])
 api_router.include_router(service_info_router, prefix="/service-info", tags=["service-info"])

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -10,6 +10,7 @@ app; the import-time side effects stay in the per-module routers.
 
 from fastapi import APIRouter
 
+from prism_service.api.agent import router as agent_router
 from prism_service.api.agent_runs import router as agent_runs_router
 from prism_service.api.brain import router as brain_router
 from prism_service.api.claude_auth import router as claude_auth_router
@@ -36,6 +37,7 @@ from prism_service.api.watchdog import router as watchdog_router
 from prism_service.api.xref import router as xref_router
 
 api_router = APIRouter(prefix="/api")
+api_router.include_router(agent_router, prefix="/agent", tags=["agent"])
 api_router.include_router(agent_runs_router, prefix="/agent-runs", tags=["agent-runs"])
 api_router.include_router(brain_router, prefix="/brain", tags=["brain"])
 api_router.include_router(claude_auth_router, prefix="/claude-auth", tags=["claude-auth"])

--- a/services/prism-service/prism_service/api/agent.py
+++ b/services/prism-service/prism_service/api/agent.py
@@ -14,35 +14,45 @@ from fastapi import APIRouter, Body, HTTPException, Query
 
 router = APIRouter()
 
-# The PI panel's reachable surface. Additions are a deliberate decision,
-# not a default — see the task plan (FR-4).
+# The PI agent's reachable surface. Additions are a deliberate decision,
+# not a default — this is EXACTLY the expert catalog exported by
+# web/pi-expert.mjs (task e70cdcda: PI ships pre-loaded as the PRISM
+# expert; the whitelist and the catalog move together). Deliberately
+# EXCLUDED admin/destructive tools: janitor_*, prism_sync, okf_index /
+# okf_get / okf_graph, prism_onboard, register_claude_source.
 AGENT_TOOL_WHITELIST = frozenset({
+    # Brain — retrieval + code-graph navigation.
     "brain_search",
+    "brain_understand",
+    "brain_find_symbol",
+    "brain_outline",
+    "brain_find_references",
+    "brain_call_chain",
+    # Memory — recall-before-store discipline lives in the expert prompt.
     "memory_recall",
     "memory_store",
+    "memory_invalidate",
+    # Tasks — the tracker PI orchestrates.
     "task_list",
+    "task_next",
     "task_create",
-    "prism_status",
-    # Conductor surface (task 9f20b605, phase 2 of the pi internal agent):
-    # deliberate additions so a DIRECTED pi job can drive SDLC work —
-    # author/patch plan_doc (task_update), advance the per-task state
-    # machine (conductor_advance), propose gate evidence (conductor_gate).
-    # All three are INTERNAL-ONLY (see INTERNAL_ONLY_TOOLS below).
     "task_update",
+    # Conductor — the SDLC state machine. Panel-reachable per owner
+    # directive (task e70cdcda): PI IS the orchestrator.
     "conductor_advance",
     "conductor_gate",
+    "workflow_state",
+    # Context + health.
+    "context_bundle",
+    "prism_status",
 })
 
-# INTERNAL AGENT CALLERS ONLY (task 9f20b605 FR-3): these mutate the SDLC
-# state machine, so they require an explicit internal=true body flag. The
-# browser PI panel never sends the flag — its reachable surface stays
-# read/create-only no matter what the model emits. The subprocess runner
-# (web/pi-runtime.mjs) sends internal=true on every bridged call.
-INTERNAL_ONLY_TOOLS = frozenset({
-    "task_update",
-    "conductor_advance",
-    "conductor_gate",
-})
+# Task 9f20b605 gated the conductor mutations to internal callers
+# (internal=true body flag). Task e70cdcda RETIRES that gate per owner
+# directive — PI is the orchestrator, so task_update / conductor_advance /
+# conductor_gate are panel-reachable. The seam stays (an empty frozenset,
+# still enforced below) for future admin-only tools.
+INTERNAL_ONLY_TOOLS: frozenset[str] = frozenset()
 
 
 @router.post("/tool")

--- a/services/prism-service/prism_service/api/agent.py
+++ b/services/prism-service/prism_service/api/agent.py
@@ -112,6 +112,56 @@ async def call_tool(
     }
 
 
+@router.post("/run")
+def record_run(
+    project: str = Query("default"), body: dict = Body(...),
+) -> dict:
+    """Record ONE task-attributed PI-panel exchange into the pi_runs ledger
+    (task fc08da8d).
+
+    Unlike POST /tool (which dispatches an MCP tool), this endpoint takes
+    the exchange's USAGE — the browser PI agent runs inference locally, so
+    its tokens never reach a Claude transcript; the panel POSTs them here on
+    agent_end. Recorded with backend='panel', purpose='panel-drive' and the
+    task_id detected from the exchange's conductor/task tool calls, so the
+    conductor tile burn + the task detail can attribute the PI agent's work
+    to the driven task. Best-effort: a malformed payload is coerced, never
+    500'd, mirroring the ledger's own never-raise discipline."""
+    from prism_service.services import pi_run_log
+
+    def _int(v) -> int:
+        try:
+            return max(0, int(v or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    def _float(v) -> float:
+        try:
+            return max(0.0, float(v or 0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    input_tokens = _int(body.get("input_tokens"))
+    output_tokens = _int(body.get("output_tokens"))
+    tools = body.get("tools_used")
+    run_id = pi_run_log.record_run(
+        backend="panel",
+        model=str(body.get("model") or ""),
+        purpose="panel-drive",
+        project=project,
+        task_id=str(body.get("task_id") or ""),
+        tools_used=tools if isinstance(tools, list) else [],
+        duration_ms=_float(body.get("ms")),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        # `tokens` is the completion-side KPI the ledger/strip reads.
+        tokens=output_tokens,
+        turns=1,
+        ok=bool(body.get("ok", True)),
+    )
+    return {"ok": run_id is not None, "run_id": run_id}
+
+
 def _error_message(text: str) -> str | None:
     """Extract the in-band dispatch-error message, or None for a real
     result. mcp.tools._dispatch_tool's catch-all emits `Error: <Type>:

--- a/services/prism-service/prism_service/api/agent.py
+++ b/services/prism-service/prism_service/api/agent.py
@@ -81,13 +81,54 @@ async def call_tool(
 
     from prism_service.mcp.tools import handle_tool
 
-    contents = await handle_tool(name, args, project_id=project)
+    # Task 4f76beb9 FR-1: an exception ESCAPING the dispatcher is a server
+    # fault, not a tool result — surface it as a clean 500 detail (type +
+    # message only, never a traceback body).
+    try:
+        contents = await handle_tool(name, args, project_id=project)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(
+            500, f"tool dispatch failed: {type(exc).__name__}: {exc}",
+        )
     # handle_tool returns list[TextContent]; tools emit JSON text. Surface
     # it parsed so the panel renders structure, with the raw text as the
     # fallback for non-JSON payloads.
     texts = [getattr(c, "text", "") for c in contents]
     raw = "\n".join(t for t in texts if t)
-    return {"name": name, "result": _parse_payload(texts[0] if texts else ""), "raw": raw}
+    # Task 4f76beb9 FR-2: the MCP layer reports dispatch errors IN-BAND as
+    # a plain 'Error: ...' text (mcp.tools._dispatch_tool catch-all). The
+    # pi agent loop needs a MACHINE-legible error it can repair from, not
+    # stack noise dressed as a result — surface it as ok:false + error.
+    err = _error_message(texts[0] if texts else "")
+    if err is not None:
+        return {"name": name, "ok": False, "error": err}
+    return {
+        "name": name,
+        "ok": True,
+        "result": _parse_payload(texts[0] if texts else ""),
+        "raw": raw,
+    }
+
+
+def _error_message(text: str) -> str | None:
+    """Extract the in-band dispatch-error message, or None for a real
+    result. mcp.tools._dispatch_tool's catch-all emits `Error: <Type>:
+    <msg>` (also `Error: Unknown tool '...'`); handle_tool may prepend the
+    PRISM_REFLECTION_PENDING nudge header (terminated by a `---` line), so
+    strip that before matching. Only a payload that STARTS with the
+    contract prefix counts — JSON results containing 'Error:' are not
+    errors."""
+    body = text or ""
+    first_line = body.split("\n", 1)[0]
+    if "PRISM_REFLECTION_PENDING" in first_line:
+        marker = "\n---\n"
+        if marker in body:
+            body = body.split(marker, 1)[1]
+    if body.startswith("Error: "):
+        return body[len("Error: "):].strip()
+    return None
 
 
 def _parse_payload(text: str):

--- a/services/prism-service/prism_service/api/agent.py
+++ b/services/prism-service/prism_service/api/agent.py
@@ -23,6 +23,25 @@ AGENT_TOOL_WHITELIST = frozenset({
     "task_list",
     "task_create",
     "prism_status",
+    # Conductor surface (task 9f20b605, phase 2 of the pi internal agent):
+    # deliberate additions so a DIRECTED pi job can drive SDLC work —
+    # author/patch plan_doc (task_update), advance the per-task state
+    # machine (conductor_advance), propose gate evidence (conductor_gate).
+    # All three are INTERNAL-ONLY (see INTERNAL_ONLY_TOOLS below).
+    "task_update",
+    "conductor_advance",
+    "conductor_gate",
+})
+
+# INTERNAL AGENT CALLERS ONLY (task 9f20b605 FR-3): these mutate the SDLC
+# state machine, so they require an explicit internal=true body flag. The
+# browser PI panel never sends the flag — its reachable surface stays
+# read/create-only no matter what the model emits. The subprocess runner
+# (web/pi-runtime.mjs) sends internal=true on every bridged call.
+INTERNAL_ONLY_TOOLS = frozenset({
+    "task_update",
+    "conductor_advance",
+    "conductor_gate",
 })
 
 
@@ -36,6 +55,15 @@ async def call_tool(
     if name not in AGENT_TOOL_WHITELIST:
         raise HTTPException(
             403, f"tool {name!r} is not whitelisted for the PI agent",
+        )
+    # Internal-only gate (task 9f20b605 FR-3): conductor mutations require
+    # a LITERAL internal=true — truthy look-alikes ("true", 1) do not open
+    # the gate, so the browser panel surface is provably unchanged.
+    if name in INTERNAL_ONLY_TOOLS and body.get("internal") is not True:
+        raise HTTPException(
+            403,
+            f"tool {name!r} is for internal agent callers only "
+            "(requires internal=true)",
         )
     args = body.get("args") or {}
     if not isinstance(args, dict):

--- a/services/prism-service/prism_service/api/agent.py
+++ b/services/prism-service/prism_service/api/agent.py
@@ -1,0 +1,64 @@
+"""PI agent tool passthrough — the omnipresent left-rail agent's ONE door
+into PRISM's MCP tool surface (task 711d5235).
+
+The browser-side pi agent (@earendil-works/pi-agent-core) does its own tool
+calling; each tool call lands here and dispatches IN-PROCESS via
+mcp.tools.handle_tool — same semantics as the MCP HTTP endpoint minus the
+localhost round-trip. Gated to a whitelist so the panel can never reach
+admin/destructive tools no matter what the model emits.
+"""
+
+import json
+
+from fastapi import APIRouter, Body, HTTPException, Query
+
+router = APIRouter()
+
+# The PI panel's reachable surface. Additions are a deliberate decision,
+# not a default — see the task plan (FR-4).
+AGENT_TOOL_WHITELIST = frozenset({
+    "brain_search",
+    "memory_recall",
+    "memory_store",
+    "task_list",
+    "task_create",
+    "prism_status",
+})
+
+
+@router.post("/tool")
+async def call_tool(
+    project: str = Query("default"), body: dict = Body(...),
+) -> dict:
+    name = body.get("name")
+    if not name or not isinstance(name, str):
+        raise HTTPException(422, "tool 'name' required")
+    if name not in AGENT_TOOL_WHITELIST:
+        raise HTTPException(
+            403, f"tool {name!r} is not whitelisted for the PI agent",
+        )
+    args = body.get("args") or {}
+    if not isinstance(args, dict):
+        raise HTTPException(422, "'args' must be an object")
+
+    from prism_service.mcp.tools import handle_tool
+
+    contents = await handle_tool(name, args, project_id=project)
+    # handle_tool returns list[TextContent]; tools emit JSON text. Surface
+    # it parsed so the panel renders structure, with the raw text as the
+    # fallback for non-JSON payloads.
+    texts = [getattr(c, "text", "") for c in contents]
+    raw = "\n".join(t for t in texts if t)
+    return {"name": name, "result": _parse_payload(texts[0] if texts else ""), "raw": raw}
+
+
+def _parse_payload(text: str):
+    """Tool text is JSON, but handle_tool may prepend the PRISM_REFLECTION
+    nudge header (a Claude-session affordance, noise to the PI panel). Parse
+    the JSON payload from the first brace/bracket; fall back to raw text."""
+    for start in (0, *(i for i in (text.find("{"), text.find("[")) if i > 0)):
+        try:
+            return json.loads(text[start:])
+        except ValueError:
+            continue
+    return text

--- a/services/prism-service/prism_service/api/brain.py
+++ b/services/prism-service/prism_service/api/brain.py
@@ -8,8 +8,17 @@ retrieval step uses Brain's normal search() to pull the top-N hits; the
 question + those hits are then formatted into a prompt and run through
 claude_cli.invoke(). Allowed-tools is empty so claude doesn't run a
 subagent loop — single-shot Q&A.
+
+PRISM_BRAIN_ASK_BACKEND=local (task e1ebdd6e, claude-p-exit epic) routes
+the SAME grounded prompt at the keyless local micro model
+(inference.local_llm) as one completion — the prompt already forbids
+tool calls, so single-shot semantics are preserved. The response
+contract is unchanged; run_id + tokens come from the run-ledger seam so
+the SPA ask panel keeps its receipts. Default stays the claude CLI.
 """
 
+import os
+import time
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query
@@ -164,6 +173,12 @@ def ask(body: AskBody) -> dict:
         f"## Answer\n"
     )
 
+    # Env-gated backend seam (task e1ebdd6e): the local micro model
+    # serves the same grounded prompt as a single completion.
+    backend = (os.environ.get("PRISM_BRAIN_ASK_BACKEND") or "").strip().lower()
+    if backend == "local":
+        return _ask_local(body, q, prompt, results)
+
     # cwd = the project's source dir, so if claude's allowed_tools
     # ever gets extended to include Read/Glob/Grep it can navigate
     # the tree. For v1 we leave allowed_tools empty (no tool calls,
@@ -190,21 +205,84 @@ def ask(body: AskBody) -> dict:
         "question": q,
         "project": body.project,
         "answer": answer,
-        "sources": [
-            {
-                "index": i + 1,
-                "file": (r.get("source_file") or r.get("file") or r.get("source") or ""),
-                "entity_name": r.get("entity_name") or r.get("doc_id") or "",
-                "entity_kind": r.get("entity_kind") or "",
-                "score": r.get("rrf_score") or r.get("score") or 0.0,
-            }
-            for i, r in enumerate(results)
-        ],
+        "sources": _sources_payload(results),
         "run_id": res.run_id,
         "exit_code": res.exit_code,
         "duration_s": res.duration_s,
         "tokens": {
             "input": res.usage.get("input_tokens", 0),
             "output": res.usage.get("output_tokens", 0),
+        },
+    }
+
+
+def _sources_payload(results: list) -> list[dict]:
+    """The retrieval receipts rendered by the SPA ask panel — identical
+    for every backend (the sources come from Brain, not the model)."""
+    return [
+        {
+            "index": i + 1,
+            "file": (r.get("source_file") or r.get("file") or r.get("source") or ""),
+            "entity_name": r.get("entity_name") or r.get("doc_id") or "",
+            "entity_kind": r.get("entity_kind") or "",
+            "score": r.get("rrf_score") or r.get("score") or 0.0,
+        }
+        for i, r in enumerate(results)
+    ]
+
+
+def _ask_local(body: AskBody, q: str, prompt: str, results: list) -> dict:
+    """Local-backend leg of /ask (task e1ebdd6e): one keyless
+    local_llm.complete completion over the SAME grounded prompt. The
+    response contract matches the claude path — run_id comes from the
+    run-ledger seam (record_local_run) and tokens from local_llm's
+    additive input/output split, so the SPA keeps its telemetry.
+    An unreachable endpoint is a 502, never a fabricated answer."""
+    from prism_service.inference import local_llm
+
+    purpose = f"brain_ask@{q[:40]}"
+    mdl = local_llm.configured_model()
+    ts_start = time.time()
+    try:
+        out = local_llm.complete(
+            prompt,
+            model=mdl,
+            max_tokens=1024,
+            purpose=purpose,
+            project=body.project,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            502, f"local ask backend failed: {type(exc).__name__}: {exc}")
+    ts_end = time.time()
+    text = (out.get("text") or "").strip()
+    usage = {
+        "input_tokens": int(out.get("input_tokens") or 0),
+        "output_tokens": int(out.get("output_tokens")
+                             or out.get("tokens") or 0),
+    }
+    run_id = ""
+    try:
+        from prism_service.services import claude_run_log
+
+        run_id = claude_run_log.record_local_run(
+            project=body.project, purpose=purpose,
+            backend="local", model=mdl,
+            final_text=text, usage=usage,
+            ts_start=ts_start, ts_end=ts_end,
+        )
+    except Exception:
+        pass  # ledger is best-effort — never fail the ask
+    return {
+        "question": q,
+        "project": body.project,
+        "answer": text or "(no answer returned)",
+        "sources": _sources_payload(results),
+        "run_id": run_id,
+        "exit_code": 0,
+        "duration_s": round(ts_end - ts_start, 3),
+        "tokens": {
+            "input": usage["input_tokens"],
+            "output": usage["output_tokens"],
         },
     }

--- a/services/prism-service/prism_service/api/brain.py
+++ b/services/prism-service/prism_service/api/brain.py
@@ -234,10 +234,12 @@ def _sources_payload(results: list) -> list[dict]:
 def _ask_local(body: AskBody, q: str, prompt: str, results: list) -> dict:
     """Local-backend leg of /ask (task e1ebdd6e): one keyless
     local_llm.complete completion over the SAME grounded prompt. The
-    response contract matches the claude path — run_id comes from the
-    run-ledger seam (record_local_run) and tokens from local_llm's
-    additive input/output split, so the SPA keeps its telemetry.
-    An unreachable endpoint is a 502, never a fabricated answer."""
+    response contract matches the claude path — run_id is the pi_runs
+    audit-ledger row the completion records for itself (task d1d4fe00:
+    pi_runs is THE ledger for pi|local runs; claude_runs stays
+    claude-only) and tokens come from local_llm's additive input/output
+    split, so the SPA keeps its telemetry. An unreachable endpoint is a
+    502, never a fabricated answer."""
     from prism_service.inference import local_llm
 
     purpose = f"brain_ask@{q[:40]}"
@@ -256,33 +258,17 @@ def _ask_local(body: AskBody, q: str, prompt: str, results: list) -> dict:
             502, f"local ask backend failed: {type(exc).__name__}: {exc}")
     ts_end = time.time()
     text = (out.get("text") or "").strip()
-    usage = {
-        "input_tokens": int(out.get("input_tokens") or 0),
-        "output_tokens": int(out.get("output_tokens")
-                             or out.get("tokens") or 0),
-    }
-    run_id = ""
-    try:
-        from prism_service.services import claude_run_log
-
-        run_id = claude_run_log.record_local_run(
-            project=body.project, purpose=purpose,
-            backend="local", model=mdl,
-            final_text=text, usage=usage,
-            ts_start=ts_start, ts_end=ts_end,
-        )
-    except Exception:
-        pass  # ledger is best-effort — never fail the ask
     return {
         "question": q,
         "project": body.project,
         "answer": text or "(no answer returned)",
         "sources": _sources_payload(results),
-        "run_id": run_id,
+        "run_id": out.get("run_id") or "",
         "exit_code": 0,
         "duration_s": round(ts_end - ts_start, 3),
         "tokens": {
-            "input": usage["input_tokens"],
-            "output": usage["output_tokens"],
+            "input": int(out.get("input_tokens") or 0),
+            "output": int(out.get("output_tokens")
+                          or out.get("tokens") or 0),
         },
     }

--- a/services/prism-service/prism_service/api/brain.py
+++ b/services/prism-service/prism_service/api/brain.py
@@ -116,7 +116,7 @@ class AskBody(BaseModel):
 
 
 @router.post("/ask")
-def ask(body: AskBody) -> dict:
+def ask(body: AskBody, project: str | None = Query(None)) -> dict:
     """Ask claude a question grounded in the project's Brain index.
 
     1. Run Brain hybrid search (BM25 + vector + graph) for top-K hits.
@@ -125,7 +125,19 @@ def ask(body: AskBody) -> dict:
     4. Return the answer + the sources we cited.
 
     Costs the user's Claude subscription one CLI invocation per call.
+
+    The effective project is resolved query-wins / body-fallback /
+    'default', mirroring the sibling brain/search route and
+    api/conductor._effective_project (task 48b965e0): a non-empty
+    ?project= grounds the answer, but a body `project` still works for
+    MCP-shaped clients. The resolved value is written back onto `body`
+    so every downstream read (Brain retrieval, source-dir lookup, the
+    local backend leg, and the echoed response field) uses it.
     """
+    resolved = ((project or "").strip()
+                or (body.project or "").strip()
+                or "default")
+    body.project = resolved
     q = (body.q or "").strip()
     if not q:
         raise HTTPException(400, "q is required")

--- a/services/prism-service/prism_service/api/conductor.py
+++ b/services/prism-service/prism_service/api/conductor.py
@@ -1,5 +1,7 @@
 """Conductor API — prompt variants, scores, session outcomes, and SDLC state."""
 
+from typing import Optional
+
 from fastapi import APIRouter, Body, HTTPException, Query
 
 from prism_service.project_context import get_project
@@ -13,6 +15,30 @@ def _svc(project: str):
         return get_project(project).conductor_svc
     except Exception as exc:
         raise HTTPException(404, f"unknown project: {project}: {exc}")
+
+
+def _effective_project(query_project: Optional[str], body: dict) -> str:
+    """Resolve the project for the mutation routes (task 48b965e0).
+
+    Query param wins (the documented REST convention); a string
+    body['project'] is the fallback for MCP-shaped clients that carry
+    project in the JSON body (the tasks-API convention); 'default' last.
+    Previously the body key was silently DROPPED and a real task came
+    back as bare 'unknown task' from the wrong project."""
+    if query_project:
+        return query_project
+    body_project = body.get("project")
+    if isinstance(body_project, str) and body_project.strip():
+        return body_project.strip()
+    return "default"
+
+
+def _name_searched_project(out: dict, task_id: str, project: str) -> dict:
+    """Enrich the service's bare 'unknown task' refusal so the failure
+    names WHICH project was searched (task 48b965e0 FR-4)."""
+    if out.get("ok") is False and out.get("reason") == "unknown task":
+        out["reason"] = f"task {task_id!r} not found in project {project!r}"
+    return out
 
 
 @router.get("/state")
@@ -48,7 +74,7 @@ def _board_tasks(s) -> list:
 
 
 @router.post("/gate")
-def gate(project: str = Query("default"), body: dict = Body(...)) -> dict:
+def gate(project: Optional[str] = Query(None), body: dict = Body(...)) -> dict:
     """Resolve a pending conductor gate from the SPA.
 
     Same path as the MCP `conductor_gate` tool: delegates to
@@ -56,12 +82,13 @@ def gate(project: str = Query("default"), body: dict = Body(...)) -> dict:
     auto-advances; reject flips->'failed' and stores reason in
     task.gate_reason. The decision PERSISTS on the task row.
     """
-    s = _svc(project)
+    effective = _effective_project(project, body)
+    s = _svc(effective)
     task_id = body.get("task_id")
     action = body.get("action")
     if not task_id or action not in ("approve", "reject"):
         raise HTTPException(422, "task_id and action ('approve'|'reject') required")
-    return s.gate_decide(
+    out = s.gate_decide(
         task_id,
         action,
         reason=body.get("reason", "") or "",
@@ -70,12 +97,14 @@ def gate(project: str = Query("default"), body: dict = Body(...)) -> dict:
         # NO-SELF-OVERRIDE actor (task 3826dac3): defaults to the session.
         actor=body.get("actor") or body.get("session_id"),
     )
+    return _name_searched_project(out, task_id, effective)
 
 
 @router.post("/advance")
-def advance(project: str = Query("default"), body: dict = Body(...)) -> dict:
+def advance(project: Optional[str] = Query(None), body: dict = Body(...)) -> dict:
     """Advance a task to the next WORKFLOW_STEP (same as the MCP advance)."""
-    s = _svc(project)
+    effective = _effective_project(project, body)
+    s = _svc(effective)
     task_id = body.get("task_id")
     if not task_id:
         raise HTTPException(422, "task_id required")
@@ -85,4 +114,4 @@ def advance(project: str = Query("default"), body: dict = Body(...)) -> dict:
         session_id=body.get("session_id"),
     )
     # Normalize key for the SPA: advance_task returns 'to_step'.
-    return out
+    return _name_searched_project(out, task_id, effective)

--- a/services/prism-service/prism_service/api/conductor.py
+++ b/services/prism-service/prism_service/api/conductor.py
@@ -96,6 +96,9 @@ def gate(project: Optional[str] = Query(None), body: dict = Body(...)) -> dict:
         session_id=body.get("session_id"),
         # NO-SELF-OVERRIDE actor (task 3826dac3): defaults to the session.
         actor=body.get("actor") or body.get("session_id"),
+        # HONEST RE-VERIFY (task 19e31e88): re-run the verifier fresh on a
+        # latched-failed gate instead of stamping an override.
+        re_verify=bool(body.get("re_verify", False)),
     )
     return _name_searched_project(out, task_id, effective)
 

--- a/services/prism-service/prism_service/api/pi_runs.py
+++ b/services/prism-service/prism_service/api/pi_runs.py
@@ -23,10 +23,19 @@ router = APIRouter()
 @router.get("")
 def list_runs(
     limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     project: Optional[str] = Query(None),
 ) -> dict:
-    runs = pi_run_log.list_recent(limit=limit, project=project)
-    return {"runs": runs, "count": len(runs)}
+    runs = pi_run_log.list_recent(limit=limit, project=project, offset=offset)
+    # `count` stays the returned page length (back-compat); `total` is the
+    # full filtered count so a client can page through the ledger.
+    return {
+        "runs": runs,
+        "count": len(runs),
+        "total": pi_run_log.count_recent(project=project),
+        "limit": limit,
+        "offset": offset,
+    }
 
 
 @router.get("/{run_id}")

--- a/services/prism-service/prism_service/api/pi_runs.py
+++ b/services/prism-service/prism_service/api/pi_runs.py
@@ -1,0 +1,37 @@
+"""/api/pi-runs — audit ledger of PRISM's internal pi/local inference runs.
+
+Backed by the file-based log at /data/pi_runs/. See
+prism_service.services.pi_run_log for the on-disk schema. Sibling of
+/api/claude-runs — the SPA's /internal-agent view renders these rows.
+
+Endpoints:
+  GET /api/pi-runs              recent manifest rows (newest first)
+  GET /api/pi-runs/{run_id}     full manifest entry for one run
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Query
+
+from prism_service.services import pi_run_log
+
+router = APIRouter()
+
+
+@router.get("")
+def list_runs(
+    limit: int = Query(50, ge=1, le=500),
+    project: Optional[str] = Query(None),
+) -> dict:
+    runs = pi_run_log.list_recent(limit=limit, project=project)
+    return {"runs": runs, "count": len(runs)}
+
+
+@router.get("/{run_id}")
+def get_run(run_id: str) -> dict:
+    entry = pi_run_log.get_run(run_id)
+    if entry is None:
+        raise HTTPException(404, f"run {run_id!r} not found")
+    return entry

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -21,6 +21,16 @@ def _svc(project: str):
         raise HTTPException(404, f"unknown project: {project}: {exc}")
 
 
+def _call_svc(fn, *args, **kwargs):
+    """Invoke a TaskService mutation, translating its boundary-validation
+    ValueError (off-enum status, over-cap title, bad parent — task
+    16234231/24ed8027) into the HTTP 422 contract the SPA/API expects."""
+    try:
+        return fn(*args, **kwargs)
+    except ValueError as exc:
+        raise HTTPException(422, str(exc))
+
+
 def _attach_turn_tokens(history: list, sessions: list, project: str) -> None:
     """Best-effort: stamp each history turn with `turn_tokens` = the
     output_tokens spent in the window (previous_turn, this_turn], summed across
@@ -127,7 +137,8 @@ def create_task(body: TaskCreate, project: str = Query("default")) -> dict:
     if not (body.title or "").strip():
         raise HTTPException(422, "title is required")
     ctx = get_project(project)
-    task = ctx.task_svc.create(
+    task = _call_svc(
+        ctx.task_svc.create,
         title=body.title.strip(),
         description=body.description or "",
         priority=body.priority or 0,
@@ -321,7 +332,7 @@ def update_task(
     kwargs = {k: v for k, v in body.dict().items() if v is not None}
     if not kwargs:
         raise HTTPException(400, "no fields to update")
-    t = svc.update(task_id, **kwargs)
+    t = _call_svc(svc.update, task_id, **kwargs)
     if not t:
         raise HTTPException(404, "task not found")
     return {"task": t, "history": svc.history(task_id)}

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -314,6 +314,27 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
             limit=50, project=project, task_id=task_id)
     except Exception:
         out["pi_activity"] = []
+    # phase_metrics (task bd1c2289): the REPRESENTATION layer on top of the
+    # fc08da8d telemetry — a per-visited-SDLC-step rollup (duration + tokens +
+    # turns + actor + gate outcome) plus a task total, computed PURELY from the
+    # history timestamps + the task-attributed pi_runs / per-turn tokens already
+    # assembled above. Rides the top level like phase_progress; the detail page
+    # merges it onto the task and renders the Phase-metrics card. Best-effort —
+    # sparse history yields empty steps, never a 500.
+    try:
+        from prism_service.services.conductor_service import (
+            compute_phase_metrics,
+        )
+        out["phase_metrics"] = compute_phase_metrics(
+            out["history"], out.get("pi_activity") or [],
+            task_status=getattr(t, "status", "") or "",
+            completed_at=getattr(t, "completed_at", "") or "",
+        )
+    except Exception:
+        out["phase_metrics"] = {
+            "steps": [],
+            "total": {"wall_duration_s": 0.0, "total_tokens": 0, "tok_s": 0.0},
+        }
     # has_prototype: a clickable MOCK prototype HTML the /prototype workflow
     # generated for this task, served in-app (see get_task_prototype). Top-level
     # boolean (like phase_progress) so the detail page can show/hide the iframe

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -240,6 +240,33 @@ def _build_timeline(history: list, sessions: list) -> dict:
             "lanes": lanes, "gates": gates}
 
 
+def _build_child_map(all_tasks: list) -> dict:
+    """parent_id → [child Task] index built from one task-list read."""
+    m: dict = {}
+    for t in all_tasks:
+        pid = getattr(t, "parent_id", "") or ""
+        if pid:
+            m.setdefault(pid, []).append(t)
+    return m
+
+
+def _subtree_nodes(child_map: dict, root_id: str) -> list:
+    """Breadth-first list of every transitive child of ``root_id`` (root
+    excluded), cycle-guarded via a visited-set (mirrors TaskService.descendants
+    — kept here so get_task walks its single in-memory map, no extra reads)."""
+    out: list = []
+    seen = {root_id}
+    queue = list(child_map.get(root_id, []))
+    while queue:
+        n = queue.pop(0)
+        if n.id in seen:
+            continue
+        seen.add(n.id)
+        out.append(n)
+        queue.extend(child_map.get(n.id, []))
+    return out
+
+
 @router.get("/{task_id}")
 def get_task(task_id: str, project: str = Query("default")) -> dict:
     svc = _svc(project)
@@ -285,6 +312,26 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
         out["has_prototype"] = prototype_file(task_id).exists()
     except Exception:
         out["has_prototype"] = False
+    # Subtree roll-up (task e72aba6d): whole-subtree descendant_count/done for
+    # the detail page's tree header, plus each DIRECT child annotated with its
+    # OWN child_count so the UI can lazy-render a tree node's chevron without
+    # re-walking. One task-list read backs all three (built into child_map).
+    try:
+        child_map = _build_child_map(svc.list())
+        subtree = _subtree_nodes(child_map, task_id)
+        active = [t for t in subtree if getattr(t, "status", "") != "cancelled"]
+        out["descendant_count"] = len(active)
+        out["descendant_done"] = sum(
+            1 for t in active if getattr(t, "status", "") == "done")
+        out["children"] = [
+            {**dataclasses.asdict(c),
+             "child_count": len(_subtree_nodes(child_map, c.id))}
+            for c in child_map.get(task_id, [])
+        ]
+    except Exception:
+        out.setdefault("descendant_count", 0)
+        out.setdefault("descendant_done", 0)
+        out.setdefault("children", [])
     return out
 
 

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -107,6 +107,10 @@ class TaskCreate(BaseModel):
     priority: int = 0
     tags: Optional[list[str]] = None
     likely_misfire: str = ""
+    oracle: str = ""
+    proof_type: str = ""
+    parent_id: str = ""
+    dependencies: Optional[list[str]] = None
     full_outcome_complete: bool = False
     enter_conductor: bool = False
 
@@ -129,6 +133,10 @@ def create_task(body: TaskCreate, project: str = Query("default")) -> dict:
         priority=body.priority or 0,
         tags=body.tags or [],
         likely_misfire=body.likely_misfire or "",
+        oracle=body.oracle or "",
+        proof_type=body.proof_type or "",
+        parent_id=body.parent_id or "",
+        dependencies=body.dependencies or [],
         full_outcome_complete=bool(body.full_outcome_complete),
     )
     advanced = None

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -304,6 +304,16 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
             out["phase_progress"] = cond.phase_progress(task_id)
     except Exception:
         pass
+    # pi_activity (task fc08da8d): the PI-panel agent's task-attributed runs
+    # from the pi_runs ledger (model, tokens, ms, tools_used) — the detail
+    # page renders a "PI agent" activity row so a task the browser PI agent
+    # drove shows its token+tool usage, not just Claude sessions. Best-effort.
+    try:
+        from prism_service.services import pi_run_log
+        out["pi_activity"] = pi_run_log.list_recent(
+            limit=50, project=project, task_id=task_id)
+    except Exception:
+        out["pi_activity"] = []
     # has_prototype: a clickable MOCK prototype HTML the /prototype workflow
     # generated for this task, served in-app (see get_task_prototype). Top-level
     # boolean (like phase_progress) so the detail page can show/hide the iframe

--- a/services/prism-service/prism_service/cli/prism_cli.py
+++ b/services/prism-service/prism_service/cli/prism_cli.py
@@ -200,10 +200,16 @@ def cmd_start(args: argparse.Namespace) -> int:
         # the instant the launching session ends. CREATE_BREAKAWAY_FROM_JOB
         # escapes the job. It raises if the job forbids breakaway, so fall
         # back to the old flags rather than failing the launch.
-        _DETACHED = 0x00000008
+        # CREATE_NO_WINDOW (not DETACHED_PROCESS): a DETACHED daemon has NO
+        # console, so every console-subprocess it spawns (claude -p, git,
+        # pytest) allocates a fresh VISIBLE conhost window — worker activity
+        # flashes terminal windows at the user. NO_WINDOW gives the daemon a
+        # hidden console that all children inherit: same detachment from the
+        # launching terminal, zero window spam.
+        _NO_WINDOW = 0x08000000  # CREATE_NO_WINDOW
         _NEW_GROUP = 0x00000200
         _BREAKAWAY = 0x01000000  # CREATE_BREAKAWAY_FROM_JOB
-        spawn_kwargs["creationflags"] = _DETACHED | _NEW_GROUP | _BREAKAWAY
+        spawn_kwargs["creationflags"] = _NO_WINDOW | _NEW_GROUP | _BREAKAWAY
     else:
         spawn_kwargs["start_new_session"] = True
 
@@ -240,7 +246,7 @@ def cmd_start(args: argparse.Namespace) -> int:
                 f"durable daemon.",
                 file=sys.stderr,
             )
-            spawn_kwargs["creationflags"] = 0x00000008 | 0x00000200
+            spawn_kwargs["creationflags"] = 0x08000000 | 0x00000200
             proc = _spawn()
         else:
             raise

--- a/services/prism-service/prism_service/cli/prism_cli.py
+++ b/services/prism-service/prism_service/cli/prism_cli.py
@@ -424,11 +424,13 @@ def cmd_principles_seed(args: argparse.Namespace) -> int:
     plan_gate is satisfiable (issue #171). In-process — resolves the project
     context directly (no running daemon needed)."""
     from prism_service.config import DEFAULT_PROJECT
-    from prism_service.project_context import get_project
+    from prism_service.project_context import create_project
     from prism_service.services.arc_governance import seed_default_principles
 
     pid = getattr(args, "project", None) or DEFAULT_PROJECT
-    ctx = get_project(pid)
+    # Seeding is a fresh-project bootstrap affordance — explicit create
+    # (get_project refuses unknown projects; finding d37193da).
+    ctx = create_project(pid)
     stored = seed_default_principles(ctx.memory_svc)
     ids = ", ".join(getattr(e, "name", "") for e in stored)
     print(f"seeded {len(stored)} architecture principle(s) into project "

--- a/services/prism-service/prism_service/engines/understand_engine.py
+++ b/services/prism-service/prism_service/engines/understand_engine.py
@@ -80,8 +80,19 @@ class RefreshResult:
     budget_limit: int = 0
 
 
-def _state_path(project: str) -> Path:
-    return project_data_dir(project) / "understand_state.json"
+def _state_path(project: str, *, create: bool = False) -> Path:
+    """Path of the project's understand_state.json.
+
+    READS MUST NOT CREATE (stress finding d37193da): the default path is
+    computed without touching disk — routing reads through the creating
+    project_data_dir() is exactly how read probes (and the pytest suite's
+    ConductorService source-path lookups) minted phantom project dirs.
+    Writers pass create=True to seed the project layout first.
+    """
+    if create:
+        return project_data_dir(project) / "understand_state.json"
+    from prism_service.config import PROJECTS_DIR
+    return PROJECTS_DIR / project / "understand_state.json"
 
 
 def _read_state(project: str) -> dict:
@@ -95,7 +106,7 @@ def _read_state(project: str) -> dict:
 
 
 def _write_state(project: str, state: dict) -> None:
-    _state_path(project).write_text(
+    _state_path(project, create=True).write_text(
         json.dumps(state, indent=2), encoding="utf-8",
     )
 

--- a/services/prism-service/prism_service/inference/analyzer_runner.py
+++ b/services/prism-service/prism_service/inference/analyzer_runner.py
@@ -15,20 +15,53 @@ re-enables the stripped env vars.
 from __future__ import annotations
 
 import json
+import logging
+import os
 import re
 from pathlib import Path
 from typing import Any, Optional
 
-from prism_service.inference import claude_cli
+from prism_service.inference import claude_cli, pi_agent
 from prism_service.services import source_service as ss
 
 
 _PROMPTS_DIR = Path(__file__).resolve().parent / "prompts"
+_log = logging.getLogger("prism.analyzer_runner")
 
 # Analyzers walk the source tree (no Brain MCP available in the
 # server-side drain context) so they need more turns than the harness
 # default. Budget caps still bound aggregate spend.
 DEFAULT_MAX_TURNS = 35
+
+# Read-only file tools an Understand analyzer needs to walk the source tree.
+# These are the claude_cli READ_ONLY_TOOLS; the pi runtime does NOT bridge
+# them today (task 96341ef8 — see _pi_has_fs_tools).
+ANALYZER_FS_TOOLS = ("Read", "Glob", "Grep")
+
+
+def _analyzer_backend() -> str:
+    """Configured analyzer inference backend. '' (unset/any other value)
+    means the default claude_cli path; 'pi' opts into the pi-agent runtime
+    (task 96341ef8, claude-p-exit epic be898578)."""
+    return (os.environ.get("PRISM_ANALYZER_BACKEND") or "").strip().lower()
+
+
+def _pi_has_fs_tools() -> bool:
+    """True iff the pi runtime advertises the Read/Glob/Grep file tools an
+    analyzer needs.
+
+    The pi runtime bridges Brain tools through the /api/agent/tool surface
+    (its catalog lives in web/pi-runtime.mjs + web/pi-expert.mjs), NOT the
+    Read/Glob/Grep file tools. An analyzer is a ~35-turn file-walk, so
+    PRISM_ANALYZER_BACKEND=pi is only viable once those fs tools join the pi
+    catalog — tracked as a follow-up (web/** is outside this task's allowed
+    files). Detection is by membership so the day they land, the pi path
+    lights up here with no further change; until then run_analyzer falls
+    back to claude with a logged skip note."""
+    catalog = (set(getattr(pi_agent, "EXPERT_TOOLS", ()))
+               | set(getattr(pi_agent, "CONDUCTOR_TOOLS", ()))
+               | set(getattr(pi_agent, "DEFAULT_TOOLS", ())))
+    return all(tool in catalog for tool in ANALYZER_FS_TOOLS)
 
 
 def _strip_frontmatter(text: str) -> str:
@@ -67,6 +100,22 @@ def _strip_preamble_to_heading(text: str) -> str:
     return text
 
 
+def _payload_from_final(final: str, analyzer: str) -> Any:
+    """Parse ONE final assistant text block into the analyzer payload.
+    Shared by the claude (stream-json) and pi (single text) backends so the
+    payload contract is identical on both (task 96341ef8)."""
+    final = (final or "").strip()
+    if analyzer == "onboarding_writer":
+        # Strip the ```markdown ... ``` fence first (if the model wrapped it),
+        # then drop any preamble before the first H1.
+        return _strip_preamble_to_heading(_strip_code_fence(final, "markdown"))
+    cleaned = _strip_code_fence(final, "json")
+    try:
+        return json.loads(cleaned)
+    except json.JSONDecodeError:
+        return {"raw": final, "error": "not_valid_json"}
+
+
 def _extract_payload(res: claude_cli.ClaudeCliResult, analyzer: str) -> Any:
     """Pull the analyzer's JSON or markdown payload out of stream-json events."""
     text_blocks: list[str] = []
@@ -77,30 +126,33 @@ def _extract_payload(res: claude_cli.ClaudeCliResult, analyzer: str) -> Any:
         for block in msg.get("content") or []:
             if isinstance(block, dict) and block.get("type") == "text":
                 text_blocks.append(block.get("text", ""))
-    final = (text_blocks[-1] if text_blocks else "").strip()
-    if analyzer == "onboarding_writer":
-        # Strip the ```markdown ... ``` fence first (if Claude wrapped it),
-        # then drop any preamble before the first H1.
-        return _strip_preamble_to_heading(_strip_code_fence(final, "markdown"))
-    cleaned = _strip_code_fence(final, "json")
-    try:
-        return json.loads(cleaned)
-    except json.JSONDecodeError:
-        return {"raw": final, "error": "not_valid_json"}
+    final = text_blocks[-1] if text_blocks else ""
+    return _payload_from_final(final, analyzer)
 
 
-def _classify(res: claude_cli.ClaudeCliResult, payload: Any) -> str:
-    """complete | partial | failed — same rules as the legacy CLI executor."""
-    parseable = (
+def _payload_parseable(payload: Any) -> bool:
+    """A payload is parseable when it's markdown starting with '#' or a
+    schema-shaped dict (no error envelope). Backend-agnostic."""
+    return (
         isinstance(payload, str) and payload.startswith("#")
     ) or (
         isinstance(payload, dict) and "error" not in payload
         and ("schema" in payload or "steps" in payload or "layers" in payload
              or "domains" in payload)
     )
-    if res.exit_code == 0 and parseable:
+
+
+def _classify_ok(exit_ok: bool, payload: Any) -> str:
+    """complete | partial | failed from an exit-ok flag + payload."""
+    parseable = _payload_parseable(payload)
+    if exit_ok and parseable:
         return "complete"
     return "partial" if parseable else "failed"
+
+
+def _classify(res: claude_cli.ClaudeCliResult, payload: Any) -> str:
+    """complete | partial | failed — same rules as the legacy CLI executor."""
+    return _classify_ok(res.exit_code == 0, payload)
 
 
 def run_analyzer(
@@ -144,6 +196,25 @@ def run_analyzer(
         f"onboarding_writer) as your final assistant message; do NOT "
         f"write files.\n"
     )
+
+    # Backend seam (task 96341ef8). Default -> claude_cli (below). The pi
+    # runtime path only engages when it can actually walk files; otherwise
+    # a skip-guard falls back to claude so a premature opt-in never yields
+    # empty analyses. pi_agent.invoke records its own pi_run_log row
+    # (backend='pi'), so the ledger stays truthful on both paths.
+    if _analyzer_backend() == "pi":
+        if _pi_has_fs_tools():
+            return _run_via_pi(
+                template + runtime, project=project, analyzer=analyzer,
+                max_turns=max_turns,
+            )
+        _log.warning(
+            "PRISM_ANALYZER_BACKEND=pi but the pi runtime advertises no "
+            "%s file tools; falling back to claude for analyzer %r "
+            "(follow-up: add read-only fs tools to the pi catalog)",
+            "/".join(ANALYZER_FS_TOOLS), analyzer,
+        )
+
     res = claude_cli.invoke(
         template + runtime,
         source_dir,
@@ -163,4 +234,39 @@ def run_analyzer(
         "wall_clock_s": 0.0,
         "status": status,
         "error": "" if status != "failed" else f"exit={res.exit_code}",
+    }
+
+
+def _run_via_pi(prompt: str, *, project: str, analyzer: str,
+                max_turns: int) -> dict:
+    """Execute one analyzer through the pi-agent runtime (task 96341ef8).
+
+    Returns the IDENTICAL run_analyzer contract (payload / tokens_used /
+    wall_clock_s / status / error) so callers persist the artifact the same
+    way regardless of backend. The agentic file-walk uses ANALYZER_FS_TOOLS;
+    pi_agent.invoke records the pi_run_log row (backend='pi', tokens, purpose)
+    itself — the single recording point (task d1d4fe00), so no extra ledger
+    write here. A spawn/parse failure (PiRuntimeError) surfaces as a failed
+    status rather than raising into the drain loop."""
+    try:
+        result = pi_agent.invoke(
+            prompt,
+            allowed_tools=ANALYZER_FS_TOOLS,
+            project=project,
+            max_turns=max_turns,
+            purpose=f"{analyzer}@pi",
+        )
+    except pi_agent.PiRuntimeError as exc:
+        return {"payload": {"raw": "", "error": "pi_runtime"},
+                "tokens_used": 0, "wall_clock_s": 0.0,
+                "status": "failed", "error": f"pi runtime: {exc}"}
+    payload = _payload_from_final(result.get("text") or "", analyzer)
+    status = _classify_ok(bool(result.get("ok")), payload)
+    return {
+        "payload": payload,
+        "tokens_used": int(result.get("tokens") or 0),
+        "wall_clock_s": round(float(result.get("ms") or 0.0) / 1000.0, 3),
+        "status": status,
+        "error": ("" if status != "failed"
+                  else str(result.get("error") or "pi run not parseable")),
     }

--- a/services/prism-service/prism_service/inference/local_llm.py
+++ b/services/prism-service/prism_service/inference/local_llm.py
@@ -1,0 +1,88 @@
+"""Keyless local-LLM client for PRISM internal inference (task ecb90f7e).
+
+Speaks the OpenAI-compatible /chat/completions dialect against a LOCAL
+endpoint (Ollama, LM Studio, vLLM, llama.cpp server). Deliberately stdlib
+urllib and deliberately NO API key — INV-1 (no cloud credential in the
+service) holds by construction. This is the engine the self-learning loop
+uses when PRISM_REFLECTION_BACKEND=local routes reflection at a micro
+model (see services/reflection_runner._invoke_backend and the
+benchmarks/micro_llm_selflearn ranking that picks the model).
+
+Env:
+  PRISM_LOCAL_LLM_URL    base URL, default http://localhost:11434/v1
+  PRISM_LOCAL_LLM_MODEL  model id, default from the bench winner
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.request
+
+DEFAULT_URL = "http://localhost:11434/v1"
+# Bench winner (benchmarks/results/micro_llm_selflearn latest.json):
+# 522MB, 100% on reflect_verdict/distill/tool_call at T1 p50 3244ms —
+# faster AND more reliable than the 7-8b baselines on these shapes.
+DEFAULT_MODEL = "qwen3:0.6b"
+
+
+def configured_url() -> str:
+    return (os.environ.get("PRISM_LOCAL_LLM_URL") or DEFAULT_URL).rstrip("/")
+
+
+def configured_model() -> str:
+    return os.environ.get("PRISM_LOCAL_LLM_MODEL") or DEFAULT_MODEL
+
+
+def complete(
+    prompt: str,
+    *,
+    model: str = "",
+    base_url: str = "",
+    system: str = "",
+    max_tokens: int = 1024,
+    json_mode: bool = False,
+    temperature: float = 0.0,
+    timeout: float = 300.0,
+) -> dict:
+    """One blocking completion. Returns {text, ms, tokens}. Raises OSError /
+    urllib.error.URLError when the endpoint is unreachable — callers treat
+    that like any other inference failure."""
+    url = (base_url or configured_url()).rstrip("/")
+    mdl = model or configured_model()
+    sys_text = system
+    if mdl.startswith("qwen3") and "/no_think" not in sys_text:
+        # qwen3 thinking mode multiplies latency; self-learning payloads
+        # are structured extraction, not reasoning marathons.
+        sys_text = (sys_text + " /no_think").strip()
+    messages = []
+    if sys_text:
+        messages.append({"role": "system", "content": sys_text})
+    messages.append({"role": "user", "content": prompt})
+    body: dict = {
+        "model": mdl,
+        "stream": False,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if json_mode:
+        body["response_format"] = {"type": "json_object"}
+    req = urllib.request.Request(
+        f"{url}/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    t0 = time.perf_counter()
+    with urllib.request.urlopen(req, timeout=timeout) as res:
+        payload = json.loads(res.read())
+    ms = (time.perf_counter() - t0) * 1000.0
+    msg = (payload.get("choices") or [{}])[0].get("message") or {}
+    usage = payload.get("usage") or {}
+    return {
+        "text": msg.get("content") or "",
+        "ms": round(ms, 1),
+        "tokens": usage.get("completion_tokens") or 0,
+    }

--- a/services/prism-service/prism_service/inference/local_llm.py
+++ b/services/prism-service/prism_service/inference/local_llm.py
@@ -85,4 +85,9 @@ def complete(
         "text": msg.get("content") or "",
         "ms": round(ms, 1),
         "tokens": usage.get("completion_tokens") or 0,
+        # ADDITIVE (task 5fc1683e): real usage split so callers can feed
+        # the run ledger without losing token telemetry. "tokens" keeps
+        # its historical meaning (completion side) for existing callers.
+        "input_tokens": usage.get("prompt_tokens") or 0,
+        "output_tokens": usage.get("completion_tokens") or 0,
     }

--- a/services/prism-service/prism_service/inference/local_llm.py
+++ b/services/prism-service/prism_service/inference/local_llm.py
@@ -35,6 +35,17 @@ def configured_model() -> str:
     return os.environ.get("PRISM_LOCAL_LLM_MODEL") or DEFAULT_MODEL
 
 
+def _record_run(**kwargs) -> None:
+    """Audit-ledger seam (services/pi_run_log): ADDITIVE, best-effort —
+    a ledger failure must never raise into the inference caller path."""
+    try:
+        from prism_service.services import pi_run_log
+
+        pi_run_log.record_run(**kwargs)
+    except Exception:
+        pass
+
+
 def complete(
     prompt: str,
     *,
@@ -45,10 +56,18 @@ def complete(
     json_mode: bool = False,
     temperature: float = 0.0,
     timeout: float = 300.0,
+    purpose: str = "",
+    project: str = "",
 ) -> dict:
     """One blocking completion. Returns {text, ms, tokens}. Raises OSError /
     urllib.error.URLError when the endpoint is unreachable — callers treat
-    that like any other inference failure."""
+    that like any other inference failure.
+
+    Every run — success or unreachable endpoint — lands in the pi_run_log
+    audit ledger as a backend=local row (the SPA's /internal-agent view).
+    The new `purpose`/`project` kwargs are ADDITIVE: defaults keep every
+    existing caller untouched; an unset purpose is inferred (reflect for
+    the reflection engine's system marker, else adhoc)."""
     url = (base_url or configured_url()).rstrip("/")
     mdl = model or configured_model()
     sys_text = system
@@ -75,13 +94,37 @@ def complete(
         headers={"content-type": "application/json"},
         method="POST",
     )
+    try:
+        from prism_service.services.pi_run_log import infer_purpose
+
+        _purpose = infer_purpose(purpose, system)
+    except Exception:
+        _purpose = purpose or "adhoc"
+    audit = {
+        "backend": "local",
+        "model": mdl,
+        "project": project,
+        "prompt_chars": len(prompt or ""),
+        "tools_used": [],  # tool-less by design
+        "purpose": _purpose,
+    }
+    ts_start = time.time()
     t0 = time.perf_counter()
-    with urllib.request.urlopen(req, timeout=timeout) as res:
-        payload = json.loads(res.read())
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as res:
+            payload = json.loads(res.read())
+    except Exception as exc:
+        _record_run(
+            duration_ms=(time.perf_counter() - t0) * 1000.0,
+            ok=False, error=f"{type(exc).__name__}: {exc}",
+            ts_start=ts_start, ts_end=time.time(),
+            **audit,
+        )
+        raise
     ms = (time.perf_counter() - t0) * 1000.0
     msg = (payload.get("choices") or [{}])[0].get("message") or {}
     usage = payload.get("usage") or {}
-    return {
+    out = {
         "text": msg.get("content") or "",
         "ms": round(ms, 1),
         "tokens": usage.get("completion_tokens") or 0,
@@ -91,3 +134,9 @@ def complete(
         "input_tokens": usage.get("prompt_tokens") or 0,
         "output_tokens": usage.get("completion_tokens") or 0,
     }
+    _record_run(
+        duration_ms=out["ms"], tokens=int(out["tokens"] or 0),
+        ok=True, error="", ts_start=ts_start, ts_end=time.time(),
+        **audit,
+    )
+    return out

--- a/services/prism-service/prism_service/inference/local_llm.py
+++ b/services/prism-service/prism_service/inference/local_llm.py
@@ -35,15 +35,18 @@ def configured_model() -> str:
     return os.environ.get("PRISM_LOCAL_LLM_MODEL") or DEFAULT_MODEL
 
 
-def _record_run(**kwargs) -> None:
+def _record_run(**kwargs) -> str:
     """Audit-ledger seam (services/pi_run_log): ADDITIVE, best-effort —
-    a ledger failure must never raise into the inference caller path."""
+    a ledger failure must never raise into the inference caller path.
+    Returns the pi ledger run_id ('' when the ledger is unavailable) so
+    complete() can hand callers their telemetry receipt (task d1d4fe00:
+    pi_runs is THE ledger for backend pi|local)."""
     try:
         from prism_service.services import pi_run_log
 
-        pi_run_log.record_run(**kwargs)
+        return pi_run_log.record_run(**kwargs) or ""
     except Exception:
-        pass
+        return ""
 
 
 def complete(
@@ -59,15 +62,21 @@ def complete(
     purpose: str = "",
     project: str = "",
 ) -> dict:
-    """One blocking completion. Returns {text, ms, tokens}. Raises OSError /
-    urllib.error.URLError when the endpoint is unreachable — callers treat
-    that like any other inference failure.
+    """One blocking completion. Returns {text, ms, tokens, input_tokens,
+    output_tokens, run_id}. Raises OSError / urllib.error.URLError when
+    the endpoint is unreachable — callers treat that like any other
+    inference failure.
 
     Every run — success or unreachable endpoint — lands in the pi_run_log
     audit ledger as a backend=local row (the SPA's /internal-agent view).
-    The new `purpose`/`project` kwargs are ADDITIVE: defaults keep every
-    existing caller untouched; an unset purpose is inferred (reflect for
-    the reflection engine's system marker, else adhoc)."""
+    This is THE single recording point for local completions (task
+    d1d4fe00): seam callers pass `purpose`/`project` through and read the
+    row's `run_id` back off the returned dict instead of writing their own
+    ledger row (claude_runs stays claude-only). The pi row carries the
+    input/output token split so no telemetry was lost in the move. All
+    new kwargs/keys are ADDITIVE: defaults keep every existing caller
+    untouched; an unset purpose is inferred (reflect for the reflection
+    engine's system marker, else adhoc)."""
     url = (base_url or configured_url()).rstrip("/")
     mdl = model or configured_model()
     sys_text = system
@@ -134,8 +143,12 @@ def complete(
         "input_tokens": usage.get("prompt_tokens") or 0,
         "output_tokens": usage.get("completion_tokens") or 0,
     }
-    _record_run(
+    # ADDITIVE (task d1d4fe00): the pi row is the caller's telemetry
+    # receipt — return its run_id and persist the token split on it.
+    out["run_id"] = _record_run(
         duration_ms=out["ms"], tokens=int(out["tokens"] or 0),
+        input_tokens=int(out["input_tokens"] or 0),
+        output_tokens=int(out["output_tokens"] or 0),
         ok=True, error="", ts_start=ts_start, ts_end=time.time(),
         **audit,
     )

--- a/services/prism-service/prism_service/inference/pi_agent.py
+++ b/services/prism-service/prism_service/inference/pi_agent.py
@@ -29,6 +29,19 @@ _CREATE_NO_WINDOW = 0x08000000  # keep worker spawns invisible (v6.7.25 lesson)
 
 DEFAULT_TOOLS: tuple[str, ...] = ("brain_search", "memory_recall")
 
+# PI ships pre-loaded as the PRISM expert (task e70cdcda): the FULL
+# catalog mirrored from web/pi-expert.mjs (EXPERT_TOOL_DEFS) and
+# api/agent.py (AGENT_TOOL_WHITELIST) — the three move together. Opt-in
+# per job; reflection keeps the lean DEFAULT_TOOLS above.
+EXPERT_TOOLS: tuple[str, ...] = (
+    "brain_search", "brain_understand", "brain_find_symbol",
+    "brain_outline", "brain_find_references", "brain_call_chain",
+    "memory_recall", "memory_store", "memory_invalidate",
+    "task_list", "task_next", "task_create", "task_update",
+    "conductor_advance", "conductor_gate",
+    "workflow_state", "context_bundle", "prism_status",
+)
+
 # Conductor surface (task 9f20b605, phase 2): OPT-IN toolset for jobs
 # DIRECTED at SDLC work — read the task (task_list by id), author/patch
 # plan_doc (task_update), advance the state machine (conductor_advance),

--- a/services/prism-service/prism_service/inference/pi_agent.py
+++ b/services/prism-service/prism_service/inference/pi_agent.py
@@ -29,6 +29,15 @@ _CREATE_NO_WINDOW = 0x08000000  # keep worker spawns invisible (v6.7.25 lesson)
 
 DEFAULT_TOOLS: tuple[str, ...] = ("brain_search", "memory_recall")
 
+# Conductor surface (task 9f20b605, phase 2): OPT-IN toolset for jobs
+# DIRECTED at SDLC work — read the task (task_list by id), author/patch
+# plan_doc (task_update), advance the state machine (conductor_advance),
+# propose gate evidence (conductor_gate). Never part of DEFAULT_TOOLS;
+# the bridge additionally gates the mutating three to internal callers.
+CONDUCTOR_TOOLS: tuple[str, ...] = (
+    "task_list", "task_update", "conductor_advance", "conductor_gate",
+)
+
 
 class PiRuntimeError(RuntimeError):
     """Runner could not be spawned or returned an unparseable result."""

--- a/services/prism-service/prism_service/inference/pi_agent.py
+++ b/services/prism-service/prism_service/inference/pi_agent.py
@@ -21,6 +21,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 from prism_service.inference import local_llm
@@ -75,6 +76,17 @@ def _ui_port() -> int:
     return UI_PORT
 
 
+def _record_run(**kwargs) -> None:
+    """Audit-ledger seam (services/pi_run_log): ADDITIVE, best-effort —
+    a ledger failure must never raise into the inference caller path."""
+    try:
+        from prism_service.services import pi_run_log
+
+        pi_run_log.record_run(**kwargs)
+    except Exception:
+        pass
+
+
 def invoke(
     prompt: str,
     *,
@@ -85,11 +97,17 @@ def invoke(
     project: str = "default",
     max_turns: int = 6,
     timeout: float = 300.0,
+    purpose: str = "",
 ) -> dict:
     """Run one agentic job. Returns the runner's result dict:
     {ok, text, turns, tools_used[{name,ms,ok}], ms, tokens, model, error?}.
     Raises PiRuntimeError on spawn/parse failure (model failures come back
-    as ok=False in the payload instead)."""
+    as ok=False in the payload instead).
+
+    Every run — success, model failure, or spawn/parse failure — lands in
+    the pi_run_log audit ledger (the SPA's /internal-agent view). `purpose`
+    labels the row (reflect|panel-bridge|adhoc); when unset it is inferred
+    from the system prompt (the reflection engine's marker), else adhoc."""
     runner = _runner_path()
     if not runner.exists():
         raise PiRuntimeError(f"pi runner missing: {runner}")
@@ -106,6 +124,25 @@ def invoke(
     kwargs: dict = {}
     if sys.platform.startswith("win"):
         kwargs["creationflags"] = _CREATE_NO_WINDOW
+    audit = {
+        "backend": "pi",
+        "model": job["model"],
+        "project": project,
+        "prompt_chars": len(prompt or ""),
+    }
+    ts_start = time.time()
+
+    def _fail(error: str) -> None:
+        from prism_service.services.pi_run_log import infer_purpose
+
+        _record_run(
+            purpose=infer_purpose(purpose, system),
+            duration_ms=(time.time() - ts_start) * 1000.0,
+            ok=False, error=error,
+            ts_start=ts_start, ts_end=time.time(),
+            **audit,
+        )
+
     try:
         proc = subprocess.run(
             [_node_exe(), str(runner)],
@@ -115,15 +152,43 @@ def invoke(
             **kwargs,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
+        try:
+            _fail(f"pi runner spawn failed: {exc}")
+        except Exception:
+            pass
         raise PiRuntimeError(f"pi runner spawn failed: {exc}") from exc
     out = (proc.stdout or "").strip()
     try:
         result = json.loads(out)
     except ValueError as exc:
+        try:
+            _fail(f"pi runner returned non-JSON (exit {proc.returncode})")
+        except Exception:
+            pass
         raise PiRuntimeError(
             f"pi runner returned non-JSON (exit {proc.returncode}): "
             f"{out[:300]!r} stderr={proc.stderr[:300]!r}"
         ) from exc
     if not isinstance(result, dict):
+        try:
+            _fail(f"pi runner returned {type(result).__name__}, expected object")
+        except Exception:
+            pass
         raise PiRuntimeError(f"pi runner returned {type(result).__name__}, expected object")
+    try:
+        from prism_service.services.pi_run_log import infer_purpose
+
+        _record_run(
+            purpose=infer_purpose(purpose, system),
+            tools_used=result.get("tools_used") or [],
+            duration_ms=float(result.get("ms") or 0),
+            tokens=int(result.get("tokens") or 0),
+            turns=int(result.get("turns") or 0),
+            ok=bool(result.get("ok")),
+            error=str(result.get("error") or ""),
+            ts_start=ts_start, ts_end=time.time(),
+            **dict(audit, model=str(result.get("model") or job["model"])),
+        )
+    except Exception:
+        pass
     return result

--- a/services/prism-service/prism_service/inference/pi_agent.py
+++ b/services/prism-service/prism_service/inference/pi_agent.py
@@ -1,0 +1,107 @@
+"""pi-agent subprocess primitive — PRISM's internal agentic inference
+(task ac69ee28).
+
+Shells out to web/pi-runtime.mjs (Node + pi-agent-core, MIT) the same way
+claude_cli shells to `claude`: one JSON job on stdin, one JSON result on
+stdout. The agent runs the LOCAL micro model (PRISM_LOCAL_LLM_MODEL /
+PRISM_LOCAL_LLM_URL — bench-ranked in benchmarks/micro_llm_selflearn) with
+PRISM tools bridged through the whitelisted /api/agent/tool surface, so
+internal inference can GROUND itself in memory/brain before answering.
+Keyless by construction (INV-1).
+
+Env:
+  PRISM_PI_RUNNER   override the runner path (tests point it at a fake)
+  PRISM_PI_NODE     override the node executable
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from prism_service.inference import local_llm
+
+_CREATE_NO_WINDOW = 0x08000000  # keep worker spawns invisible (v6.7.25 lesson)
+
+DEFAULT_TOOLS: tuple[str, ...] = ("brain_search", "memory_recall")
+
+
+class PiRuntimeError(RuntimeError):
+    """Runner could not be spawned or returned an unparseable result."""
+
+
+def _runner_path() -> Path:
+    override = os.environ.get("PRISM_PI_RUNNER")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parent.parent / "web" / "pi-runtime.mjs"
+
+
+def _node_exe() -> str:
+    exe = os.environ.get("PRISM_PI_NODE") or shutil.which("node")
+    if not exe:
+        raise PiRuntimeError("node executable not found (install Node or set PRISM_PI_NODE)")
+    return exe
+
+
+def _ui_port() -> int:
+    from prism_service.config import UI_PORT
+    return UI_PORT
+
+
+def invoke(
+    prompt: str,
+    *,
+    system: str = "",
+    allowed_tools: tuple[str, ...] = DEFAULT_TOOLS,
+    model: str = "",
+    base_url: str = "",
+    project: str = "default",
+    max_turns: int = 6,
+    timeout: float = 300.0,
+) -> dict:
+    """Run one agentic job. Returns the runner's result dict:
+    {ok, text, turns, tools_used[{name,ms,ok}], ms, tokens, model, error?}.
+    Raises PiRuntimeError on spawn/parse failure (model failures come back
+    as ok=False in the payload instead)."""
+    runner = _runner_path()
+    if not runner.exists():
+        raise PiRuntimeError(f"pi runner missing: {runner}")
+    job = {
+        "prompt": prompt,
+        "system": system,
+        "model": model or local_llm.configured_model(),
+        "base_url": base_url or local_llm.configured_url(),
+        "api_base": f"http://127.0.0.1:{_ui_port()}",
+        "project": project,
+        "allowed_tools": list(allowed_tools),
+        "max_turns": max_turns,
+    }
+    kwargs: dict = {}
+    if sys.platform.startswith("win"):
+        kwargs["creationflags"] = _CREATE_NO_WINDOW
+    try:
+        proc = subprocess.run(
+            [_node_exe(), str(runner)],
+            input=json.dumps(job),
+            capture_output=True, text=True, encoding="utf-8",
+            timeout=timeout, cwd=str(runner.parent),
+            **kwargs,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise PiRuntimeError(f"pi runner spawn failed: {exc}") from exc
+    out = (proc.stdout or "").strip()
+    try:
+        result = json.loads(out)
+    except ValueError as exc:
+        raise PiRuntimeError(
+            f"pi runner returned non-JSON (exit {proc.returncode}): "
+            f"{out[:300]!r} stderr={proc.stderr[:300]!r}"
+        ) from exc
+    if not isinstance(result, dict):
+        raise PiRuntimeError(f"pi runner returned {type(result).__name__}, expected object")
+    return result

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -498,6 +498,20 @@ async def lifespan(_app: FastAPI):
 
 app = FastAPI(title="PRISM Service", lifespan=lifespan)
 
+
+# Unknown ?project= -> 404 on EVERY route (stress finding d37193da).
+# get_project() no longer mints a phantom project dir on miss; it raises
+# UnknownProjectError, mapped here once so no per-route boilerplate is
+# needed. Creation stays explicit (POST /api/projects, MCP project_create
+# / project_onboard); the missing-param 'default' fallback is unaffected.
+from prism_service.project_context import UnknownProjectError
+
+
+@app.exception_handler(UnknownProjectError)
+async def _unknown_project_handler(request, exc: UnknownProjectError):
+    from fastapi.responses import JSONResponse
+    return JSONResponse(status_code=404, content={"detail": str(exc)})
+
 # The standalone Tauri shell loads its splash from a tauri:// origin and
 # polls /api/version cross-origin. Without these headers the webview sends
 # the request (server logs it, returns 200) but the browser silently drops

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -2970,7 +2970,10 @@ def _dispatch_tool(name: str, arguments: dict, *, project_id: str = "default") -
             }))]
 
         if name == "project_onboard":
-            ctx = get_project(project_id)
+            # Onboarding a fresh project is a deliberate CREATE — the one
+            # MCP door besides project_create allowed to mint the data dir
+            # (get_project no longer creates on miss; finding d37193da).
+            ctx = create_project(project_id)
             project_name = arguments.get("project_name") or project_id
             sub_projects = arguments.get("sub_projects") or []
             conventions = arguments.get("conventions") or []
@@ -3106,7 +3109,13 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
         # ------------------------------------------------------------------
         # Get project-scoped services
         # ------------------------------------------------------------------
-        ctx = get_project(project_id)
+        # Bootstrap tools are the documented fresh-project affordances —
+        # the ONLY dispatch paths allowed to mint the data dir now that
+        # get_project refuses unknown projects (finding d37193da).
+        if name in ("prism_onboard", "principles_seed"):
+            ctx = create_project(project_id)
+        else:
+            ctx = get_project(project_id)
         brain_svc = ctx.brain_svc
         task_svc = ctx.task_svc
         workflow_svc = ctx.workflow_svc

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -732,8 +732,9 @@ TOOLS: list[Tool] = [
         inputSchema={"type": "object", "properties": {
             "section": {"type": "string", "description":
                 "Optional: 'overview' | 'tools' | 'workflow' | 'orchestration' "
-                "(the epic fan-out playbook) | 'memory' | 'graph' | 'examples'. "
-                "Omit for the full guide."},
+                "(the epic fan-out playbook) | 'memory' | 'graph' | 'examples' "
+                "| 'changelog' (the full release history). Omit for the compact "
+                "default orientation."},
         }},
     ),
     Tool(
@@ -1769,12 +1770,28 @@ def _resolve_link_session_id() -> str:
 # Self-documenting guide (returned by prism_guide tool)
 # ---------------------------------------------------------------------------
 
-def _version_banner() -> str:
+def _version_banner(full: bool = False) -> str:
+    """Version line for the guide.
+
+    ``full=False`` (the overview default) returns a COMPACT banner: the
+    version plus a one-line headline only, then a pointer to the full
+    history. The complete PRISM_VERSION_NOTES changelog can be ~180K chars —
+    embedding it inline made a "READ FIRST" prism_guide call cost ~50K tokens
+    (task 5f93f67a). ``full=True`` returns the exhaustive banner and is used
+    only by the explicit ``changelog`` section."""
     try:
-        from prism_service.__version__ import PRISM_VERSION as _v, PRISM_VERSION_NOTES as _n
-        return f"PRISM version: **{_v}** — {_n}"
+        from prism_service.__version__ import (
+            PRISM_VERSION as _v, PRISM_VERSION_NOTES as _n)
     except Exception:
         return "PRISM version: unknown"
+    if full:
+        return f"PRISM version: **{_v}** — {_n}"
+    headline = (_n or "").strip().splitlines()[0] if (_n or "").strip() else ""
+    if len(headline) > 280:
+        headline = headline[:277].rstrip() + "…"
+    tail = f" — {headline}" if headline else ""
+    return (f"PRISM version: **{_v}**{tail}\n\n"
+            "_(full release history: `prism_guide(section=\"changelog\")`)_")
 
 
 _GUIDE_SECTIONS: dict[str, str] = {
@@ -1830,6 +1847,9 @@ in SQLite inside the container's /data volume — no network, no API keys.
 Only call `prism_guide` (this tool) once per session — the guide doesn't
 change between calls. Cache it.
 """,
+    # The exhaustive release history lives HERE, behind an explicit section,
+    # so it never bloats the READ-FIRST overview/default (task 5f93f67a).
+    "changelog": _version_banner(full=True),
     "tools": """\
 # All tools — what they do and when to call them
 
@@ -1914,7 +1934,8 @@ as navigable OKF concepts. Read-only; never writes brain.db / graph.db.
   adds `context_pack` with role card, rules, template, asset digests, and the
   same relevant context nested for model-agnostic clients.
 - `prism_guide(section?)` — this tool. Sections: overview | tools |
-  workflow | orchestration | memory | graph | examples.
+  workflow | orchestration | memory | graph | examples | changelog (the
+  full release history — kept out of the compact default).
 """,
     "workflow": """\
 # Daily workflow loop (coding agent)

--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -282,8 +282,10 @@ TOOLS: list[Tool] = [
     Tool(
         name="brain_call_chain",
         description=(
-            "Bounded BFS over the call graph starting at ``entity``. "
-            "Returns a flat edge list [{from, to, kind, relation, hop, "
+            "Bounded BFS over the call graph starting at a named symbol. "
+            "Pass ``name`` (canonical — same param as brain_find_symbol / "
+            "brain_find_references); ``entity`` is accepted as a back-compat "
+            "alias. Returns a flat edge list [{from, to, kind, relation, hop, "
             "direction}] so you can reconstruct call flow OR blast "
             "radius. By default follows only ``calls`` edges and walks "
             "forward (callees). Set direction='callers' to answer "
@@ -293,7 +295,12 @@ TOOLS: list[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {
-                "entity": {"type": "string"},
+                "name": {"type": "string",
+                         "description": "symbol identifier (canonical; "
+                                        "matches the sibling brain graph "
+                                        "tools)"},
+                "entity": {"type": "string",
+                           "description": "alias for `name` (back-compat)"},
                 "depth": {"type": "integer", "default": 2,
                           "description": "max hops (default 2)"},
                 "limit": {"type": "integer", "default": 50},
@@ -319,7 +326,10 @@ TOOLS: list[Tool] = [
                     ),
                 },
             },
-            "required": ["entity"],
+            # Neither is hard-required alone: `name` (canonical) OR `entity`
+            # (alias) satisfies the call; the dispatch enforces "at least one"
+            # and returns a clear error otherwise (task 0d2d5aeb).
+            "anyOf": [{"required": ["name"]}, {"required": ["entity"]}],
         },
     ),
     Tool(
@@ -3267,8 +3277,18 @@ BEGIN NOW with Step 0. Do not ask the user for permission — execute the steps.
             return [TextContent(type="text", text=_json(results))]
 
         if name == "brain_call_chain":
+            # `name` is the canonical symbol-identifier param (matches
+            # brain_find_symbol / brain_find_references); `entity` is kept as
+            # a back-compat alias. `entity` wins when both are supplied
+            # (task 0d2d5aeb).
+            ident = arguments.get("entity") or arguments.get("name")
+            if not ident:
+                return [TextContent(type="text", text=_json({
+                    "error": ("brain_call_chain requires a symbol identifier: "
+                              "pass `name` (canonical) or `entity` (alias)"),
+                }))]
             results = brain_svc.call_chain(
-                entity=arguments["entity"],
+                entity=ident,
                 depth=arguments.get("depth", 2),
                 limit=arguments.get("limit", 50),
                 relation=arguments.get("relation", "calls"),

--- a/services/prism-service/prism_service/models/task.py
+++ b/services/prism-service/prism_service/models/task.py
@@ -95,6 +95,14 @@ class Task:
     # page falls back to the existing description view.
     plan_doc: str = ""
     plan_diagram: str = ""
+    # Claim lease (task 41af13c0) — next_task atomically stamps claimed_by
+    # (the session that pulled the task) + claimed_at (ISO-8601 UTC) so a
+    # second next_task from a DIFFERENT session within the freshness window
+    # is handed a different task, preventing two drivers double-claiming one
+    # task. Empty = unclaimed; a claimed_at older than the lease window is
+    # reclaimable. Additive/non-breaking; round-trips via the same DB path.
+    claimed_by: str = ""
+    claimed_at: str = ""
 
     def __post_init__(self) -> None:
         if not self.id:

--- a/services/prism-service/prism_service/models/task.py
+++ b/services/prism-service/prism_service/models/task.py
@@ -6,6 +6,19 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from uuid import uuid4
 
+# Canonical task lifecycle (task 16234231). The four working states plus
+# the two terminal soft states the board/conductor already rely on:
+# 'cancelled' (conductor treats as terminal, done-tile rollups) and
+# 'deleted' (soft delete — hidden everywhere unless asked for by name).
+# TaskService.create/update enforce membership so BOTH doors (REST
+# api/tasks.py and MCP task_update) share the same teeth.
+VALID_STATUSES: tuple[str, ...] = (
+    "pending", "in_progress", "done", "blocked", "cancelled", "deleted",
+)
+
+# Titles are board-rendered everywhere; a 10KB title breaks list views.
+TITLE_MAX_LEN = 500
+
 
 @dataclass
 class Task:

--- a/services/prism-service/prism_service/project_context.py
+++ b/services/prism-service/prism_service/project_context.py
@@ -12,6 +12,7 @@ import threading
 from typing import Optional
 
 from prism_service.config import project_data_dir, list_projects, PROJECTS_DIR, DEFAULT_PROJECT
+from prism_service.data_dir import resolve_data_dir
 
 
 class ProjectContext:
@@ -182,7 +183,20 @@ class ProjectContext:
 # ---------------------------------------------------------------------------
 
 _lock = threading.Lock()
-_contexts: dict[str, ProjectContext] = {}
+# Keyed by (resolved_data_dir, project_id) — NOT project_id alone. The data
+# dir is part of the identity of a ProjectContext (it binds every service to
+# a tasks.db/brain.db/mulch under that dir). Keying on the name alone made a
+# PRISM_DATA_DIR change (the per-test isolation lever) hand back a context
+# bound to an EARLIER data dir, leaking writes into a shared store (finding
+# 33a1397b). In production PRISM_DATA_DIR is stable per process, so this
+# resolves to one dir for the process's life and is behavior-neutral.
+_contexts: dict[tuple[str, str], ProjectContext] = {}
+
+
+def _cache_key(project_id: str) -> tuple[str, str]:
+    """Compose the ``_contexts`` key: the LIVE resolved data dir paired with
+    the project id. resolve_data_dir() reads PRISM_DATA_DIR at call time."""
+    return (str(resolve_data_dir()), project_id)
 
 
 class UnknownProjectError(KeyError):
@@ -223,14 +237,15 @@ def get_project(project_id: Optional[str] = None) -> ProjectContext:
     and 'default' itself may still auto-create.
     """
     pid = project_id or DEFAULT_PROJECT
+    key = _cache_key(pid)
     with _lock:
-        ctx = _contexts.get(pid)
+        ctx = _contexts.get(key)
         if ctx is not None:
             return ctx
         if pid != DEFAULT_PROJECT and not project_exists(pid):
             raise UnknownProjectError(pid)
-        _contexts[pid] = ProjectContext(pid)
-        return _contexts[pid]
+        _contexts[key] = ProjectContext(pid)
+        return _contexts[key]
 
 
 def get_all_projects() -> list[str]:
@@ -255,9 +270,15 @@ def release_project(project_id: str) -> None:
     fresh context bound to a freshly-seeded data directory.
     """
     with _lock:
-        ctx = _contexts.pop(project_id, None)
-    if ctx is None:
-        return
+        # The cache is keyed by (data_dir, project_id); drop every entry for
+        # this project id regardless of which data dir it is bound to.
+        stale = [k for k in _contexts if k[1] == project_id]
+        ctxs = [_contexts.pop(k) for k in stale]
+    for ctx in ctxs:
+        _release_context(ctx)
+
+
+def _release_context(ctx: "ProjectContext") -> None:
     # Close any services that hold open SQLite handles. Each service
     # exposes a best-effort .close() if it has connections; missing ones
     # are silently ignored so we can free files on Windows.

--- a/services/prism-service/prism_service/project_context.py
+++ b/services/prism-service/prism_service/project_context.py
@@ -185,12 +185,51 @@ _lock = threading.Lock()
 _contexts: dict[str, ProjectContext] = {}
 
 
+class UnknownProjectError(KeyError):
+    """A caller referenced a project that has no data directory.
+
+    Raised by :func:`get_project` instead of silently minting a phantom
+    project dir (stress finding d37193da: ANY request naming an unknown
+    ``?project=`` used to create ~1.1MB on disk, including plain GETs).
+    main.py maps this to HTTP 404 for every API route. Creation stays
+    explicit via :func:`create_project` (POST /api/projects, MCP
+    project_create / project_onboard).
+    """
+
+    def __init__(self, project_id: str) -> None:
+        super().__init__(project_id)
+        self.project_id = project_id
+
+    def __str__(self) -> str:
+        return f"unknown project '{self.project_id}'"
+
+
+def project_exists(project_id: str) -> bool:
+    """True iff the project has a data dir on disk that is not
+    soft-deleted (`.deleted` marker => the trash sweeper owns it).
+    Reads PROJECTS_DIR off the config module dynamically so tests that
+    monkeypatch config.PROJECTS_DIR observe consistent behavior."""
+    from prism_service import config as _cfg
+    d = _cfg.PROJECTS_DIR / project_id
+    return d.is_dir() and not (d / ".deleted").is_file()
+
+
 def get_project(project_id: Optional[str] = None) -> ProjectContext:
-    """Get or create a ProjectContext for the given project ID."""
+    """Get the ProjectContext for an EXISTING project.
+
+    Reads must not create: an unknown non-default project raises
+    :class:`UnknownProjectError`. The long-standing missing-param
+    fallback is preserved — ``None``/'' resolves to DEFAULT_PROJECT,
+    and 'default' itself may still auto-create.
+    """
     pid = project_id or DEFAULT_PROJECT
     with _lock:
-        if pid not in _contexts:
-            _contexts[pid] = ProjectContext(pid)
+        ctx = _contexts.get(pid)
+        if ctx is not None:
+            return ctx
+        if pid != DEFAULT_PROJECT and not project_exists(pid):
+            raise UnknownProjectError(pid)
+        _contexts[pid] = ProjectContext(pid)
         return _contexts[pid]
 
 
@@ -200,7 +239,10 @@ def get_all_projects() -> list[str]:
 
 
 def create_project(project_id: str) -> ProjectContext:
-    """Create a new project (creates its data directory)."""
+    """Create a new project (creates its data directory). This is the
+    ONLY implicit-creation door besides the 'default' fallback — every
+    explicit affordance (POST /api/projects, MCP project_create,
+    MCP project_onboard) funnels through project_data_dir()."""
     project_data_dir(project_id)  # ensure dirs exist
     return get_project(project_id)
 

--- a/services/prism-service/prism_service/routes/graph_static.py
+++ b/services/prism-service/prism_service/routes/graph_static.py
@@ -934,8 +934,51 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
       // the hoverNodes canvas — both stay visible, so without this
       // skip the smaller regular label bleeds through under the
       // bigger hover label and reads as jumbled doubled text.
+      // Super-node label collision avoidance. The <=5 L0 (and L1/L2)
+      // super-node labels force-render — labelDensity is bypassed for them
+      // (see nodeReducer, level < 3) — so once FA2 packs the clusters into
+      // the centre their labels overprint ('PRISM Service Core' over
+      // 'Devtools Validation Suite'). We keep a per-frame accumulator of the
+      // label rectangles already painted and nudge each super-node label off
+      // any it would collide with (below the node first, then above, in
+      // half-line steps) — mirroring the /understand concept graph, whose
+      // labels sit clear of the node and each other. Reset every frame via
+      // the renderer's 'beforeRender' hook so rects never leak across frames.
+      const superLabelRects = [];
+      const labelRectsOverlap = (a, b) =>
+        !(a.x2 < b.x1 || b.x2 < a.x1 || a.y2 < b.y1 || b.y2 < a.y1);
+      // Returns a vertical offset (px) that clears prior super-node labels.
+      const deconflictSuperLabelY = (ctx, d, baseSize) => {
+        const w = ctx.measureText(d.label).width;
+        const h = baseSize;
+        const x1 = d.x + d.size + 4;
+        const step = h * 0.95;
+        const tries = [0, step, -step, 2 * step, -2 * step,
+                       3 * step, -3 * step, 4 * step, -4 * step];
+        for (const dy of tries) {
+          const y = d.y + dy;
+          const r = { x1, x2: x1 + w, y1: y - h / 2, y2: y + h / 2 };
+          if (!superLabelRects.some(p => labelRectsOverlap(r, p))) {
+            superLabelRects.push(r);
+            return dy;
+          }
+        }
+        return tries[tries.length - 1];
+      };
       const drawNodeLabel = (ctx, d, s) => {
         if (d.__hovered) return;
+        // Deconflict the force-rendered super-node labels (level < 3).
+        if (d.label && d.level !== undefined && d.level < 3) {
+          const baseSize = d.labelSize || s.labelSize || 13;
+          const weight = d.labelWeight || s.labelWeight || "600";
+          const font = s.labelFont || "system-ui, -apple-system, sans-serif";
+          ctx.font = `${weight} ${baseSize}px ${font}`;
+          const dy = deconflictSuperLabelY(ctx, d, baseSize);
+          if (dy) {
+            drawNodeLabelOutlined(ctx, { ...d, y: d.y + dy }, s, 1);
+            return;
+          }
+        }
         drawNodeLabelOutlined(ctx, d, s, 1);
       };
       const drawNodeHover = (ctx, d, s) => drawNodeLabelOutlined(ctx, d, s, 1.15);
@@ -1113,6 +1156,11 @@ _SIGMA_VIEWER_HTML = """<!DOCTYPE html>
       // (x: 0.5, y: 0.5) keeps the camera centered on the graph bbox,
       // which is the right framing because the spread pass above places
       // super-nodes radially around the leaf-graph centroid.
+      // Reset the super-node label collision accumulator once per frame so
+      // the placed-rectangle set reflects only THIS render pass (else rects
+      // leak across frames and every label reads as colliding).
+      renderer.on("beforeRender", () => { superLabelRects.length = 0; });
+
       const camera = renderer.getCamera();
       camera.setState({ ratio: 1.8 });
       currentRatio = 1.8;

--- a/services/prism-service/prism_service/services/claude_run_log.py
+++ b/services/prism-service/prism_service/services/claude_run_log.py
@@ -126,10 +126,12 @@ def record_run(
 ) -> None:
     """Append a manifest line for a finished run; trim older runs.
 
-    ``backend``/``model`` are ADDITIVE (task 5fc1683e, claude-p-exit epic):
-    the same ledger records claude-CLI runs AND local micro-model runs so
-    token telemetry survives a backend flip. Existing callers omit them
-    and keep the historical claude-shaped rows.
+    ``backend``/``model`` are ADDITIVE row fields (task 5fc1683e) kept for
+    row-shape stability, but this ledger is CLAUDE-ONLY (task d1d4fe00):
+    pi/local micro-model runs are recorded by inference.local_llm /
+    inference.pi_agent themselves into services/pi_run_log — the
+    /internal-agent audit surface — with the same input/output token
+    split. Nothing here should ever be called with backend != 'claude'.
     """
     try:
         _ensure_dir()
@@ -163,60 +165,6 @@ def record_run(
             f"[claude_run_log] record_run failed: {type(e).__name__}: {e}",
             file=sys.stderr, flush=True,
         )
-
-
-def record_local_run(
-    *,
-    project: str,
-    purpose: str,
-    backend: str,
-    model: str,
-    final_text: str,
-    usage: dict,
-    ts_start: float,
-    ts_end: float,
-    exit_code: int = 0,
-    stderr_text: str = "",
-) -> str:
-    """Record a run made by a NON-claude backend (local micro model / pi)
-    in the same ledger (task 5fc1683e, claude-p-exit epic).
-
-    Allocates a run_id, writes a synthetic single-event stream file (so
-    ``/api/claude-runs/<run_id>/stream`` and final-text extraction keep
-    working), then appends the manifest line with ``backend``/``model``
-    and the input/output token counts. Best-effort like record_run —
-    returns the run_id ("" when the ledger is unavailable) and never
-    raises into the inference caller.
-    """
-    try:
-        run_id, stream_path = new_run()
-        evt = {
-            "message": {
-                "content": [{"type": "text", "text": final_text or ""}],
-                "usage": {
-                    "input_tokens": int(usage.get("input_tokens", 0)),
-                    "output_tokens": int(usage.get("output_tokens", 0)),
-                },
-            }
-        }
-        stream_path.write_text(
-            json.dumps(evt, separators=(",", ":")) + "\n", encoding="utf-8",
-        )
-        record_run(
-            run_id=run_id, stream_path=stream_path,
-            ts_start=ts_start, ts_end=ts_end,
-            project=project, purpose=purpose,
-            exit_code=exit_code, usage=usage,
-            stderr_text=stderr_text,
-            backend=backend, model=model,
-        )
-        return run_id
-    except Exception as e:
-        print(
-            f"[claude_run_log] record_local_run failed: {type(e).__name__}: {e}",
-            file=sys.stderr, flush=True,
-        )
-        return ""
 
 
 def _trim_to_limit() -> None:

--- a/services/prism-service/prism_service/services/claude_run_log.py
+++ b/services/prism-service/prism_service/services/claude_run_log.py
@@ -121,13 +121,23 @@ def record_run(
     exit_code: int,
     usage: dict,
     stderr_text: str,
+    backend: str = "claude",
+    model: str = "",
 ) -> None:
-    """Append a manifest line for a finished run; trim older runs."""
+    """Append a manifest line for a finished run; trim older runs.
+
+    ``backend``/``model`` are ADDITIVE (task 5fc1683e, claude-p-exit epic):
+    the same ledger records claude-CLI runs AND local micro-model runs so
+    token telemetry survives a backend flip. Existing callers omit them
+    and keep the historical claude-shaped rows.
+    """
     try:
         _ensure_dir()
         stream_bytes = stream_path.stat().st_size if stream_path.exists() else 0
         entry = {
             "run_id": run_id,
+            "backend": backend or "claude",
+            "model": model or "",
             "ts_start": float(ts_start),
             "ts_end": float(ts_end),
             "duration_s": max(0.0, float(ts_end - ts_start)),
@@ -153,6 +163,60 @@ def record_run(
             f"[claude_run_log] record_run failed: {type(e).__name__}: {e}",
             file=sys.stderr, flush=True,
         )
+
+
+def record_local_run(
+    *,
+    project: str,
+    purpose: str,
+    backend: str,
+    model: str,
+    final_text: str,
+    usage: dict,
+    ts_start: float,
+    ts_end: float,
+    exit_code: int = 0,
+    stderr_text: str = "",
+) -> str:
+    """Record a run made by a NON-claude backend (local micro model / pi)
+    in the same ledger (task 5fc1683e, claude-p-exit epic).
+
+    Allocates a run_id, writes a synthetic single-event stream file (so
+    ``/api/claude-runs/<run_id>/stream`` and final-text extraction keep
+    working), then appends the manifest line with ``backend``/``model``
+    and the input/output token counts. Best-effort like record_run —
+    returns the run_id ("" when the ledger is unavailable) and never
+    raises into the inference caller.
+    """
+    try:
+        run_id, stream_path = new_run()
+        evt = {
+            "message": {
+                "content": [{"type": "text", "text": final_text or ""}],
+                "usage": {
+                    "input_tokens": int(usage.get("input_tokens", 0)),
+                    "output_tokens": int(usage.get("output_tokens", 0)),
+                },
+            }
+        }
+        stream_path.write_text(
+            json.dumps(evt, separators=(",", ":")) + "\n", encoding="utf-8",
+        )
+        record_run(
+            run_id=run_id, stream_path=stream_path,
+            ts_start=ts_start, ts_end=ts_end,
+            project=project, purpose=purpose,
+            exit_code=exit_code, usage=usage,
+            stderr_text=stderr_text,
+            backend=backend, model=model,
+        )
+        return run_id
+    except Exception as e:
+        print(
+            f"[claude_run_log] record_local_run failed: {type(e).__name__}: {e}",
+            file=sys.stderr, flush=True,
+        )
+        return ""
 
 
 def _trim_to_limit() -> None:

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -928,6 +928,30 @@ def live_token_events_for_session(
     return out
 
 
+def live_token_events_for_session_windowed(
+    session_id: str, project_path: str, since: float, until: float,
+    claude_home: Path | None = None,
+    override_dir: str | None = None,
+) -> list[tuple[float, int]]:
+    """Like live_token_events_for_session, but INTERSECTED with the wall-clock
+    window [since, until] (inclusive both bounds), sorted ascending. Empty on an
+    inverted window (until < since) or when no in-window turn is found.
+
+    This is what the conductor windows a SHARED driving session through: N
+    concurrent tasks link the SAME session id, so summing the whole transcript
+    made every tile render IDENTICAL turns/burn (task 03a8bfe3). Each task
+    intersects the shared session with its OWN work window instead. Reads the
+    same flat <sid>.jsonl + nested <sid>/ subagent layout as the full reader and
+    reuses the per-file (mtime,size) `_token_events` cache, so windowing one
+    shared session across N tasks in a poll costs a single parse per file."""
+    if until < since:
+        return []
+    events = live_token_events_for_session(
+        session_id, project_path, claude_home=claude_home, override_dir=override_dir
+    )
+    return [(ep, tok) for ep, tok in events if since <= ep <= until]
+
+
 def project_token_events_in_window(
     project_path: str, since: float, until: float,
     claude_home: Path | None = None,

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2321,6 +2321,46 @@ class ConductorService:
                 pass
         return self._now_epoch() - self._in_step_s(task_id)
 
+    def _task_window_end(self, task_id: str) -> float:
+        """End of the task's work window: completed_at for a done/cancelled task
+        (frozen, mirroring _in_step_s), else now. Bounds the shared-session
+        intersection so a finished task's window doesn't keep growing."""
+        if self._task_svc is not None:
+            try:
+                _t = self._task_svc.get(task_id)
+                status = (getattr(_t, "status", "") or "") if _t else ""
+                if status in ("done", "cancelled"):
+                    end = self._parse_iso(getattr(_t, "completed_at", "") or "") if _t else None
+                    if end is not None:
+                        return end
+            except Exception:
+                pass
+        return self._now_epoch()
+
+    def _session_task_count(self, session_id: str) -> int:
+        """How many distinct tasks link `session_id` (via task_sessions). A count
+        > 1 means the session is SHARED — one Claude session driving several
+        concurrent tasks — so its transcript must be windowed per task instead of
+        summed whole (task 03a8bfe3). Returns 1 (treat as exclusive: full span,
+        no windowing — preserves #137) when it can't be determined, so an error
+        never zeroes a young task's tile."""
+        if not session_id:
+            return 1
+        try:
+            conn = self._scores_conn()
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(DISTINCT task_id) FROM task_sessions "
+                    "WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+            finally:
+                conn.close()
+            n = int(row[0]) if row and row[0] is not None else 0
+            return n if n >= 1 else 1
+        except Exception:
+            return 1
+
     @staticmethod
     def _parse_iso(ts: str) -> Optional[float]:
         """ISO-8601 timestamp -> epoch seconds; None if unparseable."""
@@ -2560,33 +2600,64 @@ class ConductorService:
                 live_enabled = bool(source_path or override_dir)
                 live_fn = None
                 events_fn = None
+                windowed_fn = None
                 turns_from = None
                 if live_enabled:
                     from prism_service.services.claude_transcripts import (
                         live_tokens_for_session as live_fn,
                         live_token_events_for_session as events_fn,
+                        live_token_events_for_session_windowed as windowed_fn,
                         token_turns_from_events as turns_from,
                     )
                 # Build the FULL uncapped per-turn event timeline across the
                 # task's live sessions; total_turns is computed off the UNCAPPED
                 # series so `turns` stays honest even past the 40-turn tail cap.
+                #
+                # SHARED-SESSION WINDOWING (task 03a8bfe3): when a session is
+                # linked by MORE than one task (one Claude session driving
+                # several concurrent tiles), summing its whole transcript makes
+                # every tile render IDENTICAL turns/burn. So a shared session is
+                # intersected with THIS task's work window
+                # [_task_window_start, _task_window_end]; an EXCLUSIVE session
+                # keeps its full span (turns before the task's first history row
+                # still count — #137 young-task semantics preserved). A shared
+                # session also drops the whole-session session_outcomes.tokens_
+                # used (it would re-leak the bug post-import); only its windowed
+                # live turns count.
+                win_start = self._task_window_start(task_id)
+                win_end = self._task_window_end(task_id)
                 live_events: list[tuple[float, int]] = []
                 for s in self._task_svc.sessions_for_task(task_id):
                     sid = s.get("session_id") if isinstance(s, dict) else getattr(s, "session_id", "")
                     used = s.get("tokens_used") if isinstance(s, dict) else getattr(s, "tokens_used", 0)
                     outcome_tok = int(used or 0)
-                    live_tok = 0
-                    if live_fn and sid:
+                    shared = sid and self._session_task_count(sid) > 1
+                    session_events: list[tuple[float, int]] = []
+                    if shared and windowed_fn and sid:
                         try:
-                            live_tok = int(live_fn(sid, source_path, override_dir=override_dir) or 0)
+                            session_events = list(windowed_fn(
+                                sid, source_path, win_start, win_end,
+                                override_dir=override_dir) or [])
                         except Exception:
-                            live_tok = 0
-                    tokens += max(outcome_tok, live_tok)
-                    if events_fn and sid:
-                        try:
-                            live_events.extend(events_fn(sid, source_path, override_dir=override_dir) or [])
-                        except Exception:
-                            pass
+                            session_events = []
+                        # Windowed sessions count ONLY their in-window live turns
+                        # (never the whole-session outcome total — that leaks).
+                        tokens += sum(tok for _, tok in session_events)
+                    else:
+                        if events_fn and sid:
+                            try:
+                                session_events = list(events_fn(
+                                    sid, source_path, override_dir=override_dir) or [])
+                            except Exception:
+                                session_events = []
+                        live_tok = sum(tok for _, tok in session_events)
+                        if not session_events and live_fn and sid:
+                            try:
+                                live_tok = int(live_fn(sid, source_path, override_dir=override_dir) or 0)
+                            except Exception:
+                                live_tok = 0
+                        tokens += max(outcome_tok, live_tok)
+                    live_events.extend(session_events)
                 live_events.sort(key=lambda e: e[0])
                 # PER-TASK-EXCLUSIVE (owner decision, task 5ecbbfb8): the tile
                 # shows ONLY this task's authoritative linked-session activity.

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -158,6 +158,169 @@ def epic_rollup_verdict(nodes: list) -> tuple[bool, str]:
                   f"with strong leaf proof ({len(leaves)} leaf/leaves)")
 
 
+def compute_phase_metrics(history: list, pi_rows: Optional[list] = None, *,
+                          now: Optional[float] = None,
+                          task_status: str = "",
+                          completed_at: str = "") -> dict:
+    """Per-visited-step rollup of the SDLC — the REPRESENTATION layer on top of
+    the fc08da8d telemetry (task bd1c2289). PURE + unit-testable: reads only the
+    task's history rows (each advance_task/gate_decide carries a timestamp) plus
+    the task-attributed pi_runs rows, and returns
+
+        {"steps": [ {step, entered_at, duration_s, tokens_in, tokens_out,
+                     turns, actor, model, gate_outcome} ... ],
+         "total": {wall_duration_s, total_tokens, tok_s}}
+
+    one entry per VISITED workflow step (revisits aggregate), ordered by
+    WORKFLOW_STEPS. DURATION of a step = the next advance ts minus this step's
+    entry ts; the current/last step is measured to `now` (or completed_at for a
+    terminal task). TOKENS bucket into the step the task was on at each row's
+    timestamp — or the row's explicit `step` when the telemetry recorded one;
+    pi_runs input/output tokens and Claude per-turn `turn_tokens` (from
+    api.tasks._attach_turn_tokens) both fold in (SUM — disjoint agent work).
+    Additive: does NOT touch ConductorService.phase_progress / the tile burn.
+    Robust to sparse history — never raises (returns empty steps + a best-effort
+    total)."""
+    import re as _re
+    from datetime import datetime, timezone
+
+    def _epoch(ts: object) -> Optional[float]:
+        if ts is None:
+            return None
+        if isinstance(ts, (int, float)):
+            return float(ts)
+        try:
+            return datetime.fromisoformat(
+                str(ts).replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            return None
+
+    try:
+        from prism_service.models.workflow import WORKFLOW_STEPS
+        order = {s["id"]: i for i, s in enumerate(WORKFLOW_STEPS)}
+        step_type = {s["id"]: s.get("type") for s in WORKFLOW_STEPS}
+        step_agent = {s["id"]: s.get("agent") for s in WORKFLOW_STEPS}
+    except Exception:
+        order, step_type, step_agent = {}, {}, {}
+
+    hist = [h for h in (history or []) if isinstance(h, dict)]
+    if now is None:
+        now = datetime.now(timezone.utc).timestamp()
+    end = float(now)
+    if str(task_status) in ("done", "cancelled"):
+        ce = _epoch(completed_at)
+        if ce is not None:
+            end = ce
+
+    # Ordered advance rows -> (ts, to_step, entered_iso).
+    advances: list[tuple] = []
+    for h in hist:
+        if h.get("action") != "advance_task":
+            continue
+        ts = _epoch(h.get("timestamp"))
+        m = _re.search(r"to=([^\s;]+)", str(h.get("details") or ""))
+        if ts is not None and m:
+            advances.append((ts, m.group(1), h.get("timestamp")))
+    advances.sort(key=lambda a: a[0])
+
+    # Contiguous [start, end) segment per advance (the last runs to `end`).
+    segments: list[dict] = []
+    for i, (ts, step, iso) in enumerate(advances):
+        seg_end = advances[i + 1][0] if i + 1 < len(advances) else end
+        segments.append({"step": step, "start": ts,
+                         "end": max(seg_end, ts), "iso": iso})
+
+    # Latest gate_decide per gate wins: approve -> passed, reject -> failed.
+    gate_outcome: dict = {}
+    for h in hist:
+        if h.get("action") != "gate_decide":
+            continue
+        d = str(h.get("details") or "")
+        gm = _re.search(r"gate=([A-Za-z_]+_gate)", d)
+        am = _re.search(r"action=(\w+)", d)
+        if not (gm and am):
+            continue
+        if am.group(1) == "approve":
+            gate_outcome[gm.group(1)] = "passed"
+        elif am.group(1) == "reject":
+            gate_outcome[gm.group(1)] = "failed"
+
+    agg: dict = {}
+
+    def _bucket(step: str) -> dict:
+        e = agg.get(step)
+        if e is None:
+            e = {"step": step, "entered_at": None, "duration_s": 0.0,
+                 "tokens_in": 0, "tokens_out": 0, "turns": 0,
+                 "actor": step_agent.get(step) or "", "model": "",
+                 "gate_outcome": None}
+            agg[step] = e
+        return e
+
+    for seg in segments:
+        e = _bucket(seg["step"])
+        e["duration_s"] += max(0.0, seg["end"] - seg["start"])
+        if e["entered_at"] is None:
+            e["entered_at"] = seg["iso"]
+
+    def _step_for_ts(ts: float) -> Optional[str]:
+        chosen = None
+        for seg in segments:
+            if seg["start"] <= ts < seg["end"]:
+                return seg["step"]
+            if ts >= seg["start"]:
+                chosen = seg["step"]
+        return chosen
+
+    # pi_runs token attribution (explicit step wins, else bucket by ts window).
+    for r in (pi_rows or []):
+        if not isinstance(r, dict):
+            continue
+        step = r.get("step")
+        if not (step and step in order):
+            ts = _epoch(r.get("ts_end") or r.get("ts"))
+            step = _step_for_ts(ts) if ts is not None else None
+        if not step:
+            continue
+        e = _bucket(step)
+        e["tokens_in"] += int(r.get("input_tokens") or 0)
+        e["tokens_out"] += int(r.get("output_tokens") or r.get("tokens") or 0)
+        e["turns"] += int(r.get("turns") or 0) or 1
+        if r.get("model"):
+            e["model"] = str(r.get("model"))
+
+    # Claude per-turn output tokens (api.tasks stamps turn_tokens on history).
+    for h in hist:
+        tok = h.get("turn_tokens")
+        if not isinstance(tok, (int, float)) or tok <= 0:
+            continue
+        ts = _epoch(h.get("timestamp"))
+        step = _step_for_ts(ts) if ts is not None else None
+        if not step:
+            continue
+        e = _bucket(step)
+        e["tokens_out"] += int(tok)
+        e["turns"] += 1
+
+    for step, e in agg.items():
+        if step_type.get(step) == "gate" or step.endswith("_gate"):
+            e["gate_outcome"] = gate_outcome.get(step, "none")
+        e["duration_s"] = round(e["duration_s"], 3)
+
+    steps = sorted(agg.values(),
+                   key=lambda e: (order.get(e["step"], 999),
+                                  e["entered_at"] or ""))
+
+    all_ts = [t for t in (_epoch(h.get("timestamp")) for h in hist)
+              if t is not None]
+    wall = max(0.0, end - min(all_ts)) if all_ts else 0.0
+    total_tokens = sum(e["tokens_in"] + e["tokens_out"] for e in steps)
+    tok_s = round(total_tokens / wall, 3) if wall > 0 else 0.0
+    return {"steps": steps,
+            "total": {"wall_duration_s": round(wall, 3),
+                      "total_tokens": total_tokens, "tok_s": tok_s}}
+
+
 def green_gate_outcome_note(slice_green: bool, completion_proof: object,
                             incomplete_children: int) -> str:
     """Advisory note (annotate, never block) for the GAP-4 outcome verdict.

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -111,34 +111,51 @@ def full_outcome_verdict(slice_green: bool, completion_proof: object,
     return True, ""
 
 
-def epic_rollup_verdict(children: list) -> tuple[bool, str]:
-    """Issue #171 — an EPIC/parent green_gate is satisfiable by ROLLING UP
-    its children. When every non-cancelled child task is status=done AND
-    carries a strong completion_proof, the children ARE the parent's proof,
-    so the epic need not reproduce its own red->green artifact. A weak or
-    incomplete child FAILS with a concrete reason (no false green; NOT a
-    blanket override). Returns (False, reason) when there are no children to
-    roll up — a childless task is not an epic and takes the normal artifact
-    path. Pure + unit-testable; reuses is_weak_proof so the proof bar matches
-    full_outcome_verdict.
+def epic_rollup_verdict(nodes: list) -> tuple[bool, str]:
+    """Issue #171 + task e72aba6d — an EPIC/parent green_gate is satisfiable by
+    ROLLING UP its subtree. ``nodes`` is the parent's WHOLE subtree (every
+    transitive descendant), NOT just its direct children, so the roll-up is
+    correct to ANY depth: an incomplete grandchild blocks the grandparent.
+
+    Verdict:
+      * every non-cancelled descendant must be status=done (an incomplete node
+        anywhere in the subtree fails), AND
+      * every non-cancelled LEAF descendant must carry a strong completion_proof
+        — a leaf is a node no other active node names as its parent. INTERMEDIATE
+        nodes need not carry their own proof: their proof is their children's
+        rolled-up proofs, so requiring one would false-RED a legitimately
+        rolled-up sub-epic.
+
+    A flat list of direct children (the historical caller) degenerates
+    correctly: with no parent links among them every node is a leaf, so all
+    require strong proof — identical to the pre-subtree behavior. Returns
+    (False, reason) when there is nothing to roll up (a childless task is not an
+    epic and takes the normal artifact path). Pure + unit-testable; reuses
+    is_weak_proof so the proof bar matches full_outcome_verdict.
     """
-    active = [c for c in (children or [])
+    active = [c for c in (nodes or [])
               if str(_task_attr(c, "status", "")) != "cancelled"]
     if not active:
         return False, "no child tasks to roll up (not an epic)"
     incomplete = [c for c in active
                   if str(_task_attr(c, "status", "")) != "done"]
     if incomplete:
-        return False, (f"{len(incomplete)} child task(s) not done — epic "
+        return False, (f"{len(incomplete)} descendant task(s) not done — epic "
                        "roll-up needs every child done")
-    weak = [c for c in active
+    # Leaf = an active node that is not the parent of any other active node.
+    active_ids = {str(_task_attr(c, "id", "")) for c in active}
+    parents_in_set = {str(_task_attr(c, "parent_id", ""))
+                      for c in active} & active_ids
+    leaves = [c for c in active
+              if str(_task_attr(c, "id", "")) not in parents_in_set]
+    weak = [c for c in leaves
             if is_weak_proof(_task_attr(c, "completion_proof", ""))]
     if weak:
         ids = ", ".join(str(_task_attr(c, "id", "?"))[:8] for c in weak)
-        return False, (f"{len(weak)} child task(s) with weak/absent "
+        return False, (f"{len(weak)} leaf task(s) with weak/absent "
                        f"completion_proof ({ids})")
-    return True, (f"epic roll-up: all {len(active)} child task(s) done with "
-                  "strong completion_proof")
+    return True, (f"epic roll-up: all {len(active)} descendant task(s) done "
+                  f"with strong leaf proof ({len(leaves)} leaf/leaves)")
 
 
 def green_gate_outcome_note(slice_green: bool, completion_proof: object,
@@ -1837,11 +1854,14 @@ class ConductorService:
         rollup_reason = ""
         rollup_has_children = False
         if gate_step_id == "green_gate":
-            _kids = [c for c in self._task_svc.list()
-                     if _task_attr(c, "parent_id", "") == task_id]
-            rollup_has_children = bool(_kids)
-            if _kids:
-                rollup_ok, rollup_reason = epic_rollup_verdict(_kids)
+            # Subtree-aware (task e72aba6d): roll up the WHOLE subtree, not just
+            # direct children, so a grandparent gates green only when every
+            # descendant is done — an incomplete grandchild can no longer be
+            # invisible behind a done intermediate node.
+            _subtree = self._task_svc.descendants(task_id)
+            rollup_has_children = bool(_subtree)
+            if _subtree:
+                rollup_ok, rollup_reason = epic_rollup_verdict(_subtree)
 
         verifier_payload: Optional[dict] = None
         verifier_validation: Optional[str] = None

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2690,6 +2690,14 @@ class ConductorService:
                         live_token_events_for_session_windowed as windowed_fn,
                         token_turns_from_events as turns_from,
                     )
+                # token_turns_from_events is a PURE events->burn helper (no
+                # source dependency), so import it even without a Claude source:
+                # a task the PI agent drove (fc08da8d) may have NO transcript at
+                # all, yet its folded pi_runs events must still derive tok/s.
+                if turns_from is None:
+                    from prism_service.services.claude_transcripts import (
+                        token_turns_from_events as turns_from,
+                    )
                 # Build the FULL uncapped per-turn event timeline across the
                 # task's live sessions; total_turns is computed off the UNCAPPED
                 # series so `turns` stays honest even past the 40-turn tail cap.
@@ -2739,6 +2747,38 @@ class ConductorService:
                                 live_tok = 0
                         tokens += max(outcome_tok, live_tok)
                     live_events.extend(session_events)
+                # PI-AGENT FOLD (task fc08da8d): the browser PI panel runs
+                # inference LOCALLY, so its exchanges never land in a Claude
+                # transcript — the tile would read 0 turns for a task the PI
+                # agent actually drove. Fold in the task-attributed pi_runs
+                # rows (backend panel|pi|local, this task_id, in the work
+                # window) as extra burn events. SUM, not max: the PI tokens
+                # and the Claude-transcript tokens are DISJOINT real work by
+                # two different agents (not two measurements of ONE session,
+                # which is why the per-session read above takes max) — they
+                # add. Best-effort; never break the tile.
+                try:
+                    from pathlib import Path
+                    from prism_service.services import pi_run_log
+                    project_id = Path(self._scores_db).parent.name
+                    for r in pi_run_log.list_recent(
+                        limit=pi_run_log.RUN_LOG_LIMIT,
+                        project=project_id, task_id=task_id):
+                        if str(r.get("backend") or "") not in ("panel", "pi", "local"):
+                            continue
+                        ts = r.get("ts_end") or r.get("ts")
+                        if ts is None:
+                            continue
+                        ts = float(ts)
+                        if not (win_start <= ts <= win_end):
+                            continue
+                        out_tok = int(r.get("output_tokens") or r.get("tokens") or 0)
+                        if out_tok <= 0:
+                            continue
+                        live_events.append((ts, out_tok))
+                        tokens += out_tok
+                except Exception:
+                    pass
                 live_events.sort(key=lambda e: e[0])
                 # PER-TASK-EXCLUSIVE (owner decision, task 5ecbbfb8): the tile
                 # shows ONLY this task's authoritative linked-session activity.

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1614,6 +1614,7 @@ class ConductorService:
         override: bool = False,
         session_id: Optional[str] = None,
         actor: Optional[str] = None,
+        re_verify: bool = False,
     ) -> dict:
         """Resolve a pending gate on a task.
 
@@ -1629,6 +1630,19 @@ class ConductorService:
         plan_coverage) require ``override=True``. When ``override`` is
         True, the verifier is bypassed and the audit row carries
         actor='manual-override' plus the supplied reason.
+
+        HONEST RE-VERIFY (task 19e31e88): a gate that latched
+        ``gate_state='failed'`` (often from a transient/env artifact during
+        the verifier run) can be re-armed on merit with ``action='approve'``
+        + ``re_verify=True`` (NOT override). This resets the gate to
+        'pending' internally and RE-RUNS VerifierService fresh, releasing
+        ONLY if the verifier now passes. The release is a normal
+        verifier-passed release — actor='conductor', no override actor
+        stamped, no 'manual-override' audit row. If the fresh verify still
+        fails the gate stays 'failed' with the new reason, so a genuinely
+        red slice cannot re-arm green via re_verify. re_verify requires an
+        attached VerifierService (nothing to re-run otherwise) and is
+        ignored when ``override`` is also True (override wins, unchanged).
 
         Returns a dict shaped:
           {'ok': bool, 'task_id', 'gate_step',
@@ -1671,13 +1685,21 @@ class ConductorService:
                 "gate_state": task.gate_state,
                 "reason": "task is not currently on a gate step",
             }
+        # HONEST RE-VERIFY (task 19e31e88): re_verify re-arms a FAILED gate by
+        # re-running the verifier fresh — it is NOT an override, so override
+        # (when also passed) wins and re_verify is inert on that path.
+        reverify_active = (
+            action == "approve" and re_verify and not override
+            and task.gate_state == "failed"
+        )
         # Conductor v2 follow-up (#79): allow manual recovery on failed
         # gates. An explicit override=True on action='approve' supersedes
         # the verifier's earlier ruling; the audit row tags actor=
         # 'manual-override' so the recovery stays visible in task_history.
+        # re_verify=True instead re-runs the verifier fresh (no override).
         # 'reject' on a failed gate is still pointless (already failed).
         if task.gate_state == "failed":
-            if not (action == "approve" and override):
+            if not (action == "approve" and (override or reverify_active)):
                 return {
                     "ok": False,
                     "task_id": task_id,
@@ -1685,7 +1707,22 @@ class ConductorService:
                     "gate_state": task.gate_state,
                     "reason": (
                         "gate_state is 'failed'; recovery requires "
-                        "action='approve' with override=True"
+                        "action='approve' with override=True, or "
+                        "re_verify=True to re-run the verifier fresh"
+                    ),
+                }
+            if reverify_active and self._verifier_svc is None:
+                # Nothing to re-run: re_verify only makes sense against an
+                # attached verifier. Do NOT silently fall through to the
+                # legacy trust-caller path (that would release without proof).
+                return {
+                    "ok": False,
+                    "task_id": task_id,
+                    "gate_step": task.workflow_step,
+                    "gate_state": task.gate_state,
+                    "reason": (
+                        "re_verify requires an attached VerifierService to "
+                        "re-run; none is wired for this task"
                     ),
                 }
         elif task.gate_state != "pending":
@@ -1701,6 +1738,25 @@ class ConductorService:
             }
 
         gate_step_id = task.workflow_step
+
+        if reverify_active:
+            # Reset the latched failure to 'pending' and record the fresh
+            # re-verify attempt, then fall through to the verifier-driven
+            # approve branch below (override False, verifier attached -> the
+            # 'else' path re-runs VerifierService). No override actor, no
+            # 'manual-override' row: on pass this is a normal conductor
+            # verifier release; on fail it re-latches with the new reason.
+            self._task_svc.update(
+                task_id, gate_state="pending", gate_reason="",
+            )
+            self._task_svc.record_history(
+                task_id, action="gate_decide",
+                details=(f"gate={gate_step_id}; action=approve; "
+                         "re_verify=True; reset failed->pending for a "
+                         "fresh verifier run"),
+                actor="conductor",
+            )
+            task = self._task_svc.get(task_id)
 
         if action == "reject":
             self._task_svc.update(
@@ -1829,7 +1885,7 @@ class ConductorService:
             ]
             if reason:
                 detail_bits.append(f"reason={reason}")
-        elif rollup_ok:
+        elif rollup_ok and not reverify_active:
             # Epic roll-up satisfies the green_gate WITHOUT override and
             # WITHOUT the epic's own verifier diff — the children's proofs are
             # the proof (issue #171). The artifact tooth is skipped below.
@@ -1869,7 +1925,8 @@ class ConductorService:
                     action="gate_decide",
                     details=(
                         f"gate={gate_step_id}; action=approve; "
-                        f"verifier=fail; validation="
+                        + ("re_verify=True; " if reverify_active else "")
+                        + "verifier=fail; validation="
                         f"{verifier_validation or 'none'}; "
                         f"reason={verifier_reason}"
                     ),
@@ -1892,6 +1949,8 @@ class ConductorService:
                 "action=approve",
                 f"verifier=pass; validation={verifier_validation}",
             ]
+            if reverify_active:
+                detail_bits.append("re_verify=True")
             if reason:
                 detail_bits.append(f"reason={reason}")
 
@@ -2016,6 +2075,8 @@ class ConductorService:
             response["validation"] = verifier_validation
         if override:
             response["override"] = True
+        if reverify_active:
+            response["re_verify"] = True
         return response
 
     # Session-id prefixes used by smoke tests, dogfood probes, and the

--- a/services/prism-service/prism_service/services/event_handlers.py
+++ b/services/prism-service/prism_service/services/event_handlers.py
@@ -180,19 +180,26 @@ def handle_memory_written(event) -> None:
 
 
 def _summarize_haiku(ctx, mem, entry) -> None:
-    """Summarize a novel memory via claude --model haiku and persist it.
-    Best-effort: an auth/parse failure leaves summary empty for a later
-    retry, never crashes the pool."""
-    from prism_service.inference import claude_cli
-    from prism_service.services.memory_summary_worker import render_prompt
+    """Summarize a novel memory and persist it. Routed through the
+    memory-summary backend seam (task cba42d6b, claude-p-exit epic):
+    the default stays `claude --model haiku` exactly as before;
+    PRISM_MEMORY_SUMMARY_BACKEND=local serves the same distillation
+    prompt from the local micro model and records a claude_runs ledger
+    row (backend='local' + token counts). Best-effort: an auth/parse
+    failure leaves summary empty for a later retry, never crashes the
+    pool."""
+    from prism_service.services.memory_summary_worker import (
+        _invoke_backend, render_prompt)
 
     work_dir = str(ctx._data_dir) if ctx is not None else "."
+    project = str(getattr(ctx, "project_id", "") or "") if ctx else ""
     try:
-        result = claude_cli.invoke(
+        result = _invoke_backend(
             prompt=render_prompt(entry.name, entry.description),
-            work_dir=work_dir, plugin_dir=work_dir,
-            max_turns=1, model="haiku", allowed_tools=(),
+            work_dir=work_dir,
+            project=project,
             purpose="memory_summary",
+            model="haiku",   # criterion 7 pin on the claude default path
         )
     except Exception as exc:  # noqa: BLE001
         _log(f"summarize failed: {exc}")
@@ -288,9 +295,11 @@ def handle_session_imported(event) -> None:
 
 
 def _reflect_once(project: str, ctx, scores_db: str, candidate_id: str) -> dict:
-    """Build the reflect prompt for one candidate and invoke claude ONCE.
+    """Build the reflect prompt for one candidate and run ONE inference
+    through reflection_runner's backend seam (task cba42d6b): the default
+    stays the claude CLI with the exact prior arguments; PRISM_REFLECTION_
+    BACKEND=local|pi routes the same brief at the micro-model backends.
     Returns the parsed verdict ({} on any failure)."""
-    from prism_service.inference import claude_cli
     from prism_service.services import reflection_runner as rr
     from prism_service.services import source_service as ss
 
@@ -316,7 +325,7 @@ def _reflect_once(project: str, ctx, scores_db: str, candidate_id: str) -> dict:
         source_dir = ctx._data_dir
     prompt = rr._build_prompt(project, str(source_dir), candidate_id, row, scope)
     try:
-        result = claude_cli.invoke(
+        result = rr._invoke_backend(
             prompt=prompt, work_dir=str(source_dir), plugin_dir=str(source_dir),
             max_turns=15, allowed_tools=rr.DEFAULT_REFLECT_TOOLS,
             project=project, purpose="prism-reflect",

--- a/services/prism-service/prism_service/services/graph_enrich.py
+++ b/services/prism-service/prism_service/services/graph_enrich.py
@@ -248,16 +248,15 @@ def active_backend() -> str:
 
 def _enrich_local(scope: dict, project: str) -> tuple[str, str]:
     """Local-backend leg of enrich_one: same render_prompt contract,
-    json_mode completion against inference.local_llm, and a run-ledger
-    row (backend='local' + input/output tokens) so telemetry survives
-    the backend flip. Any failure returns ("", "") — the cycle moves on
-    and retries next sweep, exactly like a claude failure."""
-    import time as _time
-
+    json_mode completion against inference.local_llm. The completion
+    records ITSELF in the pi_runs audit ledger (backend='local',
+    purpose='graph_enrich', project, input/output token split) — pi_runs
+    is THE ledger for pi|local runs (task d1d4fe00); claude_runs stays
+    claude-only. Any failure returns ("", "") — the cycle moves on and
+    retries next sweep, exactly like a claude failure."""
     from prism_service.inference import local_llm
 
     mdl = local_llm.configured_model()
-    ts_start = _time.time()
     try:
         out = local_llm.complete(
             render_prompt(scope),
@@ -270,25 +269,7 @@ def _enrich_local(scope: dict, project: str) -> tuple[str, str]:
     except Exception as exc:
         _log(f"enrich_one local backend raised: {exc}")
         return "", ""
-    ts_end = _time.time()
-    text = out.get("text") or ""
-    try:
-        from prism_service.services import claude_run_log
-
-        claude_run_log.record_local_run(
-            project=project, purpose="graph_enrich",
-            backend="local", model=mdl,
-            final_text=text,
-            usage={
-                "input_tokens": int(out.get("input_tokens") or 0),
-                "output_tokens": int(out.get("output_tokens")
-                                     or out.get("tokens") or 0),
-            },
-            ts_start=ts_start, ts_end=ts_end,
-        )
-    except Exception:
-        pass  # ledger is best-effort — never fail the enrich cycle
-    return _parse(text)
+    return _parse(out.get("text") or "")
 
 
 def enrich_one(scope: dict, project: str) -> tuple[str, str]:

--- a/services/prism-service/prism_service/services/graph_enrich.py
+++ b/services/prism-service/prism_service/services/graph_enrich.py
@@ -23,6 +23,13 @@ Env:
   PRISM_GRAPH_ENRICH_WORKER=off            # default on
   PRISM_GRAPH_ENRICH_WORKER_INTERVAL=120   # seconds between sweeps
   PRISM_GRAPH_ENRICH_WORKER_MAX_PER_CYCLE=4
+  PRISM_GRAPH_ENRICH_BACKEND=local         # route the {name, purpose}
+                                           # extraction at the keyless local
+                                           # micro model (inference.local_llm,
+                                           # json_mode) instead of `claude -p`
+                                           # (default: claude); runs land in
+                                           # the run ledger with
+                                           # backend='local' + token counts
 """
 
 from __future__ import annotations
@@ -230,9 +237,67 @@ def _parse(text: str) -> tuple[str, str]:
     return name, purpose
 
 
+def active_backend() -> str:
+    """Graph-enrich inference seam selector (task f669c5ce, claude-p-exit
+    epic): PRISM_GRAPH_ENRICH_BACKEND=local routes the {name, purpose}
+    extraction at the keyless local micro model; anything else stays the
+    claude CLI (the historical default)."""
+    raw = (os.environ.get("PRISM_GRAPH_ENRICH_BACKEND") or "").strip().lower()
+    return "local" if raw == "local" else "claude"
+
+
+def _enrich_local(scope: dict, project: str) -> tuple[str, str]:
+    """Local-backend leg of enrich_one: same render_prompt contract,
+    json_mode completion against inference.local_llm, and a run-ledger
+    row (backend='local' + input/output tokens) so telemetry survives
+    the backend flip. Any failure returns ("", "") — the cycle moves on
+    and retries next sweep, exactly like a claude failure."""
+    import time as _time
+
+    from prism_service.inference import local_llm
+
+    mdl = local_llm.configured_model()
+    ts_start = _time.time()
+    try:
+        out = local_llm.complete(
+            render_prompt(scope),
+            model=mdl,
+            json_mode=True,
+            max_tokens=256,
+            purpose="graph_enrich",
+            project=project,
+        )
+    except Exception as exc:
+        _log(f"enrich_one local backend raised: {exc}")
+        return "", ""
+    ts_end = _time.time()
+    text = out.get("text") or ""
+    try:
+        from prism_service.services import claude_run_log
+
+        claude_run_log.record_local_run(
+            project=project, purpose="graph_enrich",
+            backend="local", model=mdl,
+            final_text=text,
+            usage={
+                "input_tokens": int(out.get("input_tokens") or 0),
+                "output_tokens": int(out.get("output_tokens")
+                                     or out.get("tokens") or 0),
+            },
+            ts_start=ts_start, ts_end=ts_end,
+        )
+    except Exception:
+        pass  # ledger is best-effort — never fail the enrich cycle
+    return _parse(text)
+
+
 def enrich_one(scope: dict, project: str) -> tuple[str, str]:
-    """Infer (name, purpose) for one scope via claude -p. Returns ("","")
-    on any failure so the caller moves on and retries next cycle."""
+    """Infer (name, purpose) for one scope via the env-gated backend seam
+    (`claude -p` by default; PRISM_GRAPH_ENRICH_BACKEND=local for the
+    keyless micro model). Returns ("","") on any failure so the caller
+    moves on and retries next cycle."""
+    if active_backend() == "local":
+        return _enrich_local(scope, project)
     from prism_service.inference import claude_cli
     from prism_service.project_context import get_project
     try:
@@ -275,7 +340,7 @@ def _enrich_kind(graph, project, scope_kind, scopes, budget, out):
         if not name:
             out["errors"] += 1
             continue
-        prov = f"claude @ {time.strftime('%Y-%m-%d')}"
+        prov = f"{active_backend()} @ {time.strftime('%Y-%m-%d')}"
         if graph.upsert_annotation(scope_kind, s["scope_id"], "name",
                                    name, purpose, s["input_hash"], prov):
             out["enriched"] += 1

--- a/services/prism-service/prism_service/services/memory_ops/base.py
+++ b/services/prism-service/prism_service/services/memory_ops/base.py
@@ -16,8 +16,13 @@ Plus four data attributes that drive routing + audit:
   * ``op_type``    — the op family name, written to ``consolidation_runs.op_type``.
   * ``schema``     — the JSON shape the verdict must satisfy.
   * ``model``      — per-op model name for ``claude_cli.invoke(model=...)``;
-    empty string falls through to the CLI default (Sonnet). Cheap ops
-    (forget / prune) default to a Haiku; synthesis ops (distill) to Opus.
+    empty string falls through to the runner's ``CLAUDE_MODEL_MAP`` entry
+    (distill_procedural -> Opus) and then the CLI default (Sonnet). Cheap
+    ops (forget / prune) ride the default; synthesis pins live in the map.
+  * ``local_model`` — per-op model for the env-gated local backend
+    (``PRISM_MEMORY_OPS_BACKEND=local``, task 9f61d484); empty string falls
+    through to the runner's ``LOCAL_MODEL_MAP`` entry and then
+    ``local_llm.configured_model()`` (the bench-ranked micro model).
   * ``provenance`` — static provenance metadata stamped onto stored memories.
 """
 
@@ -38,8 +43,13 @@ class MemoryOperation(ABC):
     op_type: str = ""
     #: Verdict JSON schema (field -> type hint). Advisory, not enforced here.
     schema: dict[str, Any] = {}
-    #: Per-op model for ``claude_cli.invoke(model=...)``. "" => CLI default.
+    #: Per-op model for ``claude_cli.invoke(model=...)``. "" => the runner's
+    #: CLAUDE_MODEL_MAP entry, then the CLI default.
     model: str = ""
+    #: Per-op model for the local backend (PRISM_MEMORY_OPS_BACKEND=local).
+    #: "" => the runner's LOCAL_MODEL_MAP entry, then
+    #: local_llm.configured_model().
+    local_model: str = ""
     #: Static provenance metadata stamped onto memories this op produces.
     provenance: dict[str, Any] = {}
 

--- a/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
+++ b/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
@@ -106,8 +106,12 @@ class DistillProceduralOperation(MemoryOperation):
         "invalidate_memory_ids": "[]",
         "confidence": "float 0-1",
     }
-    # Synthesis op -> Opus (cheap ops use Haiku); "" falls to CLI default.
-    model = "claude-opus-4-20250514"
+    # Model routing lives in runner._CLAUDE_OP_MODEL (task 9f61d484): the
+    # opus pin for this synthesis op is the op map's entry, NOT a hardcoded
+    # id here, so the map is the single home of routing. "" here means the
+    # runner supplies distill's model (opus for claude; qwen3 only on the
+    # PRISM_MEMORY_OPS_DISTILL_LOCAL opt-in — micro-model distill is uncertain).
+    model = ""
     provenance = {"source": "distill_procedural", "tier": 2}
 
     def select(self, project: str) -> list:

--- a/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
+++ b/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
@@ -106,11 +106,12 @@ class DistillProceduralOperation(MemoryOperation):
         "invalidate_memory_ids": "[]",
         "confidence": "float 0-1",
     }
-    # Model routing lives in runner._CLAUDE_OP_MODEL (task 9f61d484): the
+    # Model routing lives in runner.CLAUDE_MODEL_MAP (task 9f61d484): the
     # opus pin for this synthesis op is the op map's entry, NOT a hardcoded
     # id here, so the map is the single home of routing. "" here means the
-    # runner supplies distill's model (opus for claude; qwen3 only on the
-    # PRISM_MEMORY_OPS_DISTILL_LOCAL opt-in — micro-model distill is uncertain).
+    # runner supplies distill's model (opus on the default claude path; a
+    # local micro model only on the PRISM_MEMORY_OPS_BACKEND=local opt-in —
+    # micro-model distill quality is uncertain and measured, not assumed).
     model = ""
     provenance = {"source": "distill_procedural", "tier": 2}
 

--- a/services/prism-service/prism_service/services/memory_ops/runner.py
+++ b/services/prism-service/prism_service/services/memory_ops/runner.py
@@ -15,13 +15,97 @@ marks the row ``completed``, so a second tick on the same item short-circuits
 from __future__ import annotations
 
 import json as _json
+import os
 import sqlite3
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 from prism_service.inference import claude_cli
 from prism_service.services.memory_ops.base import MemoryOperation
+
+# Per-op model routing (task 9f61d484, claude-p-exit epic be898578).
+#
+# CLAUDE_MODEL_MAP is the SINGLE home of the claude-backend model pins: the
+# opus id for the distill_procedural synthesis op lives HERE, never hardcoded
+# in the op class (oracle: no hardcoded opus id remains in distill_procedural).
+# distill's opus pin is the DEFAULT path (env unset) — micro-model distill
+# quality is uncertain, so going local for distill is an explicit opt-in via
+# PRISM_MEMORY_OPS_BACKEND=local (which routes EVERY op at the local backend).
+CLAUDE_MODEL_MAP: dict[str, str] = {
+    "distill_procedural": "claude-opus-4-20250514",
+}
+# LOCAL_MODEL_MAP pins per-op local models for the local backend; empty by
+# default (ops fall through to local_llm.configured_model() — the
+# bench-ranked micro model, benchmarks/micro_llm_selflearn). An op may also
+# carry a ``local_model`` attribute that wins over the map.
+LOCAL_MODEL_MAP: dict[str, str] = {}
+
+
+def _op_backend(op_type: str) -> str:
+    """Resolve the inference backend for one op. Default (env unset / any
+    value but 'local') -> 'claude' (claude_cli.invoke with CLAUDE_MODEL_MAP
+    routing). PRISM_MEMORY_OPS_BACKEND=local routes EVERY op at the keyless
+    local micro model (local_llm.complete)."""
+    backend = (os.environ.get("PRISM_MEMORY_OPS_BACKEND") or "").strip().lower()
+    return "local" if backend == "local" else "claude"
+
+
+def _resolve_model(op: MemoryOperation, backend: str) -> str:
+    """Model id for `op` under `backend`.
+
+    Claude: the op's own ``model`` (routing intact) else CLAUDE_MODEL_MAP's
+    entry (distill_procedural -> opus) else "" (CLI default Sonnet).
+    Local: the op's ``local_model`` else LOCAL_MODEL_MAP's entry else
+    local_llm.configured_model() (the bench-ranked micro model)."""
+    op_type = getattr(op, "op_type", "") or ""
+    if backend == "local":
+        from prism_service.inference import local_llm
+
+        return (getattr(op, "local_model", "") or ""
+                or LOCAL_MODEL_MAP.get(op_type)
+                or local_llm.configured_model())
+    return (getattr(op, "model", "") or "") or CLAUDE_MODEL_MAP.get(op_type) or ""
+
+
+class _LocalOpResult:
+    """claude_cli-result-shaped adapter for the local micro-LLM backend
+    (mirrors memory_summary_worker._LocalBackendResult) so run_one's
+    exit_code / final_text() / run_id / duration_s handling is untouched."""
+
+    def __init__(self, text: str, run_id: str = "", duration_s: float = 0.0):
+        self._text = text
+        self.exit_code = 0
+        self.run_id = run_id
+        self.duration_s = duration_s
+
+    def final_text(self) -> str:
+        return self._text
+
+
+def _invoke_local(*, prompt: str, model: str, project: str, op_type: str):
+    """Route one memory op at the keyless local micro model. Every op's
+    verdict is a JSON object, so json_mode=True. local_llm.complete records
+    the run in the pi_run_log ledger (backend='local', purpose/project
+    passthrough, input/output token split) — pi_runs is THE ledger for
+    pi|local runs (task d1d4fe00); the run_id rides back on the result."""
+    from prism_service.inference import local_llm
+
+    t0 = time.perf_counter()
+    out = local_llm.complete(
+        prompt,
+        model=model,
+        json_mode=True,
+        max_tokens=1024,
+        purpose=f"memory-ops:{op_type}" if op_type else "memory-ops",
+        project=project,
+    )
+    return _LocalOpResult(
+        out.get("text") or "",
+        run_id=out.get("run_id") or "",
+        duration_s=round(time.perf_counter() - t0, 3),
+    )
 
 
 @dataclass
@@ -118,21 +202,31 @@ def run_one(op: MemoryOperation, item: Any, project: str) -> OperationResult:
 
     prompt = op.build_prompt(item, project)
 
-    # Model routing: op.model drives claude_cli.invoke(model=...); "" falls
-    # through to the CLI default (Sonnet). No hard-coding here.
+    # Backend + model routing (task 9f61d484). Default -> claude_cli.invoke
+    # with the op map's model (distill -> opus, else op.model else CLI
+    # default). PRISM_MEMORY_OPS_BACKEND=local routes at the keyless local
+    # micro model via local_llm.complete (json_mode — every verdict is JSON),
+    # which itself records the pi_run_log ledger row (backend + token split).
+    backend = _op_backend(op_type)
+    model = _resolve_model(op, backend)
     try:
-        result = claude_cli.invoke(
-            prompt=prompt,
-            work_dir=str(source_dir),
-            plugin_dir=str(source_dir),
-            model=getattr(op, "model", "") or "",
-            project=project,
-            purpose=f"prism-{op_type}" if op_type else "prism-memory-op",
-        )
+        if backend == "local":
+            result = _invoke_local(
+                prompt=prompt, model=model, project=project, op_type=op_type,
+            )
+        else:
+            result = claude_cli.invoke(
+                prompt=prompt,
+                work_dir=str(source_dir),
+                plugin_dir=str(source_dir),
+                model=model,
+                project=project,
+                purpose=f"prism-{op_type}" if op_type else "prism-memory-op",
+            )
     except Exception as exc:
         return OperationResult(
-            ok=False, op_type=op_type, error=f"claude_cli failed: {exc}",
-            item=item,
+            ok=False, op_type=op_type,
+            error=f"{backend} inference failed: {exc}", item=item,
         )
 
     raw_text = result.final_text() or ""

--- a/services/prism-service/prism_service/services/memory_summary_worker.py
+++ b/services/prism-service/prism_service/services/memory_summary_worker.py
@@ -19,8 +19,9 @@ Env:
   PRISM_MEMORY_SUMMARY_BACKEND=local       # route summaries at the keyless
                                            # local micro model instead of
                                            # `claude -p` (default: claude);
-                                           # runs still land in claude_runs
-                                           # with backend='local' + tokens
+                                           # runs land in the pi_runs audit
+                                           # ledger (backend='local' +
+                                           # input/output tokens)
 """
 
 from __future__ import annotations
@@ -147,9 +148,11 @@ def _invoke_backend(*, prompt: str, work_dir: str, project: str,
     Default: the claude CLI, exactly as before (``model`` passes through so
     call sites like event_handlers' novelty summarizer keep their haiku
     pin). PRISM_MEMORY_SUMMARY_BACKEND=local routes the SAME distillation
-    prompt at the keyless local micro model (inference.local_llm) and
-    records the run in the claude_runs ledger with backend='local' +
-    input/output token counts — telemetry survives the backend flip.
+    prompt at the keyless local micro model (inference.local_llm), which
+    records the run itself in the pi_runs audit ledger (backend='local',
+    purpose/project passthrough, input/output token split) — pi_runs is
+    THE ledger for pi|local runs (task d1d4fe00); claude_runs stays
+    claude-only. run_id rides back on the completion output.
     """
     backend = (os.environ.get("PRISM_MEMORY_SUMMARY_BACKEND") or "").strip().lower()
     if backend == "local":
@@ -162,28 +165,14 @@ def _invoke_backend(*, prompt: str, work_dir: str, project: str,
             model=mdl,
             system=_LOCAL_DISTILL_SYSTEM,
             max_tokens=128,
+            purpose=purpose,
+            project=project,
         )
         ts_end = time.time()
         text = out.get("text") or ""
-        run_id = ""
-        try:
-            from prism_service.services import claude_run_log
-
-            run_id = claude_run_log.record_local_run(
-                project=project, purpose=purpose,
-                backend="local", model=mdl,
-                final_text=text,
-                usage={
-                    "input_tokens": int(out.get("input_tokens") or 0),
-                    "output_tokens": int(out.get("output_tokens")
-                                         or out.get("tokens") or 0),
-                },
-                ts_start=ts_start, ts_end=ts_end,
-            )
-        except Exception:
-            pass  # ledger is best-effort — never fail the summary
         return _LocalBackendResult(
-            text, run_id=run_id, duration_s=round(ts_end - ts_start, 3))
+            text, run_id=out.get("run_id") or "",
+            duration_s=round(ts_end - ts_start, 3))
     from prism_service.inference import claude_cli
 
     return claude_cli.invoke(

--- a/services/prism-service/prism_service/services/memory_summary_worker.py
+++ b/services/prism-service/prism_service/services/memory_summary_worker.py
@@ -16,6 +16,11 @@ Env:
   PRISM_MEMORY_SUMMARY_WORKER=off          # default on; off disables it
   PRISM_MEMORY_SUMMARY_WORKER_INTERVAL=300  # seconds between sweeps
   PRISM_MEMORY_SUMMARY_WORKER_MAX_PER_CYCLE=3
+  PRISM_MEMORY_SUMMARY_BACKEND=local       # route summaries at the keyless
+                                           # local micro model instead of
+                                           # `claude -p` (default: claude);
+                                           # runs still land in claude_runs
+                                           # with backend='local' + tokens
 """
 
 from __future__ import annotations
@@ -111,10 +116,94 @@ def _strip(text: str) -> str:
     return " ".join(t.split())
 
 
+class _LocalBackendResult:
+    """claude_cli-result-shaped adapter for the local micro-LLM backend
+    (mirrors reflection_runner._LocalResult) so summarize_one's existing
+    exit_code / final_text handling is untouched."""
+
+    def __init__(self, text: str, run_id: str = "", duration_s: float = 0.0):
+        self._text = text
+        self.exit_code = 0
+        self.run_id = run_id
+        self.duration_s = duration_s
+
+    def final_text(self) -> str:
+        return self._text
+
+
+# System prompt for the local distillation path. The user prompt stays the
+# unchanged render_prompt output — same contract both backends.
+_LOCAL_DISTILL_SYSTEM = (
+    "You distill PRISM project knowledge into skimmable tile text. "
+    "Reply with ONLY the single plain-English sentence the prompt asks "
+    "for — no preamble, no quotation marks."
+)
+
+
+def _invoke_backend(*, prompt: str, work_dir: str, project: str,
+                    purpose: str, model: str = ""):
+    """Memory-summary inference seam (task 5fc1683e, claude-p-exit epic).
+
+    Default: the claude CLI, exactly as before (``model`` passes through so
+    call sites like event_handlers' novelty summarizer keep their haiku
+    pin). PRISM_MEMORY_SUMMARY_BACKEND=local routes the SAME distillation
+    prompt at the keyless local micro model (inference.local_llm) and
+    records the run in the claude_runs ledger with backend='local' +
+    input/output token counts — telemetry survives the backend flip.
+    """
+    backend = (os.environ.get("PRISM_MEMORY_SUMMARY_BACKEND") or "").strip().lower()
+    if backend == "local":
+        from prism_service.inference import local_llm
+
+        mdl = local_llm.configured_model()
+        ts_start = time.time()
+        out = local_llm.complete(
+            prompt,
+            model=mdl,
+            system=_LOCAL_DISTILL_SYSTEM,
+            max_tokens=128,
+        )
+        ts_end = time.time()
+        text = out.get("text") or ""
+        run_id = ""
+        try:
+            from prism_service.services import claude_run_log
+
+            run_id = claude_run_log.record_local_run(
+                project=project, purpose=purpose,
+                backend="local", model=mdl,
+                final_text=text,
+                usage={
+                    "input_tokens": int(out.get("input_tokens") or 0),
+                    "output_tokens": int(out.get("output_tokens")
+                                         or out.get("tokens") or 0),
+                },
+                ts_start=ts_start, ts_end=ts_end,
+            )
+        except Exception:
+            pass  # ledger is best-effort — never fail the summary
+        return _LocalBackendResult(
+            text, run_id=run_id, duration_s=round(ts_end - ts_start, 3))
+    from prism_service.inference import claude_cli
+
+    return claude_cli.invoke(
+        prompt=prompt,
+        work_dir=work_dir,
+        plugin_dir=work_dir,
+        max_turns=1,
+        model=model,
+        project=project,
+        purpose=purpose,
+        allowed_tools=(),
+    )
+
+
 def summarize_one(name: str, description: str, project: str) -> str:
-    """Synchronously generate a summary via `claude -p`. Returns the
-    cleaned single-sentence summary, or "" on any failure (auth missing,
-    parse error, etc.) so the caller can move on and retry next cycle."""
+    """Synchronously generate a summary via the backend seam (`claude -p`
+    by default; PRISM_MEMORY_SUMMARY_BACKEND=local for the micro model).
+    Returns the cleaned single-sentence summary, or "" on any failure
+    (auth missing, endpoint down, parse error, etc.) so the caller can
+    move on and retry next cycle."""
     from prism_service.inference import claude_cli
     from prism_service.project_context import get_project
     prompt = render_prompt(name, description)
@@ -127,14 +216,11 @@ def summarize_one(name: str, description: str, project: str) -> str:
     except Exception:
         work_dir = os.getcwd()
     try:
-        result = claude_cli.invoke(
+        result = _invoke_backend(
             prompt=prompt,
             work_dir=work_dir,
-            plugin_dir=work_dir,
-            max_turns=1,
             project=project,
             purpose="memory_summary",
-            allowed_tools=(),
         )
     except claude_cli.ClaudeNotLoggedInError:
         _log("claude not logged in; pausing this cycle")

--- a/services/prism-service/prism_service/services/okf_host.py
+++ b/services/prism-service/prism_service/services/okf_host.py
@@ -31,6 +31,51 @@ def _slug(text: str) -> str:
     return s or "untitled"
 
 
+def _path_segments(title: str) -> list[str]:
+    """File-concept title -> its path segments (leading slashes stripped)."""
+    return [s for s in (title or "").strip("/").split("/") if s]
+
+
+def _is_path_suffix(short: list[str], long: list[str]) -> bool:
+    """True when *short* is a segment-aligned tail of *long* (a bare
+    'prism_cli.py' vs the qualified 'prism_service/cli/prism_cli.py'). A
+    shared basename alone ('pkg_a/utils.py' vs 'pkg_b/utils.py') is NOT a
+    suffix, so genuinely distinct files are never merged."""
+    if not short or len(short) > len(long):
+        return False
+    return all(short[-1 - i] == long[-1 - i] for i in range(len(short)))
+
+
+def dedupe_file_concepts(nodes: list[dict]) -> list[dict]:
+    """Collapse file concepts that resolve to the SAME file (task 61aafcc6).
+
+    /understand's Code domain listed one file twice — a bare 'prism_cli.py' and
+    the qualified 'prism_service/cli/prism_cli.py' — because they are two memory
+    concepts for the same file, inflating the domain's count. Dedup file-type
+    concepts by resolved path: when one file title is a segment-aligned
+    path-suffix of another, keep the most-qualified (longest-path) title and
+    drop the less-qualified duplicate. Non-file concepts pass through untouched;
+    distinct files sharing only a basename are preserved. Pure + order-stable.
+    """
+    files = [n for n in nodes if n.get("type") == "file"]
+    # Longest path first so the qualified concept is the one we keep.
+    ranked = sorted(files, key=lambda n: len(_path_segments(n.get("title", ""))),
+                    reverse=True)
+    kept: list[dict] = []
+    dropped: set = set()
+    for n in ranked:
+        segs = _path_segments(n.get("title", ""))
+        if not segs:
+            kept.append(n)
+            continue
+        if any(_is_path_suffix(segs, _path_segments(k.get("title", "")))
+               for k in kept):
+            dropped.add(id(n))
+        else:
+            kept.append(n)
+    return [n for n in nodes if id(n) not in dropped]
+
+
 def _first_sentence(text: str, limit: int = 200) -> str:
     text = (text or "").strip().replace("\n", " ")
     head = text.split(". ", 1)[0]
@@ -238,7 +283,14 @@ class OkfHost:
                 "path": path,
                 "description": str(c.frontmatter.get("description", "") or ""),
             })
-        return {"nodes": nodes, "edges": self._edges()}
+        # Dedup file concepts that resolve to the same file (task 61aafcc6) so
+        # the /understand Code domain doesn't list one file twice and inflate
+        # its count; then drop any edge left dangling by a removed node.
+        nodes = dedupe_file_concepts(nodes)
+        kept_ids = {n["id"] for n in nodes}
+        edges = [e for e in self._edges()
+                 if e["source"] in kept_ids and e["target"] in kept_ids]
+        return {"nodes": nodes, "edges": edges}
 
     def backlinks(self, target_id: str) -> list[dict]:
         """Inbound 'cited by' = concepts whose body links to this concept."""

--- a/services/prism-service/prism_service/services/pi_run_log.py
+++ b/services/prism-service/prism_service/services/pi_run_log.py
@@ -26,10 +26,18 @@ Manifest line schema (each row a complete JSON object):
         "prompt_chars": 1234,
         "tools_used":   [{"name": "brain_search", "ms": 40.2, "ok": true}],
         "turns":        3,                   # 0 for tool-less local runs
-        "tokens":       42,
+        "tokens":       42,                  # completion side (KPI strip)
+        "input_tokens":  33,                 # additive split (task d1d4fe00)
+        "output_tokens": 42,                 # — telemetry survives the
+                                             # claude_runs -> pi_runs move
         "ok":           true,
         "error":        ""                   # first 1 KB on failure
     }
+
+    pi_runs is THE ledger for backend pi|local (task d1d4fe00):
+    local_llm.complete and pi_agent.invoke record here themselves, so
+    seam callers must NOT write their own row — they pass purpose/
+    project through and read the run_id back off the completion.
 
 Unlike claude runs there is NO per-run stream file: the tool receipts
 are small structured rows that ride the manifest line directly, which
@@ -101,6 +109,8 @@ def record_run(
     tools_used: Optional[list] = None,
     duration_ms: float = 0.0,
     tokens: int = 0,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
     turns: int = 0,
     ok: bool = True,
     error: str = "",
@@ -129,6 +139,10 @@ def record_run(
             "tools_used": _clean_tools(tools_used),
             "turns": int(turns or 0),
             "tokens": int(tokens or 0),
+            # Additive input/output split (task d1d4fe00) — the fields
+            # the claude_runs ledger carried, preserved on the move.
+            "input_tokens": int(input_tokens or 0),
+            "output_tokens": int(output_tokens or 0),
             "ok": bool(ok),
             "error": _truncate(str(error or ""), _ERROR_MAX),
         }

--- a/services/prism-service/prism_service/services/pi_run_log.py
+++ b/services/prism-service/prism_service/services/pi_run_log.py
@@ -177,9 +177,10 @@ def _trim_to_limit() -> None:
     tmp.replace(_MANIFEST)
 
 
-def list_recent(limit: int = 50, project: Optional[str] = None) -> list[dict]:
-    """Return the most recent runs, newest first. Reads the whole
-    manifest (bounded by RUN_LOG_LIMIT) once and slices."""
+def _read_filtered(project: Optional[str] = None) -> list[dict]:
+    """Read the whole manifest (bounded by RUN_LOG_LIMIT) once and return
+    the rows NEWEST FIRST, filtered by project. Shared by list_recent and
+    count_recent so a page and its grand total come from one read."""
     if not _MANIFEST.exists():
         return []
     out: list[dict] = []
@@ -198,7 +199,23 @@ def list_recent(limit: int = 50, project: Optional[str] = None) -> list[dict]:
     except OSError:
         return []
     out.reverse()  # newest first
-    return out[:limit]
+    return out
+
+
+def list_recent(limit: int = 50, project: Optional[str] = None,
+                offset: int = 0) -> list[dict]:
+    """Return one newest-first PAGE of runs. `offset` skips that many
+    rows before taking `limit` (an offset past the end yields []); both
+    default to the full-first-page behavior. Pair with count_recent for
+    the grand total when paginating."""
+    off = max(0, int(offset))
+    return _read_filtered(project)[off:off + limit]
+
+
+def count_recent(project: Optional[str] = None) -> int:
+    """Full count of runs (project-filtered) — the grand total the API
+    reports alongside a page so a client can paginate."""
+    return len(_read_filtered(project))
 
 
 def get_run(run_id: str) -> Optional[dict]:

--- a/services/prism-service/prism_service/services/pi_run_log.py
+++ b/services/prism-service/prism_service/services/pi_run_log.py
@@ -30,6 +30,7 @@ Manifest line schema (each row a complete JSON object):
         "input_tokens":  33,                 # additive split (task d1d4fe00)
         "output_tokens": 42,                 # — telemetry survives the
                                              # claude_runs -> pi_runs move
+        "task_id":      "fc08da8d-...",      # driven task (fc08da8d); "" adhoc
         "ok":           true,
         "error":        ""                   # first 1 KB on failure
     }
@@ -112,6 +113,7 @@ def record_run(
     input_tokens: int = 0,
     output_tokens: int = 0,
     turns: int = 0,
+    task_id: str = "",
     ok: bool = True,
     error: str = "",
     ts_start: Optional[float] = None,
@@ -143,6 +145,10 @@ def record_run(
             # the claude_runs ledger carried, preserved on the move.
             "input_tokens": int(input_tokens or 0),
             "output_tokens": int(output_tokens or 0),
+            # Task-attribution (task fc08da8d): the task this run acted on,
+            # so the conductor tile burn + task detail can attribute the PI
+            # agent's tokens to the driven task. Additive, default "".
+            "task_id": str(task_id or ""),
             "ok": bool(ok),
             "error": _truncate(str(error or ""), _ERROR_MAX),
         }
@@ -177,10 +183,12 @@ def _trim_to_limit() -> None:
     tmp.replace(_MANIFEST)
 
 
-def _read_filtered(project: Optional[str] = None) -> list[dict]:
+def _read_filtered(project: Optional[str] = None,
+                   task_id: Optional[str] = None) -> list[dict]:
     """Read the whole manifest (bounded by RUN_LOG_LIMIT) once and return
-    the rows NEWEST FIRST, filtered by project. Shared by list_recent and
-    count_recent so a page and its grand total come from one read."""
+    the rows NEWEST FIRST, filtered by project (and, when given, task_id).
+    Shared by list_recent and count_recent so a page and its grand total
+    come from one read."""
     if not _MANIFEST.exists():
         return []
     out: list[dict] = []
@@ -195,6 +203,8 @@ def _read_filtered(project: Optional[str] = None) -> list[dict]:
                 continue
             if project and entry.get("project") != project:
                 continue
+            if task_id and entry.get("task_id") != task_id:
+                continue
             out.append(entry)
     except OSError:
         return []
@@ -203,13 +213,14 @@ def _read_filtered(project: Optional[str] = None) -> list[dict]:
 
 
 def list_recent(limit: int = 50, project: Optional[str] = None,
-                offset: int = 0) -> list[dict]:
+                offset: int = 0, task_id: Optional[str] = None) -> list[dict]:
     """Return one newest-first PAGE of runs. `offset` skips that many
     rows before taking `limit` (an offset past the end yields []); both
-    default to the full-first-page behavior. Pair with count_recent for
-    the grand total when paginating."""
+    default to the full-first-page behavior. `task_id` (task fc08da8d)
+    narrows to the runs attributed to one driven task. Pair with
+    count_recent for the grand total when paginating."""
     off = max(0, int(offset))
-    return _read_filtered(project)[off:off + limit]
+    return _read_filtered(project, task_id=task_id)[off:off + limit]
 
 
 def count_recent(project: Optional[str] = None) -> int:

--- a/services/prism-service/prism_service/services/pi_run_log.py
+++ b/services/prism-service/prism_service/services/pi_run_log.py
@@ -1,0 +1,219 @@
+"""Persistent audit ledger of PRISM's internal pi/local inference runs.
+
+Every internal agentic job through `inference.pi_agent.invoke` (incl.
+reflection with PRISM_REFLECTION_BACKEND=pi) and every plain completion
+through `inference.local_llm.complete` is recorded so operators can
+VISUALLY audit what the internal agent is doing (owner directive:
+internal tools come with an audit surface by default). This is the
+sibling of services/claude_run_log.py — same pattern (append-only
+manifest under DATA_DIR, env-tunable bound + trim, best-effort record,
+list_recent/get_run), different store and row shape:
+
+    /data/pi_runs/
+        manifest.jsonl          # one append-only line per run
+
+Manifest line schema (each row a complete JSON object):
+
+    {
+        "run_id":       "uuid hex, 12 chars",
+        "ts":           1779417347.123,      # run start (epoch s)
+        "ts_end":       1779417349.456,
+        "duration_ms":  2333.0,
+        "backend":      "pi" | "local",
+        "model":        "qwen3:0.6b",
+        "purpose":      "reflect" | "panel-bridge" | "adhoc",
+        "project":      "prism",             # may be ""
+        "prompt_chars": 1234,
+        "tools_used":   [{"name": "brain_search", "ms": 40.2, "ok": true}],
+        "turns":        3,                   # 0 for tool-less local runs
+        "tokens":       42,
+        "ok":           true,
+        "error":        ""                   # first 1 KB on failure
+    }
+
+Unlike claude runs there is NO per-run stream file: the tool receipts
+are small structured rows that ride the manifest line directly, which
+is why this is a sibling ledger rather than a `backend` field bolted
+onto claude_run_log (whose rows are subprocess-shaped: exit_code,
+stream_path, stderr_excerpt, final_text — and whose /api/claude-runs
+consumers render exactly those fields).
+
+`/api/pi-runs` reads this file from the tail; the SPA's /internal-agent
+audit view renders the rows. Bounded by RUN_LOG_LIMIT.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import uuid
+from typing import Optional
+
+from prism_service.config import DATA_DIR
+
+_RUNS_DIR = DATA_DIR / "pi_runs"
+_MANIFEST = _RUNS_DIR / "manifest.jsonl"
+
+# Bound on how many runs we keep. Operator-tunable via env.
+RUN_LOG_LIMIT = int(os.environ.get("PRISM_PI_RUN_LOG_LIMIT", "500"))
+_ERROR_MAX = 1024
+
+# The purposes the audit view groups by. Free-form strings are allowed
+# (the ledger never rejects a row over vocabulary) — these are the
+# canonical three.
+KNOWN_PURPOSES = ("reflect", "panel-bridge", "adhoc")
+
+
+def _truncate(s: str, limit: int) -> str:
+    if not s:
+        return ""
+    return s if len(s) <= limit else s[: limit - 1] + "…"
+
+
+def _clean_tools(tools_used: object) -> list[dict]:
+    """Normalize tool receipts to [{name, ms, ok}] — drop anything that
+    isn't dict-shaped so a malformed runner payload can't poison the
+    manifest line."""
+    out: list[dict] = []
+    for t in tools_used or []:
+        if not isinstance(t, dict):
+            continue
+        try:
+            out.append({
+                "name": str(t.get("name", "")),
+                "ms": float(t.get("ms", 0) or 0),
+                "ok": bool(t.get("ok", False)),
+            })
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def record_run(
+    *,
+    backend: str,
+    model: str,
+    purpose: str = "adhoc",
+    project: str = "",
+    prompt_chars: int = 0,
+    tools_used: Optional[list] = None,
+    duration_ms: float = 0.0,
+    tokens: int = 0,
+    turns: int = 0,
+    ok: bool = True,
+    error: str = "",
+    ts_start: Optional[float] = None,
+    ts_end: Optional[float] = None,
+) -> Optional[str]:
+    """Append one manifest line; trim older runs. Best-effort: NEVER
+    raises into the inference caller path — returns the run_id on
+    success, None on failure."""
+    try:
+        _RUNS_DIR.mkdir(parents=True, exist_ok=True)
+        now = time.time()
+        start = float(ts_start) if ts_start is not None else now
+        end = float(ts_end) if ts_end is not None else now
+        run_id = uuid.uuid4().hex[:12]
+        entry = {
+            "run_id": run_id,
+            "ts": start,
+            "ts_end": end,
+            "duration_ms": max(0.0, float(duration_ms)),
+            "backend": str(backend or ""),
+            "model": str(model or ""),
+            "purpose": str(purpose or "adhoc"),
+            "project": str(project or ""),
+            "prompt_chars": int(prompt_chars or 0),
+            "tools_used": _clean_tools(tools_used),
+            "turns": int(turns or 0),
+            "tokens": int(tokens or 0),
+            "ok": bool(ok),
+            "error": _truncate(str(error or ""), _ERROR_MAX),
+        }
+        with _MANIFEST.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, separators=(",", ":")) + "\n")
+        _trim_to_limit()
+        return run_id
+    except Exception as e:
+        # Logging is best-effort — never let a ledger failure break
+        # reflection or any other internal inference path.
+        print(
+            f"[pi_run_log] record_run failed: {type(e).__name__}: {e}",
+            file=sys.stderr, flush=True,
+        )
+        return None
+
+
+def _trim_to_limit() -> None:
+    """If the manifest exceeds RUN_LOG_LIMIT lines, drop the oldest.
+    Cheap because the manifest is bounded and line-oriented."""
+    if not _MANIFEST.exists():
+        return
+    try:
+        lines = _MANIFEST.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return
+    if len(lines) <= RUN_LOG_LIMIT:
+        return
+    kept = lines[len(lines) - RUN_LOG_LIMIT:]
+    tmp = _MANIFEST.with_suffix(".jsonl.tmp")
+    tmp.write_text("\n".join(kept) + "\n", encoding="utf-8")
+    tmp.replace(_MANIFEST)
+
+
+def list_recent(limit: int = 50, project: Optional[str] = None) -> list[dict]:
+    """Return the most recent runs, newest first. Reads the whole
+    manifest (bounded by RUN_LOG_LIMIT) once and slices."""
+    if not _MANIFEST.exists():
+        return []
+    out: list[dict] = []
+    try:
+        for line in _MANIFEST.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if project and entry.get("project") != project:
+                continue
+            out.append(entry)
+    except OSError:
+        return []
+    out.reverse()  # newest first
+    return out[:limit]
+
+
+def get_run(run_id: str) -> Optional[dict]:
+    """Return the manifest entry for a specific run_id (or None)."""
+    if not run_id or not _MANIFEST.exists():
+        return None
+    try:
+        for line in _MANIFEST.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if entry.get("run_id") == run_id:
+                return entry
+    except OSError:
+        return None
+    return None
+
+
+def infer_purpose(purpose: str, system: str) -> str:
+    """Resolve the recorded purpose: an explicit purpose wins; otherwise
+    the reflection engine is recognized by its system-prompt marker
+    (reflection_runner passes no purpose — it is owned by another
+    surface); everything else is adhoc."""
+    if purpose:
+        return purpose
+    if "reflection engine" in (system or "").lower():
+        return "reflect"
+    return "adhoc"

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -328,13 +328,41 @@ def _invoke_backend(
     project: str,
     purpose: str,
 ):
-    """Reflection inference seam (task ecb90f7e). Default: the claude CLI,
-    exactly as before. PRISM_REFLECTION_BACKEND=local routes through
-    inference.local_llm — a FREE local micro model (PRISM_LOCAL_LLM_MODEL,
-    bench-ranked in benchmarks/micro_llm_selflearn). The local path is
-    TOOL-LESS: the verdict is grounded solely by the brief baked into the
-    prompt, which is also why the prompt builder inlines the evidence."""
-    if (os.environ.get("PRISM_REFLECTION_BACKEND") or "").strip().lower() == "local":
+    """Reflection inference seam (tasks ecb90f7e + ac69ee28). Default: the
+    claude CLI, exactly as before. Two local micro-model backends:
+
+    PRISM_REFLECTION_BACKEND=pi — the pi-agent-core runtime (Node sidecar,
+    web/pi-runtime.mjs): AGENTIC reflection. The model can brain_search and
+    memory_recall mid-loop to ground its verdict and decline duplicates —
+    the memory/brain-expert behavior.
+
+    PRISM_REFLECTION_BACKEND=local — plain completion via inference.local_llm,
+    TOOL-LESS: the verdict is grounded solely by the brief in the prompt."""
+    backend = (os.environ.get("PRISM_REFLECTION_BACKEND") or "").strip().lower()
+    if backend == "pi":
+        from prism_service.inference import pi_agent
+
+        out = pi_agent.invoke(
+            prompt,
+            system=(
+                "You are PRISM's reflection engine and its memory/brain "
+                "expert. Use memory_recall FIRST to check whether the "
+                "knowledge already exists — if it does, do NOT propose it "
+                "again in new_memories. Use brain_search to verify file "
+                "claims. Your FINAL message must be ONLY the JSON verdict "
+                "object the task specifies — no prose."
+            ),
+            allowed_tools=("brain_search", "memory_recall"),
+            project=project,
+            max_turns=max_turns,
+        )
+        text = out.get("text") or ""
+        if not out.get("ok") and not text:
+            raise RuntimeError(f"pi runtime failed: {out.get('error') or 'no output'}")
+        result = _LocalResult(text, float(out.get("ms") or 0), int(out.get("tokens") or 0))
+        result.tools_used = out.get("tools_used") or []
+        return result
+    if backend == "local":
         from prism_service.inference import local_llm
 
         out = local_llm.complete(

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -19,7 +19,9 @@ One call ⇒ one candidate processed:
 from __future__ import annotations
 
 import json as _json
+import os
 import sqlite3
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -300,6 +302,60 @@ def _extract_verdict(raw_text: str) -> dict:
     raise ValueError("no JSON object found in verdict text")
 
 
+class _LocalResult:
+    """claude_cli-result-shaped adapter for the local micro-LLM backend."""
+
+    def __init__(self, text: str, ms: float, tokens: int):
+        self._text = text
+        self.exit_code = 0
+        self.run_id = f"local-{int(time.time())}"
+        self.ms = ms
+        self.tokens = tokens
+
+    def final_text(self) -> str:
+        return self._text
+
+
+def _invoke_backend(
+    *,
+    prompt: str,
+    work_dir: str,
+    plugin_dir: str,
+    max_turns: int,
+    allowed_tools: tuple[str, ...],
+    project: str,
+    purpose: str,
+):
+    """Reflection inference seam (task ecb90f7e). Default: the claude CLI,
+    exactly as before. PRISM_REFLECTION_BACKEND=local routes through
+    inference.local_llm — a FREE local micro model (PRISM_LOCAL_LLM_MODEL,
+    bench-ranked in benchmarks/micro_llm_selflearn). The local path is
+    TOOL-LESS: the verdict is grounded solely by the brief baked into the
+    prompt, which is also why the prompt builder inlines the evidence."""
+    if (os.environ.get("PRISM_REFLECTION_BACKEND") or "").strip().lower() == "local":
+        from prism_service.inference import local_llm
+
+        out = local_llm.complete(
+            prompt,
+            model=local_llm.configured_model(),
+            system=(
+                "You are PRISM's reflection engine. Respond with ONLY the "
+                "JSON verdict object the prompt specifies — no prose."
+            ),
+            json_mode=True,
+        )
+        return _LocalResult(out["text"], out["ms"], out["tokens"])
+    return claude_cli.invoke(
+        prompt=prompt,
+        work_dir=work_dir,
+        plugin_dir=plugin_dir,
+        max_turns=max_turns,
+        allowed_tools=allowed_tools,
+        project=project,
+        purpose=purpose,
+    )
+
+
 def run_one(
     project: str,
     candidate_id: str,
@@ -349,7 +405,7 @@ def run_one(
     prompt = _build_prompt(project, str(source_dir), candidate_id, row, scope)
 
     try:
-        result = claude_cli.invoke(
+        result = _invoke_backend(
             prompt=prompt,
             work_dir=str(source_dir),
             plugin_dir=str(source_dir),

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -311,6 +311,8 @@ class _LocalResult:
         self.run_id = f"local-{int(time.time())}"
         self.ms = ms
         self.tokens = tokens
+        # claude_cli result surface consumed downstream (run_one :506).
+        self.duration_s = round(ms / 1000.0, 2)
 
     def final_text(self) -> str:
         return self._text

--- a/services/prism-service/prism_service/services/supervisor.py
+++ b/services/prism-service/prism_service/services/supervisor.py
@@ -256,10 +256,13 @@ def _spawn_server() -> int:
     cli/prism_cli._spawn."""
     spawn_kwargs: dict = {}
     if sys.platform.startswith("win"):
-        _DETACHED = 0x00000008
+        # CREATE_NO_WINDOW, not DETACHED_PROCESS — a console-less server makes
+        # every console child (claude -p, git) flash a visible conhost window;
+        # a hidden console is inherited silently (mirrors cli/prism_cli._spawn).
+        _NO_WINDOW = 0x08000000  # CREATE_NO_WINDOW
         _NEW_GROUP = 0x00000200
         _BREAKAWAY = 0x01000000  # CREATE_BREAKAWAY_FROM_JOB
-        spawn_kwargs["creationflags"] = _DETACHED | _NEW_GROUP | _BREAKAWAY
+        spawn_kwargs["creationflags"] = _NO_WINDOW | _NEW_GROUP | _BREAKAWAY
     else:
         spawn_kwargs["start_new_session"] = True
     try:
@@ -279,7 +282,7 @@ def _spawn_server() -> int:
                 f"respawned server runs INSIDE the job and may be reaped when "
                 f"the launching session ends"
             )
-            spawn_kwargs["creationflags"] = 0x00000008 | 0x00000200
+            spawn_kwargs["creationflags"] = 0x08000000 | 0x00000200
             proc = subprocess.Popen(
                 [sys.executable, "-m", "prism_service.main"],
                 stdin=subprocess.DEVNULL, close_fds=True, **spawn_kwargs,

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -7,7 +7,12 @@ import sqlite3
 from datetime import datetime, timezone
 from typing import Callable, Optional
 
-from prism_service.models.task import Task, TaskHistory
+from prism_service.models.task import (
+    TITLE_MAX_LEN,
+    VALID_STATUSES,
+    Task,
+    TaskHistory,
+)
 
 
 # Callable signature for LL-03's embedder injection. Returns packed
@@ -251,6 +256,27 @@ class TaskService:
         self._record_history(task_id, action, details=details, actor=actor)
 
     # ------------------------------------------------------------------
+    # Boundary validation (task 16234231) — lives HERE so the REST API
+    # (api/tasks.py -> 422) and the MCP task_update path share one set
+    # of teeth. Raises ValueError with a caller-actionable message.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _validate_status(value: object) -> None:
+        if value not in VALID_STATUSES:
+            raise ValueError(
+                f"invalid status {value!r}; allowed values: "
+                + ", ".join(VALID_STATUSES)
+            )
+
+    @staticmethod
+    def _validate_title(value: object) -> None:
+        if isinstance(value, str) and len(value) > TITLE_MAX_LEN:
+            raise ValueError(
+                f"title too long ({len(value)} chars); max {TITLE_MAX_LEN}"
+            )
+
+    # ------------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------------
 
@@ -275,7 +301,12 @@ class TaskService:
         plan_doc: str = "",
         plan_diagram: str = "",
     ) -> Task:
-        """Create a new task and return it."""
+        """Create a new task and return it.
+
+        Raises ValueError when the title exceeds TITLE_MAX_LEN
+        (task 16234231 — titles are board-rendered everywhere).
+        """
+        self._validate_title(title)
         task = Task(
             title=title,
             description=description,
@@ -400,10 +431,21 @@ class TaskService:
         return tasks
 
     def update(self, task_id: str, **kwargs: object) -> Optional[Task]:
-        """Update arbitrary fields on a task. Records change history."""
+        """Update arbitrary fields on a task. Records change history.
+
+        Boundary validation (task 16234231): an off-enum ``status`` or an
+        over-cap ``title`` raises ValueError BEFORE anything persists —
+        a typo'd status used to silently vanish the task from every
+        status-keyed surface (board lanes, task_next, conductor claiming).
+        """
         task = self.get(task_id)
         if task is None:
             return None
+
+        if "status" in kwargs:
+            self._validate_status(kwargs["status"])
+        if "title" in kwargs:
+            self._validate_title(kwargs["title"])
 
         now = datetime.now(timezone.utc).isoformat()
         changes: list[str] = []

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -52,7 +52,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     verify TEXT DEFAULT '[]',
     stop_if TEXT DEFAULT '[]',
     plan_doc TEXT DEFAULT '',
-    plan_diagram TEXT DEFAULT ''
+    plan_diagram TEXT DEFAULT '',
+    claimed_by TEXT DEFAULT '',
+    claimed_at TEXT DEFAULT ''
 );
 
 CREATE TABLE IF NOT EXISTS task_history (
@@ -98,6 +100,10 @@ _LL_TASK_COLUMNS: list[tuple[str, str]] = [
     # SPA keeps the current description view).
     ("plan_doc", "TEXT DEFAULT ''"),
     ("plan_diagram", "TEXT DEFAULT ''"),
+    # Claim lease (task 41af13c0): who pulled the task + when, so next_task
+    # can skip a task freshly claimed by a DIFFERENT session. Backfill ''.
+    ("claimed_by", "TEXT DEFAULT ''"),
+    ("claimed_at", "TEXT DEFAULT ''"),
 ]
 
 
@@ -232,6 +238,10 @@ class TaskService:
                       and row["plan_doc"] is not None else ""),
             plan_diagram=(row["plan_diagram"] if "plan_diagram" in keys
                           and row["plan_diagram"] is not None else ""),
+            claimed_by=(row["claimed_by"] if "claimed_by" in keys
+                        and row["claimed_by"] is not None else ""),
+            claimed_at=(row["claimed_at"] if "claimed_at" in keys
+                        and row["claimed_at"] is not None else ""),
         )
 
     def _record_history(
@@ -628,14 +638,36 @@ class TaskService:
     # Next-task algorithm
     # ------------------------------------------------------------------
 
-    def next_task(self) -> Optional[dict]:
+    # Default claim-lease freshness window: a task claimed by another session
+    # within this many seconds is skipped by next_task (task 41af13c0).
+    _CLAIM_LEASE_WINDOW_S = 900  # 15 minutes
+
+    def next_task(
+        self,
+        session_id: Optional[str] = None,
+        lease_window_s: int = _CLAIM_LEASE_WINDOW_S,
+    ) -> Optional[dict]:
         """Return the highest-priority unblocked pending task.
 
         Algorithm:
         1. Fetch all pending tasks.
         2. Filter out tasks whose dependencies are not all 'done'.
         3. Sort by priority DESC, created_at ASC.
-        4. Return top result with a reason string.
+        4. Skip tasks freshly claimed by a DIFFERENT session (claim lease).
+        5. Atomically stamp the chosen task with claimed_by + claimed_at.
+        6. Return top result with a reason string.
+
+        CLAIM LEASE (task 41af13c0): task_next / conductor claiming used to
+        have no lease, so two concurrent drivers could grab the SAME task
+        (observed live: 9f61d484 was double-driven). When ``session_id`` is
+        supplied, a task claimed within ``lease_window_s`` by a DIFFERENT
+        session is skipped, and the chosen task is stamped
+        ``claimed_by=session_id`` + ``claimed_at=now`` before it is returned —
+        so a second next_task from another session gets a DIFFERENT task. A
+        session re-claiming its own fresh task gets it back (idempotent), and
+        an expired claim (older than the window) is reclaimable. BACKWARD
+        COMPATIBLE: ``session_id=None`` keeps the legacy behavior — no skip,
+        no stamp — so unclaimed and expired-claim tasks are always returned.
         """
         pending = self.list(status="pending")
         if not pending:
@@ -654,16 +686,64 @@ class TaskService:
         if not unblocked:
             return None
 
+        # Claim lease: skip a task freshly claimed by a DIFFERENT session.
+        # session_id=None => legacy path (no skip): pick the top task as-is.
+        if session_id:
+            eligible = [
+                t for t in unblocked
+                if not self._claim_is_fresh_by_other(
+                    t, session_id, lease_window_s)
+            ]
+            if not eligible:
+                return None
+            best = eligible[0]
+            self._stamp_claim(best.id, session_id)
+        else:
+            best = unblocked[0]
+
         # Already sorted by priority DESC, created_at ASC from list()
-        best = unblocked[0]
         reason_parts = [f"priority={best.priority}"]
         if best.assigned_agent:
             reason_parts.append(f"assigned to {best.assigned_agent}")
         if best.story_file:
             reason_parts.append(f"story={best.story_file}")
+        if session_id:
+            reason_parts.append(f"claimed by {session_id}")
         reason = "Highest priority unblocked task: " + ", ".join(reason_parts)
 
         return {"task": best, "reason": reason}
+
+    def _claim_is_fresh_by_other(
+        self, task: Task, session_id: str, lease_window_s: int,
+    ) -> bool:
+        """True when ``task`` is claimed by a session OTHER than
+        ``session_id`` and the claim is younger than ``lease_window_s`` — i.e.
+        it is actively leased elsewhere and must not be handed out again. An
+        unclaimed task, a task this session already owns, or a claim older
+        than the window all return False (available)."""
+        claimed_by = getattr(task, "claimed_by", "") or ""
+        claimed_at = getattr(task, "claimed_at", "") or ""
+        if not claimed_by or claimed_by == session_id:
+            return False
+        try:
+            when = datetime.fromisoformat(claimed_at)
+        except (ValueError, TypeError):
+            return False  # unparseable stamp => treat as reclaimable
+        if when.tzinfo is None:
+            when = when.replace(tzinfo=timezone.utc)
+        age_s = (datetime.now(timezone.utc) - when).total_seconds()
+        return age_s < lease_window_s
+
+    def _stamp_claim(self, task_id: str, session_id: str) -> None:
+        """Atomically record ``session_id`` as the claimant of ``task_id``
+        with a fresh ``claimed_at`` timestamp (task 41af13c0). Written via a
+        targeted UPDATE so it never disturbs the other task columns."""
+        now = datetime.now(timezone.utc).isoformat()
+        self._db.execute(
+            "UPDATE tasks SET claimed_by=?, claimed_at=? WHERE id=?",
+            (session_id, now, task_id),
+        )
+        self._db.commit()
 
     # ------------------------------------------------------------------
     # History

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -318,6 +318,59 @@ class TaskService:
             chain.append(ancestor)
             cursor = ancestor
 
+    def _validate_dependencies(self, dependencies: object,
+                               task_id: Optional[str] = None) -> None:
+        """Dependency-link integrity (task 47d0179a). Mirrors
+        :meth:`_validate_parent`: every dependency id must (1) be a
+        non-empty string naming an existing task, (2) not be the task
+        itself, and (3) not close a dependency cycle through the task —
+        each new dep's transitive dependency chain is walked with a
+        visited-guard so pre-existing corrupt cycles in stored rows
+        terminate the walk instead of hanging it. ``task_id`` is None on
+        create (a fresh id can never be in an existing chain, so only
+        existence/emptiness applies). Raises ValueError; both doors ride
+        the existing translators (api/tasks.py -> 422, MCP -> in-band)."""
+        if dependencies is None:
+            return
+        if not isinstance(dependencies, (list, tuple)):
+            raise ValueError("dependencies must be a list of task ids")
+        deps = [str(d or "") for d in dependencies]
+        for dep in deps:
+            if not dep.strip():
+                raise ValueError(
+                    "dependencies must not contain empty ids")
+            if task_id is not None and dep == task_id:
+                raise ValueError(
+                    f"task {task_id} cannot depend on itself")
+            if self.get(dep) is None:
+                raise ValueError(
+                    f"dependency task {dep!r} does not exist")
+        if task_id is None:
+            return
+        # Cycle walk: from each new dep, follow stored dependency lists;
+        # reaching task_id means this update would close a cycle.
+        stack = list(deps)
+        visited: set[str] = set()
+        while stack:
+            cur = stack.pop()
+            if cur == task_id:
+                raise ValueError(
+                    "dependencies would create a cycle: task "
+                    f"{task_id} is (transitively) a dependency of "
+                    "its own dependencies")
+            if cur in visited:
+                continue  # pre-existing corrupt cycle — not ours to close
+            visited.add(cur)
+            row = self._db.execute(
+                "SELECT dependencies FROM tasks WHERE id = ?", (cur,)
+            ).fetchone()
+            raw = (row["dependencies"] or "[]") if row else "[]"
+            try:
+                nxt = json.loads(raw)
+            except (ValueError, TypeError):
+                nxt = []
+            stack.extend(str(x) for x in (nxt or []) if x)
+
     # ------------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------------
@@ -351,6 +404,7 @@ class TaskService:
         """
         self._validate_title(title)
         self._validate_parent(parent_id)
+        self._validate_dependencies(dependencies)
         task = Task(
             title=title,
             description=description,
@@ -492,6 +546,9 @@ class TaskService:
             self._validate_title(kwargs["title"])
         if "parent_id" in kwargs:
             self._validate_parent(kwargs["parent_id"], task_id=task_id)
+        if "dependencies" in kwargs:
+            self._validate_dependencies(
+                kwargs["dependencies"], task_id=task_id)
 
         now = datetime.now(timezone.utc).isoformat()
         changes: list[str] = []

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -276,6 +276,48 @@ class TaskService:
                 f"title too long ({len(value)} chars); max {TITLE_MAX_LEN}"
             )
 
+    def _validate_parent(self, parent_id: object,
+                         task_id: Optional[str] = None) -> None:
+        """Parent-link integrity (task 24ed8027). A non-empty parent must
+        (1) not be the task itself, (2) exist, and (3) not close an
+        ancestor cycle through the task — the parent's chain is walked up
+        with a visited-guard so pre-existing corrupt cycles in stored
+        rows terminate the walk instead of hanging it. task_id is None on
+        create (a fresh id can never be in an existing chain, so only
+        existence applies)."""
+        pid = str(parent_id or "")
+        if not pid:
+            return  # '' = make/keep root — always valid
+        if task_id is not None and pid == task_id:
+            raise ValueError(
+                f"task {task_id} cannot be its own parent"
+            )
+        if self.get(pid) is None:
+            raise ValueError(f"parent task {pid!r} does not exist")
+        if task_id is None:
+            return
+        chain = [pid]
+        visited = {pid}
+        cursor = pid
+        while True:
+            row = self._db.execute(
+                "SELECT parent_id FROM tasks WHERE id = ?", (cursor,)
+            ).fetchone()
+            ancestor = (row["parent_id"] or "") if row else ""
+            if not ancestor:
+                return
+            if ancestor == task_id:
+                chain.append(task_id)
+                raise ValueError(
+                    "re-parenting would create a cycle: "
+                    + " -> ".join([task_id, *chain])
+                )
+            if ancestor in visited:
+                return  # pre-existing corrupt cycle above — not ours to close
+            visited.add(ancestor)
+            chain.append(ancestor)
+            cursor = ancestor
+
     # ------------------------------------------------------------------
     # CRUD
     # ------------------------------------------------------------------
@@ -304,9 +346,11 @@ class TaskService:
         """Create a new task and return it.
 
         Raises ValueError when the title exceeds TITLE_MAX_LEN
-        (task 16234231 — titles are board-rendered everywhere).
+        (task 16234231 — titles are board-rendered everywhere) or when a
+        non-empty parent_id names no existing task (task 24ed8027).
         """
         self._validate_title(title)
+        self._validate_parent(parent_id)
         task = Task(
             title=title,
             description=description,
@@ -446,6 +490,8 @@ class TaskService:
             self._validate_status(kwargs["status"])
         if "title" in kwargs:
             self._validate_title(kwargs["title"])
+        if "parent_id" in kwargs:
+            self._validate_parent(kwargs["parent_id"], task_id=task_id)
 
         now = datetime.now(timezone.utc).isoformat()
         changes: list[str] = []

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -538,6 +538,50 @@ class TaskService:
 
         return tasks
 
+    # ------------------------------------------------------------------
+    # Hierarchy — whole-subtree walk (task e72aba6d). Every consumer used
+    # to look ONE level deep (direct children only); these expose the whole
+    # transitive subtree so the detail tree, board badge, and epic green_gate
+    # roll-up render/roll up to ANY depth.
+    # ------------------------------------------------------------------
+
+    def descendants(self, task_id: str) -> list[Task]:
+        """Return every transitive child of ``task_id`` (the whole subtree,
+        the task itself excluded) as a breadth-first list.
+
+        ONE list read: the parent→children index is built in memory and
+        walked, so a deep tree costs a single query, not one-per-node.
+        Cycle-guarded exactly like :meth:`_validate_parent`'s ancestor walk —
+        a corrupt ``parent_id`` cycle in stored rows terminates the walk via a
+        visited-set instead of hanging it (and never re-adds the root)."""
+        kids_by_parent: dict[str, list[Task]] = {}
+        for t in self.list():
+            pid = getattr(t, "parent_id", "") or ""
+            if pid:
+                kids_by_parent.setdefault(pid, []).append(t)
+        out: list[Task] = []
+        visited: set[str] = {task_id}
+        queue: list[Task] = list(kids_by_parent.get(task_id, []))
+        while queue:
+            node = queue.pop(0)
+            if node.id in visited:
+                continue  # pre-existing corrupt cycle — do not re-walk
+            visited.add(node.id)
+            out.append(node)
+            queue.extend(kids_by_parent.get(node.id, []))
+        return out
+
+    def descendant_counts(self, task_id: str) -> tuple[int, int]:
+        """``(total, done)`` over the whole subtree (task itself excluded).
+
+        Cancelled descendants drop out of BOTH totals so a cancelled leaf
+        never blocks a 100%-done roll-up — mirrors the epic roll-up verdict's
+        cancelled handling."""
+        active = [t for t in self.descendants(task_id)
+                  if getattr(t, "status", "") != "cancelled"]
+        done = sum(1 for t in active if getattr(t, "status", "") == "done")
+        return len(active), done
+
     def update(self, task_id: str, **kwargs: object) -> Optional[Task]:
         """Update arbitrary fields on a task. Records change history.
 

--- a/services/prism-service/prism_service/services/verifier_service.py
+++ b/services/prism-service/prism_service/services/verifier_service.py
@@ -296,10 +296,22 @@ def _run_python_tools(workspace: Path, py_files: list[str]) -> list[Claim]:
         # manual override. The suite root is derived (never hardcoded) and
         # the resolved PRISM data dir is defensively --ignore'd so a
         # data-dir-inside-repo layout can never poison collection again.
+        #
+        # DAEMON-EXCLUSIVE EXCLUSION (task 91ac81e8): this Tier0 suite runs as
+        # a SUBPROCESS OF THE LIVE DAEMON. A handful of process-lifecycle /
+        # pidfile / learning-loop tests spawn+reap real orphan processes and
+        # probe prism.pid under the data dir the running daemon OWNS — they
+        # pass standalone but flake ONLY in-daemon, so a genuinely 0-failed
+        # tree could never clear green_gate mechanically (every green needed a
+        # distinct-actor override — the gate-theater the doctrine targets).
+        # Deselect them here with `-m "not daemon_exclusive"`; they STILL run
+        # in normal CI / standalone (no `-m` filter there), and the verifier is
+        # NOT weakened — a real failure in any non-excluded test still fails.
         import sys as _sys
         suite_root = _pytest_suite_root(workspace)
         rc, out, err = _run_tool(
             [_sys.executable, "-m", "pytest", "-q", "--no-header",
+             "-m", "not daemon_exclusive",
              *_data_dir_ignores(suite_root)],
             suite_root, timeout_s=600.0)
         c = _claim(0, "tooling.pytest", "<full-suite>", rc, out, err)

--- a/services/prism-service/prism_service/services/verifier_service.py
+++ b/services/prism-service/prism_service/services/verifier_service.py
@@ -264,8 +264,9 @@ def _run_python_tools(workspace: Path, py_files: list[str]) -> list[Claim]:
     claims: list[Claim] = []
     if not py_files:
         return claims
-    if shutil.which("ruff"):
-        rc, out, err = _run_tool(["ruff", "check", *py_files], workspace)
+    ruff = _ruff_cmd()
+    if ruff:
+        rc, out, err = _run_tool([*ruff, "check", *py_files], workspace)
         claims.append(_claim(0, "tooling.ruff", ",".join(py_files[:5]), rc, out, err))
     else:
         claims.append(Claim(tier=0, kind="tooling.ruff", target="", status="skipped",
@@ -286,11 +287,24 @@ def _run_python_tools(workspace: Path, py_files: list[str]) -> list[Claim]:
         # raised [WinError 2] -> exit 127 -> the suite was SKIPPED and the gate
         # saw a FALSE pass (0 tests run). sys.executable is the daemon's
         # interpreter, which has pytest importable, so `-m pytest` always runs.
+        #
+        # RUN IN THE SERVICE WORKSPACE (task 271dacc9): cwd was the repo
+        # root, where pytest's rootdir fallback walked the fork data dir
+        # (a stale full repo mirror under graphify-src/**) and duplicate
+        # tests.* basenames exploded collection ('import file mismatch',
+        # exit 2) -> tier0=fail on EVERY run -> every green_gate needed a
+        # manual override. The suite root is derived (never hardcoded) and
+        # the resolved PRISM data dir is defensively --ignore'd so a
+        # data-dir-inside-repo layout can never poison collection again.
         import sys as _sys
+        suite_root = _pytest_suite_root(workspace)
         rc, out, err = _run_tool(
-            [_sys.executable, "-m", "pytest", "-q", "--no-header"],
-            workspace, timeout_s=600.0)
-        claims.append(_claim(0, "tooling.pytest", "<full-suite>", rc, out, err))
+            [_sys.executable, "-m", "pytest", "-q", "--no-header",
+             *_data_dir_ignores(suite_root)],
+            suite_root, timeout_s=600.0)
+        c = _claim(0, "tooling.pytest", "<full-suite>", rc, out, err)
+        c.evidence["cwd"] = str(suite_root)
+        claims.append(c)
     return claims
 
 
@@ -302,6 +316,80 @@ def _pytest_available() -> bool:
         return True
     import importlib.util
     return importlib.util.find_spec("pytest") is not None
+
+
+def _ruff_cmd() -> Optional[list[str]]:
+    """How to invoke ruff, or None when it truly isn't available.
+    Mirrors the pytest lesson (task 271dacc9): a venv-only install has no
+    `ruff` shim on PATH but the module imports fine, so falling back to
+    `sys.executable -m ruff` kills the standing 'ruff not installed'
+    skip instead of silently accepting unlinted diffs."""
+    if shutil.which("ruff"):
+        return ["ruff"]
+    import importlib.util
+    import sys as _sys
+    if importlib.util.find_spec("ruff") is not None:
+        return [_sys.executable, "-m", "ruff"]
+    return None
+
+
+def _is_within(child: Path, parent: Path) -> bool:
+    """True when ``child`` resolves inside (or equal to) ``parent``."""
+    try:
+        child.resolve().relative_to(parent.resolve())
+        return True
+    except (ValueError, OSError):
+        return False
+
+
+def _pytest_suite_root(workspace: Path) -> Path:
+    """Where the Tier0 full-suite pytest run should execute (task 271dacc9).
+
+    Running at a monorepo root is wrong for PRISM self-dev: the root
+    pyproject's testpaths can dangle, making pytest fall back to FULL
+    rootdir collection — which walks the fork data dir's stale repo
+    mirror (graphify-src/**) and explodes on duplicate tests.* module
+    basenames ('import file mismatch'). The service suite root is derived
+    robustly, never hardcoded:
+
+      1. the RUNNING prism_service package's distribution root (the dir
+         holding pyproject.toml), when it lives inside the workspace;
+      2. the conventional ``services/prism-service`` layout under the
+         workspace (agent worktree checkouts of the same repo shape);
+      3. the workspace itself (generic, non-PRISM projects — unchanged).
+    """
+    ws = Path(workspace).resolve()
+    try:
+        import prism_service as _ps
+        pkg_file = getattr(_ps, "__file__", None)
+        if pkg_file:
+            dist_root = Path(pkg_file).resolve().parent.parent
+            if (dist_root / "pyproject.toml").exists() and _is_within(dist_root, ws):
+                return dist_root
+    except Exception:
+        pass
+    cand = ws / "services" / "prism-service"
+    if (cand / "pyproject.toml").exists() and (cand / "prism_service").is_dir():
+        return cand.resolve()
+    return ws
+
+
+def _data_dir_ignores(suite_root: Path) -> list[str]:
+    """Belt-and-braces ``--ignore`` for the resolved PRISM data dir when it
+    lives INSIDE the pytest suite root (task 271dacc9). A data dir inside
+    the repo (e.g. PRISM_DATA_DIR=.dev-data / data-selfimprove) carries
+    mirrored repo copies whose tests.* modules collide with the real suite
+    and poison collection. Never raises; equal-to-root is not ignored
+    (that would ignore the whole suite)."""
+    try:
+        from prism_service.data_dir import resolve_data_dir
+        dd = resolve_data_dir()
+        root = Path(suite_root).resolve()
+        if dd.resolve() != root and _is_within(dd, root):
+            return [f"--ignore={dd.resolve()}"]
+    except Exception:
+        pass
+    return []
 
 
 def _run_node_tools(workspace: Path, js_files: list[str]) -> list[Claim]:

--- a/services/prism-service/prism_service/web/package.json
+++ b/services/prism-service/prism_service/web/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@earendil-works/pi-agent-core": "^0.80.3",
+    "@earendil-works/pi-ai": "^0.80.3",
     "@nous-research/ui": "^0.16.0",
     "@observablehq/plot": "^0.6.17",
     "@react-three/fiber": "^9.6.0",

--- a/services/prism-service/prism_service/web/pi-expert.d.mts
+++ b/services/prism-service/prism_service/web/pi-expert.d.mts
@@ -1,0 +1,21 @@
+/**
+ * Type surface for pi-expert.mjs (task e70cdcda) — lets the SPA
+ * (src/lib/piAgent.ts, tsc strict) import the shared expert module
+ * without duplicating the prompt or the TypeBox catalog. Keep in sync
+ * with the runtime exports in pi-expert.mjs; the catalog value shape is
+ * exactly what lib/piAgent.ts's prismTool() consumes.
+ */
+import type { AgentTool } from "@earendil-works/pi-agent-core";
+
+/** PI's PRISM expertise: stores, gate doctrine, task/memory discipline. */
+export declare const EXPERT_SYSTEM_PROMPT: string;
+
+/** The full PRISM tool catalog keyed by real MCP tool name. */
+export declare const EXPERT_TOOL_DEFS: Record<
+  string,
+  {
+    label: string;
+    description: string;
+    parameters: AgentTool["parameters"];
+  }
+>;

--- a/services/prism-service/prism_service/web/pi-expert.mjs
+++ b/services/prism-service/prism_service/web/pi-expert.mjs
@@ -29,6 +29,18 @@ GATE DOCTRINE (non-negotiable):
 - red_gate expects a committed failing-test trace; green_gate expects captured full-suite-green or a demonstrable-UI artifact.
 - A FAILED gate LATCHES: do not try to advance past it and do not retry-approve in a loop — report the failure and its reason instead.
 
+DRIVING A TASK (the ACTION loop — do these in order, one tool call per step):
+1. READ the task: task_list(id="<task>") — a lean by-id read, NOT the whole board. Note its current workflow_step.
+2. AUTHOR the plan with task_update(id, plan_doc, plan_diagram):
+   - plan_doc is markdown with EXACTLY these headers: '## Summary' (one paragraph), '## Requirements' with 'FR-1', 'FR-2'… bullets, and '## Acceptance Criteria' with 'AC-1', 'AC-2'… bullets where EVERY AC line carries an inline '- oracle: <observable check>'.
+   - plan_diagram is RAW Mermaid source starting with a diagram keyword (flowchart / sequenceDiagram / stateDiagram …). No code fences.
+3. conductor_advance(id) repeatedly to walk review_previous_notes -> draft_story until the step is story_gate and the gate is PENDING.
+4. conductor_gate(id, action="approve", reason="<rubric evidence>") — the reason MUST quote the real plan_doc rubric (the FR-n / AC-n oracle lines you wrote), never a fabrication.
+5. CONTINUE the same pattern through the rest of the SDLC, in this order:
+   verify_plan -> plan_gate (approve with the plan evidence) -> write_failing_tests (author tests that FAIL, commit them) -> red_gate (approve with the committed failing-test trace) -> implement_tasks (make them pass) -> verify_green_state -> green_gate (approve with captured full-suite-green or a demonstrable-UI artifact).
+6. NEVER fabricate a gate reason, test output, or artifact. If you lack the evidence a gate needs, STOP and say so.
+7. A latched (failed) gate = STOP and report its gate_reason. Do not loop conductor_gate.
+
 TASK DISCIPLINE:
 - Titles are short, human-friendly statements of WHAT the feature is (~4-9 words). Mechanics, phases and file lists go in the description, never the title.
 - Set an oracle (the observable signal that proves the outcome) and a proof_type matched to it: test (a suite), demo (a shown surface), artifact (a file path), metric (a number moving). completion_proof must carry receipt-backed evidence, not self-attestation.

--- a/services/prism-service/prism_service/web/pi-expert.mjs
+++ b/services/prism-service/prism_service/web/pi-expert.mjs
@@ -1,0 +1,253 @@
+/**
+ * pi-expert — PI's PRISM expertise, in ONE place (task e70cdcda).
+ *
+ * The single source of (a) the expert system prompt and (b) the full
+ * PRISM tool catalog (TypeBox schemas matched to the real MCP
+ * inputSchemas in prism_service/mcp/tools.py). Imported by BOTH
+ * surfaces: web/pi-runtime.mjs (Node subprocess) and the SPA rail panel
+ * (src/lib/piAgent.ts) — never duplicate a prompt or schema per surface.
+ *
+ * Lives in web/ so the bare "@earendil-works/pi-ai" import resolves from
+ * the SPA's node_modules in Node AND Vite.
+ */
+
+import { Type } from "@earendil-works/pi-ai";
+
+// ------------------------------------------------------------- prompt
+
+export const EXPERT_SYSTEM_PROMPT = `You are PI, PRISM's expert agent. PRISM is an AI-assisted engineering system with four stores you operate through tools:
+- Brain: a hybrid (BM25 + vector + graph) index of the project's code and docs, plus a code graph (symbols, call edges, references).
+- Memory: the team's long-term memory — conventions, decisions, failures, patterns — recallable by natural language.
+- Tasks: a tracker (tasks, epics via parent_id, tags, oracle/proof fields).
+- Conductor: a per-task SDLC state machine that walks every task through the same 10 steps, in order:
+  review_previous_notes -> draft_story -> story_gate -> verify_plan -> plan_gate -> write_failing_tests -> red_gate -> implement_tasks -> verify_green_state -> green_gate.
+
+GATE DOCTRINE (non-negotiable):
+- conductor_advance moves a task to the NEXT step and is refused while a gate is pending — decide the gate first with conductor_gate.
+- conductor_gate action='approve' REQUIRES a reason describing the validation EVIDENCE used (test run output, rubric result, artifact path). Approving without evidence is forbidden.
+- story_gate and plan_gate are rubric-verified mechanically over the task's plan_doc: it needs '## Summary', '## Requirements' with FR-n bullets, and '## Acceptance Criteria' with AC-n bullets where EVERY AC line carries an inline '- oracle: <observable check>'. plan_diagram must be RAW Mermaid source starting with a diagram keyword (flowchart, sequenceDiagram, classDiagram, stateDiagram, erDiagram...). Attach plan_doc + plan_diagram (task_update) BEFORE advancing into story_gate.
+- red_gate expects a committed failing-test trace; green_gate expects captured full-suite-green or a demonstrable-UI artifact.
+- A FAILED gate LATCHES: do not try to advance past it and do not retry-approve in a loop — report the failure and its reason instead.
+
+TASK DISCIPLINE:
+- Titles are short, human-friendly statements of WHAT the feature is (~4-9 words). Mechanics, phases and file lists go in the description, never the title.
+- Set an oracle (the observable signal that proves the outcome) and a proof_type matched to it: test (a suite), demo (a shown surface), artifact (a file path), metric (a number moving). completion_proof must carry receipt-backed evidence, not self-attestation.
+
+MEMORY DISCIPLINE:
+- ALWAYS memory_recall before memory_store — never store a duplicate of existing knowledge.
+- A memory without evidence is nearly useless: include concrete file paths / code references in the description.
+
+TOOL ECONOMY:
+- You run on a small model: make ONE well-aimed tool call instead of many exploratory ones. Prefer brain_understand for orientation, brain_find_symbol/brain_outline for targeted reads.
+- NEVER fabricate a tool result, test output, or gate evidence. If you do not have the evidence, say so.`;
+
+// ------------------------------------------------------------ catalog
+
+// Keyed by the REAL MCP tool names dispatched by mcp.tools.handle_tool;
+// every parameter name below is verified against the matching
+// inputSchema in prism_service/mcp/tools.py. Additions/removals are a
+// deliberate decision mirrored in api/agent.py's AGENT_TOOL_WHITELIST.
+export const EXPERT_TOOL_DEFS = {
+  // ---------------------------------------------------------- brain
+  brain_search: {
+    label: "Brain search",
+    description: "Search the project's code/knowledge base (hybrid BM25 + vector + graph). Use for keyword/concept lookups when you don't yet know which file or symbol matters.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Search query" }),
+      domain: Type.Optional(Type.String({ description: "Filter by domain (py, ts, md, expertise)" })),
+      limit: Type.Optional(Type.Integer({ description: "Max results (default 5)" })),
+      domains: Type.Optional(Type.Array(Type.String(), { description: "Filter by multiple domains" })),
+    }),
+  },
+  brain_understand: {
+    label: "Brain understand",
+    description: "ONE graph-aware retrieval: ranked hits + their neighbor subgraph + per-file context bundles. Use FIRST when orienting on an area of the codebase — it replaces chaining brain_search + references + call chains. Empty query = whole-graph overview.",
+    parameters: Type.Object({
+      query: Type.Optional(Type.String({ description: "What to understand; omit for a centrality-ranked overview" })),
+      limit: Type.Optional(Type.Integer({ description: "Max ranked hits (default 20)" })),
+      depth: Type.Optional(Type.Integer({ description: "Neighbor hops 0-3 (default 1)" })),
+      seed_files: Type.Optional(Type.Array(Type.String(), { description: "Seed the view from these files instead of a text query" })),
+      label: Type.Optional(Type.String({ description: "Human label for a seed_files selection" })),
+    }),
+  },
+  brain_find_symbol: {
+    label: "Find symbol",
+    description: "Fetch the chunk(s) for a named function/class/method — the token-cheap alternative to reading a whole file. Use when you know the symbol name.",
+    parameters: Type.Object({
+      name: Type.String({ description: "Entity name (function, class, method)" }),
+      kind: Type.Optional(Type.String({ description: "Optional filter: function|class|method|module" })),
+      limit: Type.Optional(Type.Integer({ description: "Max chunks (default 10)" })),
+    }),
+  },
+  brain_outline: {
+    label: "File outline",
+    description: "Symbol outline of a source file (names/kinds/line ranges, no bodies). Use to orient on a file BEFORE fetching specific chunks via brain_find_symbol.",
+    parameters: Type.Object({
+      source_file: Type.String({ description: "File path as indexed" }),
+    }),
+  },
+  brain_find_references: {
+    label: "Find references",
+    description: "Call sites of a named entity via the code graph — semantic 'who uses this'. Use before changing a function to see its blast surface.",
+    parameters: Type.Object({
+      name: Type.String({ description: "Entity name" }),
+      limit: Type.Optional(Type.Integer({ description: "Max results (default 20)" })),
+      include_rationale: Type.Optional(Type.Boolean({ description: "Include rationale-comment edges (default false)" })),
+    }),
+  },
+  brain_call_chain: {
+    label: "Call chain",
+    description: "Bounded BFS over the call graph from an entity. direction='callers' answers 'who breaks if I change this?'; 'callees' traces forward call flow.",
+    parameters: Type.Object({
+      entity: Type.String({ description: "Start entity" }),
+      depth: Type.Optional(Type.Integer({ description: "Max hops (default 2)" })),
+      limit: Type.Optional(Type.Integer({ description: "Max edges (default 50)" })),
+      relation: Type.Optional(Type.String({ description: "Edge-kind filter: 'calls' (default), '*', 'uses', 'inherits'..." })),
+      direction: Type.Optional(Type.String({ description: "callees | callers | both" })),
+    }),
+  },
+  // --------------------------------------------------------- memory
+  memory_recall: {
+    label: "Memory recall",
+    description: "Recall the team's long-term memory: conventions, decisions, failures. ALWAYS check here before claiming something is new knowledge and before every memory_store.",
+    parameters: Type.Object({
+      query: Type.String({ description: "Natural-language query" }),
+      domain: Type.Optional(Type.String({ description: "Filter by domain" })),
+      limit: Type.Optional(Type.Integer({ description: "Max results (default 5)" })),
+    }),
+  },
+  memory_store: {
+    label: "Memory store",
+    description: "Store an expertise entry in long-term memory. Use ONLY after memory_recall shows no duplicate; the description must carry file-path/code evidence.",
+    parameters: Type.Object({
+      domain: Type.String({ description: "Expertise domain (conventions, architecture, testing...)" }),
+      name: Type.String({ description: "Short kebab-case name" }),
+      description: Type.String({ description: "DETAILED description with file paths / code examples" }),
+      type: Type.String({ description: "pattern | convention | failure | decision" }),
+      classification: Type.String({ description: "tactical | foundational | strategic" }),
+      evidence: Type.Optional(Type.Object({}, { additionalProperties: true, description: "{file_paths: [...], commit, pr}" })),
+      importance: Type.Optional(Type.Integer({ description: "1-10 (default 5)" })),
+      memory_type: Type.Optional(Type.String({ description: "semantic | episodic | procedural" })),
+      adr_status: Type.Optional(Type.String({ description: "ADR status for type=decision: proposed | accepted | superseded" })),
+      supersedes: Type.Optional(Type.String({ description: "mx-XXXXXX id this entry supersedes" })),
+      session_id: Type.Optional(Type.String({ description: "Session to stamp on the memory row" })),
+    }),
+  },
+  memory_invalidate: {
+    label: "Memory invalidate",
+    description: "Soft-delete a memory (status=invalidated, audit-preserved). Use when recall surfaces an entry that no longer applies — never leave stale knowledge active.",
+    parameters: Type.Object({
+      memory_id: Type.String({ description: "Memory id (mx-XXXXXX)" }),
+      reason: Type.Optional(Type.String({ description: "Why it no longer applies" })),
+    }),
+  },
+  // ---------------------------------------------------------- tasks
+  task_list: {
+    label: "Task list",
+    description: "List tasks. Default = ACTIVE work only. Use id=<task> to re-read ONE task cheaply (never pull the whole board for that) and fields=[...] to project only the keys you need.",
+    parameters: Type.Object({
+      status: Type.Optional(Type.String({ description: "pending | in_progress | blocked | done | cancelled | deleted | all" })),
+      assigned_agent: Type.Optional(Type.String({ description: "Filter by assigned agent" })),
+      tag: Type.Optional(Type.String({ description: "Filter by tag" })),
+      story_file: Type.Optional(Type.String({ description: "Filter by story file" })),
+      parent_id: Type.Optional(Type.String({ description: "One epic's children; '' for roots only" })),
+      id: Type.Optional(Type.String({ description: "By-id read: return just this task" })),
+      fields: Type.Optional(Type.Array(Type.String(), { description: "Projection: only these keys per task" })),
+    }),
+  },
+  task_next: {
+    label: "Task next",
+    description: "Get the next highest-priority unblocked task. Use when asked 'what should be worked on next?'.",
+    parameters: Type.Object({}),
+  },
+  task_create: {
+    label: "Task create",
+    description: "Create a task. Title = short human-friendly WHAT (~4-9 words, mechanics go in description); set oracle + proof_type up front.",
+    parameters: Type.Object({
+      title: Type.String({ description: "Short human-friendly title (~4-9 words)" }),
+      description: Type.Optional(Type.String({ description: "Mechanics, phases, file hooks — the details" })),
+      priority: Type.Optional(Type.Integer({ description: "Higher = more important (default 0)" })),
+      dependencies: Type.Optional(Type.Array(Type.String(), { description: "Task IDs this depends on" })),
+      tags: Type.Optional(Type.Array(Type.String(), { description: "Tags for categorization" })),
+      story_file: Type.Optional(Type.String({ description: "Associated story file path" })),
+      assigned_agent: Type.Optional(Type.String({ description: "Persona to assign (sm, dev, qa)" })),
+      parent_id: Type.Optional(Type.String({ description: "Parent epic id (makes this a child)" })),
+      oracle: Type.Optional(Type.String({ description: "Observable signal that proves the outcome" })),
+      proof_type: Type.Optional(Type.String({ description: "test | demo | artifact | metric | review | source_backed_answer | decision" })),
+      completion_proof: Type.Optional(Type.String({ description: "Receipt-backed evidence the oracle is satisfied" })),
+      likely_misfire: Type.Optional(Type.String({ description: "How this could pass-but-be-wrong" })),
+      allowed_files: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: file allowlist" })),
+      verify: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: commands that prove the slice" })),
+      stop_if: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: halt conditions" })),
+      plan_doc: Type.Optional(Type.String({ description: "Plan markdown (## Summary / ## Requirements FR-n / ## Acceptance Criteria, AC-n each with inline '- oracle:')" })),
+      plan_diagram: Type.Optional(Type.String({ description: "Raw Mermaid source starting with a diagram keyword" })),
+    }),
+  },
+  task_update: {
+    label: "Task update",
+    description: "Update a task you are driving: author/patch plan_doc (markdown) or plan_diagram (Mermaid), set status, oracle, or completion_proof. Attach plan_doc BEFORE advancing into story_gate.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID to update" }),
+      title: Type.Optional(Type.String({ description: "Rename (short human-friendly, ~4-9 words)" })),
+      status: Type.Optional(Type.String({ description: "pending | in_progress | done | blocked" })),
+      priority: Type.Optional(Type.Integer({ description: "New priority" })),
+      assigned_agent: Type.Optional(Type.String({ description: "New agent assignment" })),
+      blocked_reason: Type.Optional(Type.String({ description: "Reason when status=blocked" })),
+      parent_id: Type.Optional(Type.String({ description: "Re-parent under an epic ('' = root)" })),
+      oracle: Type.Optional(Type.String({ description: "Observable signal that proves the outcome" })),
+      proof_type: Type.Optional(Type.String({ description: "test | demo | artifact | metric | review | source_backed_answer | decision" })),
+      completion_proof: Type.Optional(Type.String({ description: "Receipt-backed evidence the oracle is satisfied" })),
+      likely_misfire: Type.Optional(Type.String({ description: "How this could pass-but-be-wrong" })),
+      allowed_files: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: file allowlist" })),
+      verify: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: verify commands" })),
+      stop_if: Type.Optional(Type.Array(Type.String(), { description: "Worker contract: halt conditions" })),
+      plan_doc: Type.Optional(Type.String({ description: "Plan markdown (## Summary / ## Requirements FR-n / ## Acceptance Criteria, AC-n each with inline '- oracle:')" })),
+      plan_diagram: Type.Optional(Type.String({ description: "Raw Mermaid source starting with a diagram keyword" })),
+    }),
+  },
+  // ------------------------------------------------------ conductor
+  conductor_advance: {
+    label: "Conductor advance",
+    description: "Advance a task to the next SDLC workflow step. Refused while a gate is pending — decide the gate first with conductor_gate. Pass a validation note describing what the finished step proved.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID to advance" }),
+      validation: Type.Optional(Type.String({ description: "Validation note for the transition" })),
+      session_id: Type.Optional(Type.String({ description: "Session to link on advance" })),
+      fields: Type.Optional(Type.Array(Type.String(), { description: "Projection: only these response keys" })),
+    }),
+  },
+  conductor_gate: {
+    label: "Conductor gate",
+    description: "Decide a pending gate. action 'approve' REQUIRES reason describing the validation evidence used; 'reject' stores reason as the failure. A failed gate LATCHES — report, don't loop.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID whose gate to decide" }),
+      action: Type.String({ description: "approve | reject" }),
+      reason: Type.String({ description: "Validation evidence (required on approve)" }),
+      override: Type.Optional(Type.Boolean({ description: "Bypass verifier / recover a failed gate — distinct actor only, audited" })),
+      actor: Type.Optional(Type.String({ description: "Who clears the gate (must differ from the work-producing actor on override)" })),
+      session_id: Type.Optional(Type.String({ description: "Session to link on the decision" })),
+      fields: Type.Optional(Type.Array(Type.String(), { description: "Projection: only these response keys" })),
+    }),
+  },
+  workflow_state: {
+    label: "Workflow state",
+    description: "Current PRISM workflow state (active step, progress, session info). Use to orient before advancing anything.",
+    parameters: Type.Object({}),
+  },
+  // -------------------------------------------------------- context
+  context_bundle: {
+    label: "Context bundle",
+    description: "Deterministic context pack: role card, rules, Brain context, memory recall, active tasks, workflow state, health. Use at session start or when handed a persona.",
+    parameters: Type.Object({
+      persona: Type.Optional(Type.String({ description: "Agent persona (sm, dev, qa)" })),
+      story_file: Type.Optional(Type.String({ description: "Story file path for scoped context" })),
+    }),
+  },
+  prism_status: {
+    label: "PRISM status",
+    description: "Brain/Graph index health (doc counts, staleness). Use to check whether the index is trustworthy before leaning on Brain results.",
+    parameters: Type.Object({
+      file_hashes: Type.Optional(Type.Object({}, { additionalProperties: true, description: "Optional {path: sha256} map for precise drift detection" })),
+    }),
+  },
+};

--- a/services/prism-service/prism_service/web/pi-runtime.mjs
+++ b/services/prism-service/prism_service/web/pi-runtime.mjs
@@ -1,0 +1,253 @@
+/**
+ * pi-runtime — PRISM's internal inference agent (task ac69ee28).
+ *
+ * Runs a pi-agent-core Agent loop on the LOCAL micro model with PRISM
+ * tools bridged through the whitelisted POST /api/agent/tool. Spawned by
+ * prism_service/inference/pi_agent.py (one JSON job on stdin, one JSON
+ * result on stdout — exit 0 even on model failure, error in the payload).
+ *
+ * Lives in web/ so bare imports resolve from the SPA's node_modules
+ * (@earendil-works pi 0.80.3 already installed) — zero extra install.
+ *
+ * pi toolkit: https://github.com/badlogic/pi-mono (MIT, Mario Zechner).
+ */
+
+import { Agent } from "@earendil-works/pi-agent-core";
+import { createModels, createProvider, Type } from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+// ------------------------------------------------------------- model
+
+function buildModel(modelId, baseUrl) {
+  return {
+    id: modelId,
+    name: modelId,
+    api: "openai-completions",
+    provider: "pi-local",
+    baseUrl,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 2048,
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStrictMode: false,
+    },
+  };
+}
+
+function buildModels(model, baseUrl) {
+  const models = createModels();
+  models.setProvider(createProvider({
+    id: "pi-local",
+    name: "Local (OpenAI-compatible)",
+    baseUrl,
+    // Keyless local server — empty ModelAuth reads as unconfigured, so
+    // resolve a dummy key (Ollama/vLLM/LM Studio ignore Authorization).
+    auth: { apiKey: { name: "local (keyless)", resolve: async () => ({ auth: { apiKey: "local-keyless" }, source: "local" }) } },
+    models: [model],
+    api: openAICompletionsApi(),
+  }));
+  return models;
+}
+
+// -------------------------------------------------- PRISM tool bridges
+
+const TOOL_DEFS = {
+  brain_search: {
+    label: "Brain search",
+    description: "Search the project's code/knowledge base (hybrid BM25 + vector + graph).",
+    parameters: Type.Object({ query: Type.String({ description: "Search query" }) }),
+  },
+  memory_recall: {
+    label: "Memory recall",
+    description: "Recall the team's long-term memory: conventions, decisions, failures. ALWAYS check here before claiming something is new knowledge.",
+    parameters: Type.Object({ query: Type.String({ description: "Natural-language query" }) }),
+  },
+  task_list: {
+    label: "Task list",
+    description: "List tasks in the PRISM tracker (optional status filter).",
+    parameters: Type.Object({ status: Type.Optional(Type.String()) }),
+  },
+  prism_status: {
+    label: "PRISM status",
+    description: "Brain/Graph index health (doc counts, staleness).",
+    parameters: Type.Object({}),
+  },
+};
+
+function cap(text, n = 6000) {
+  const s = typeof text === "string" ? text : JSON.stringify(text, null, 1);
+  return s.length > n ? `${s.slice(0, n)}\n…(truncated)` : s;
+}
+
+function buildTools(job, receipts) {
+  const names = (job.allowed_tools && job.allowed_tools.length)
+    ? job.allowed_tools : ["brain_search", "memory_recall"];
+  return names.filter((n) => TOOL_DEFS[n]).map((name) => ({
+    name,
+    ...TOOL_DEFS[name],
+    execute: async (_id, params) => {
+      const t0 = Date.now();
+      const res = await fetch(
+        `${job.api_base}/api/agent/tool?project=${encodeURIComponent(job.project)}`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ name, args: params ?? {} }),
+        },
+      );
+      const ms = Date.now() - t0;
+      if (!res.ok) {
+        receipts.push({ name, ms, ok: false });
+        throw new Error(`${name} -> HTTP ${res.status}`);
+      }
+      const payload = await res.json();
+      receipts.push({ name, ms, ok: true });
+      return { content: [{ type: "text", text: cap(payload.result) }], details: { ms } };
+    },
+  }));
+}
+
+// -------------------------------------- text tool-call interception
+
+function messageText(message) {
+  const c = message?.content;
+  if (typeof c === "string") return c;
+  if (Array.isArray(c)) {
+    return c.filter((p) => p?.type === "text").map((p) => p.text).join("");
+  }
+  return "";
+}
+
+function parseTextToolCall(text) {
+  let t = (text || "").trim();
+  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/.exec(t);
+  if (fence) t = fence[1].trim();
+  if (!t.startsWith("{") || !t.endsWith("}")) return null;
+  try {
+    const obj = JSON.parse(t);
+    const name = obj?.name;
+    const args = obj?.arguments ?? obj?.args ?? obj?.parameters ?? {};
+    if (typeof name !== "string" || !name) return null;
+    if (typeof args !== "object" || args === null || Array.isArray(args)) return null;
+    return { name, args };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------- run
+
+async function runJob(job) {
+  const started = Date.now();
+  const baseUrl = (job.base_url || "http://localhost:11434/v1").replace(/\/$/, "");
+  const modelId = job.model || "qwen3:0.6b";
+  const model = buildModel(modelId, baseUrl);
+  const models = buildModels(model, baseUrl);
+  const receipts = [];
+  const tools = buildTools(job, receipts);
+  let system = job.system || "";
+  if (modelId.startsWith("qwen3") && !system.includes("/no_think")) {
+    system = `${system} /no_think`.trim();
+  }
+
+  const agent = new Agent({
+    initialState: { systemPrompt: system, model, thinkingLevel: "off", tools },
+    streamFn: (m, c, o) => models.streamSimple(m, c, o),
+    getApiKey: () => "local-keyless",
+  });
+
+  let turns = 0;
+  agent.subscribe((e) => { if (e.type === "turn_end") turns++; });
+
+  const lastAssistantText = () => {
+    const msgs = agent.state.messages;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i]?.role === "assistant") return messageText(msgs[i]);
+    }
+    return "";
+  };
+
+  await agent.prompt(job.prompt);
+  if (agent.state.errorMessage) {
+    return { ok: false, error: agent.state.errorMessage, text: lastAssistantText(),
+             turns, tools_used: receipts, ms: Date.now() - started, tokens: 0, model: modelId };
+  }
+
+  // Micro-model reality (proven on the panel, Ollama 0.30.7): tool calls
+  // arrive as PLAIN JSON TEXT. Execute them app-side and continue, capped.
+  let budget = Number.isFinite(job.intercept_budget) ? job.intercept_budget : 4;
+  for (;;) {
+    const call = parseTextToolCall(lastAssistantText());
+    if (!call || budget <= 0) break;
+    const tool = tools.find((t) => t.name === call.name);
+    if (!tool) break;
+    budget--;
+    let resultText;
+    try {
+      const res = await tool.execute(`text-${Date.now()}`, call.args);
+      resultText = res.content.map((c) => c.text).join("\n");
+    } catch (err) {
+      resultText = `ERROR: ${err?.message ?? err}`;
+    }
+    await agent.prompt(
+      `[${call.name} result]\n${resultText}\n\nContinue. If you have enough evidence, emit your FINAL answer now in the exact output format the task specified. Do not call another tool unless strictly necessary.`,
+    );
+    if (agent.state.errorMessage) break;
+  }
+
+  const text = lastAssistantText();
+  return {
+    ok: true, text, turns, tools_used: receipts,
+    ms: Date.now() - started,
+    tokens: Math.round(text.length / 4), // approximation; usage not surfaced per-run
+    model: modelId,
+  };
+}
+
+// --------------------------------------------------------------- main
+
+async function main() {
+  if (process.argv.includes("--check")) {
+    // Offline validation: imports resolved, model + tools construct.
+    const model = buildModel("check-model", "http://localhost:0/v1");
+    buildModels(model, "http://localhost:0/v1");
+    const receipts = [];
+    const tools = buildTools(
+      { allowed_tools: Object.keys(TOOL_DEFS), api_base: "http://localhost:0", project: "check" },
+      receipts,
+    );
+    if (tools.length !== Object.keys(TOOL_DEFS).length) throw new Error("tool construction failed");
+    if (!parseTextToolCall('{"name": "brain_search", "arguments": {"query": "x"}}')) {
+      throw new Error("interception parser failed");
+    }
+    process.stdout.write(JSON.stringify({ ok: true, tools: tools.map((t) => t.name) }));
+    return;
+  }
+
+  let raw = "";
+  process.stdin.setEncoding("utf-8");
+  for await (const chunk of process.stdin) raw += chunk;
+  let job;
+  try {
+    job = JSON.parse(raw);
+  } catch (err) {
+    process.stdout.write(JSON.stringify({ ok: false, error: `bad job JSON: ${err?.message}` }));
+    return;
+  }
+  let result;
+  try {
+    result = await runJob(job);
+  } catch (err) {
+    result = { ok: false, error: String(err?.stack ?? err), tools_used: [], turns: 0, ms: 0, tokens: 0 };
+  }
+  process.stdout.write(JSON.stringify(result));
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => { process.stderr.write(String(err?.stack ?? err)); process.exit(1); },
+);

--- a/services/prism-service/prism_service/web/pi-runtime.mjs
+++ b/services/prism-service/prism_service/web/pi-runtime.mjs
@@ -21,6 +21,11 @@ import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completio
 // (task e70cdcda). Never re-declare a tool schema here.
 import { EXPERT_SYSTEM_PROMPT, EXPERT_TOOL_DEFS } from "./pi-expert.mjs";
 
+// Shared multi-call parser (task c4bb21f8): ONE source for both PI
+// interception surfaces so an array / concatenated tool-call block parses
+// identically here and in the SPA panel. Returns an ORDERED LIST.
+import { parseTextToolCall, parseTextToolCalls } from "./pi-toolcall.mjs";
+
 // ------------------------------------------------------------- model
 
 function buildModel(modelId, baseUrl) {
@@ -116,22 +121,9 @@ function messageText(message) {
   return "";
 }
 
-function parseTextToolCall(text) {
-  let t = (text || "").trim();
-  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/.exec(t);
-  if (fence) t = fence[1].trim();
-  if (!t.startsWith("{") || !t.endsWith("}")) return null;
-  try {
-    const obj = JSON.parse(t);
-    const name = obj?.name;
-    const args = obj?.arguments ?? obj?.args ?? obj?.parameters ?? {};
-    if (typeof name !== "string" || !name) return null;
-    if (typeof args !== "object" || args === null || Array.isArray(args)) return null;
-    return { name, args };
-  } catch {
-    return null;
-  }
-}
+// parseTextToolCall / parseTextToolCalls now live in the shared
+// pi-toolcall.mjs module (imported above) — single object, fenced object,
+// top-level array, and concatenated objects all parse to an ordered list.
 
 // ---------------------------------------------------------------- run
 
@@ -174,23 +166,37 @@ async function runJob(job) {
   }
 
   // Micro-model reality (proven on the panel, Ollama 0.30.7): tool calls
-  // arrive as PLAIN JSON TEXT. Execute them app-side and continue, capped.
-  let budget = Number.isFinite(job.intercept_budget) ? job.intercept_budget : 4;
+  // arrive as PLAIN JSON TEXT. A MULTI-step ask arrives as the WHOLE plan
+  // in ONE block — a top-level array or several concatenated objects (task
+  // c4bb21f8). Parse the block into an ordered list, execute each KNOWN
+  // tool in order (unknown names skipped with a noted receipt), feed the
+  // combined results back, then let the model emit its final answer.
+  // `budget` is a TOTAL-call cap across the whole exchange (runaway guard).
+  let budget = Number.isFinite(job.intercept_budget) ? job.intercept_budget : 6;
   for (;;) {
-    const call = parseTextToolCall(lastAssistantText());
-    if (!call || budget <= 0) break;
-    const tool = tools.find((t) => t.name === call.name);
-    if (!tool) break;
-    budget--;
-    let resultText;
-    try {
-      const res = await tool.execute(`text-${Date.now()}`, call.args);
-      resultText = res.content.map((c) => c.text).join("\n");
-    } catch (err) {
-      resultText = `ERROR: ${err?.message ?? err}`;
+    const calls = parseTextToolCalls(lastAssistantText());
+    if (!calls.length || budget <= 0) break;
+    const results = [];
+    for (const call of calls) {
+      if (budget <= 0) {
+        results.push(`[${call.name} skipped: intercept budget exhausted]`);
+        continue;
+      }
+      const tool = tools.find((t) => t.name === call.name);
+      if (!tool) {
+        results.push(`[${call.name} skipped: not a known PRISM tool]`);
+        continue;
+      }
+      budget--;
+      try {
+        const res = await tool.execute(`text-${Date.now()}-${results.length}`, call.args);
+        results.push(`[${call.name} result]\n${res.content.map((c) => c.text).join("\n")}`);
+      } catch (err) {
+        results.push(`[${call.name} error] ${err?.message ?? err}`);
+      }
     }
     await agent.prompt(
-      `[${call.name} result]\n${resultText}\n\nContinue. If you have enough evidence, emit your FINAL answer now in the exact output format the task specified. Do not call another tool unless strictly necessary.`,
+      `${results.join("\n\n")}\n\nContinue. If you have enough evidence, emit your FINAL answer now in the exact output format the task specified. Do not call another tool unless strictly necessary.`,
     );
     if (agent.state.errorMessage) break;
   }
@@ -220,11 +226,23 @@ async function main() {
     if (!parseTextToolCall('{"name": "brain_search", "arguments": {"query": "x"}}')) {
       throw new Error("interception parser failed");
     }
+    // Multi-call block interception (task c4bb21f8): a top-level ARRAY and
+    // concatenated objects must each parse to an ordered list of 2 calls.
+    const arrCalls = parseTextToolCalls(
+      '[{"name":"brain_search","arguments":{"query":"x"}},{"name":"task_create","arguments":{"title":"t"}}]');
+    const catCalls = parseTextToolCalls(
+      '{"name":"brain_search","arguments":{"query":"x"}}\n{"name":"task_create","arguments":{"title":"t"}}');
+    if (arrCalls.length !== 2 || catCalls.length !== 2) {
+      throw new Error("multi-call interception parser failed");
+    }
     // Surface the bridge body the SAME helper builds for live execute, so
     // tests can prove the internal flag rides every call (task 9f20b605).
     process.stdout.write(JSON.stringify({
       ok: true,
       tools: tools.map((t) => t.name),
+      // Multi-call parse report (task c4bb21f8): array + concatenated each
+      // yield an ordered list of 2 — the shape the single-object parser dropped.
+      multicall: { array: arrCalls.length, concatenated: catCalls.length },
       bridge_body: bridgeBody("conductor_advance", { id: "check" }),
       // The shared expert prompt the run path defaults to when job.system
       // is empty (task e70cdcda) — surfaced so tests prove it's wired.

--- a/services/prism-service/prism_service/web/pi-runtime.mjs
+++ b/services/prism-service/prism_service/web/pi-runtime.mjs
@@ -13,8 +13,13 @@
  */
 
 import { Agent } from "@earendil-works/pi-agent-core";
-import { createModels, createProvider, Type } from "@earendil-works/pi-ai";
+import { createModels, createProvider } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+
+// PI's PRISM expertise — ONE shared source for the system prompt + the
+// full tool catalog, consumed by this runner AND the SPA rail panel
+// (task e70cdcda). Never re-declare a tool schema here.
+import { EXPERT_SYSTEM_PROMPT, EXPERT_TOOL_DEFS } from "./pi-expert.mjs";
 
 // ------------------------------------------------------------- model
 
@@ -55,66 +60,14 @@ function buildModels(model, baseUrl) {
 
 // -------------------------------------------------- PRISM tool bridges
 
-const TOOL_DEFS = {
-  brain_search: {
-    label: "Brain search",
-    description: "Search the project's code/knowledge base (hybrid BM25 + vector + graph).",
-    parameters: Type.Object({ query: Type.String({ description: "Search query" }) }),
-  },
-  memory_recall: {
-    label: "Memory recall",
-    description: "Recall the team's long-term memory: conventions, decisions, failures. ALWAYS check here before claiming something is new knowledge.",
-    parameters: Type.Object({ query: Type.String({ description: "Natural-language query" }) }),
-  },
-  task_list: {
-    label: "Task list",
-    description: "List tasks in the PRISM tracker (optional status filter).",
-    parameters: Type.Object({ status: Type.Optional(Type.String()) }),
-  },
-  prism_status: {
-    label: "PRISM status",
-    description: "Brain/Graph index health (doc counts, staleness).",
-    parameters: Type.Object({}),
-  },
-  // Conductor surface (task 9f20b605, phase 2): the SDLC state machine.
-  // Names are the REAL MCP tool names dispatched by mcp.tools.handle_tool;
-  // all three are internal-only on the bridge (bridgeBody sends the flag).
-  task_update: {
-    label: "Task update",
-    description: "Update a task you are driving: author/patch plan_doc (markdown) or plan_diagram (Mermaid), set status or completion_proof.",
-    parameters: Type.Object({
-      id: Type.String({ description: "Task ID to update" }),
-      plan_doc: Type.Optional(Type.String({ description: "Plan markdown (## Summary / ## Requirements / ## Acceptance Criteria, each AC with an inline 'oracle:')" })),
-      plan_diagram: Type.Optional(Type.String({ description: "Mermaid diagram source" })),
-      status: Type.Optional(Type.String({ description: "pending | in_progress | done | blocked" })),
-      completion_proof: Type.Optional(Type.String({ description: "Receipt-backed evidence the oracle is satisfied" })),
-      oracle: Type.Optional(Type.String({ description: "Observable signal that proves the outcome" })),
-    }),
-  },
-  conductor_advance: {
-    label: "Conductor advance",
-    description: "Advance a task to the next SDLC workflow step. Refused while a gate is pending — decide the gate first with conductor_gate.",
-    parameters: Type.Object({
-      id: Type.String({ description: "Task ID to advance" }),
-      validation: Type.Optional(Type.String({ description: "Validation note for the transition" })),
-      session_id: Type.Optional(Type.String({ description: "Session to link on advance" })),
-    }),
-  },
-  conductor_gate: {
-    label: "Conductor gate",
-    description: "Decide a pending gate. action 'approve' REQUIRES reason describing the validation evidence used; 'reject' stores reason as the failure.",
-    parameters: Type.Object({
-      id: Type.String({ description: "Task ID whose gate to decide" }),
-      action: Type.String({ description: "approve | reject" }),
-      reason: Type.String({ description: "Validation evidence (required on approve)" }),
-      session_id: Type.Optional(Type.String({ description: "Session to link on the decision" })),
-    }),
-  },
-};
+// The catalog is the shared expert module's — one source for both
+// surfaces (task e70cdcda). Local alias keeps the call sites readable.
+const TOOL_DEFS = EXPERT_TOOL_DEFS;
 
 // The runner is an INTERNAL caller by construction — every bridged call
-// carries internal=true so the internal-only conductor tools (whitelisted
-// in api/agent.py, browser panel excluded) are reachable (task 9f20b605).
+// carries internal=true (task 9f20b605). Task e70cdcda retired the
+// internal-only gate in api/agent.py (PI IS the orchestrator, panel
+// included); the flag stays as harmless caller provenance.
 function bridgeBody(name, params) {
   return { name, args: params ?? {}, internal: true };
 }
@@ -190,7 +143,9 @@ async function runJob(job) {
   const models = buildModels(model, baseUrl);
   const receipts = [];
   const tools = buildTools(job, receipts);
-  let system = job.system || "";
+  // PI ships pre-loaded as the PRISM expert (task e70cdcda): an empty
+  // job.system runs with the shared expert prompt, never a blank slate.
+  let system = job.system || EXPERT_SYSTEM_PROMPT;
   if (modelId.startsWith("qwen3") && !system.includes("/no_think")) {
     system = `${system} /no_think`.trim();
   }
@@ -271,6 +226,9 @@ async function main() {
       ok: true,
       tools: tools.map((t) => t.name),
       bridge_body: bridgeBody("conductor_advance", { id: "check" }),
+      // The shared expert prompt the run path defaults to when job.system
+      // is empty (task e70cdcda) — surfaced so tests prove it's wired.
+      expert_prompt_chars: EXPERT_SYSTEM_PROMPT.length,
     }));
     return;
   }

--- a/services/prism-service/prism_service/web/pi-runtime.mjs
+++ b/services/prism-service/prism_service/web/pi-runtime.mjs
@@ -76,7 +76,48 @@ const TOOL_DEFS = {
     description: "Brain/Graph index health (doc counts, staleness).",
     parameters: Type.Object({}),
   },
+  // Conductor surface (task 9f20b605, phase 2): the SDLC state machine.
+  // Names are the REAL MCP tool names dispatched by mcp.tools.handle_tool;
+  // all three are internal-only on the bridge (bridgeBody sends the flag).
+  task_update: {
+    label: "Task update",
+    description: "Update a task you are driving: author/patch plan_doc (markdown) or plan_diagram (Mermaid), set status or completion_proof.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID to update" }),
+      plan_doc: Type.Optional(Type.String({ description: "Plan markdown (## Summary / ## Requirements / ## Acceptance Criteria, each AC with an inline 'oracle:')" })),
+      plan_diagram: Type.Optional(Type.String({ description: "Mermaid diagram source" })),
+      status: Type.Optional(Type.String({ description: "pending | in_progress | done | blocked" })),
+      completion_proof: Type.Optional(Type.String({ description: "Receipt-backed evidence the oracle is satisfied" })),
+      oracle: Type.Optional(Type.String({ description: "Observable signal that proves the outcome" })),
+    }),
+  },
+  conductor_advance: {
+    label: "Conductor advance",
+    description: "Advance a task to the next SDLC workflow step. Refused while a gate is pending — decide the gate first with conductor_gate.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID to advance" }),
+      validation: Type.Optional(Type.String({ description: "Validation note for the transition" })),
+      session_id: Type.Optional(Type.String({ description: "Session to link on advance" })),
+    }),
+  },
+  conductor_gate: {
+    label: "Conductor gate",
+    description: "Decide a pending gate. action 'approve' REQUIRES reason describing the validation evidence used; 'reject' stores reason as the failure.",
+    parameters: Type.Object({
+      id: Type.String({ description: "Task ID whose gate to decide" }),
+      action: Type.String({ description: "approve | reject" }),
+      reason: Type.String({ description: "Validation evidence (required on approve)" }),
+      session_id: Type.Optional(Type.String({ description: "Session to link on the decision" })),
+    }),
+  },
 };
+
+// The runner is an INTERNAL caller by construction — every bridged call
+// carries internal=true so the internal-only conductor tools (whitelisted
+// in api/agent.py, browser panel excluded) are reachable (task 9f20b605).
+function bridgeBody(name, params) {
+  return { name, args: params ?? {}, internal: true };
+}
 
 function cap(text, n = 6000) {
   const s = typeof text === "string" ? text : JSON.stringify(text, null, 1);
@@ -96,7 +137,7 @@ function buildTools(job, receipts) {
         {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ name, args: params ?? {} }),
+          body: JSON.stringify(bridgeBody(name, params)),
         },
       );
       const ms = Date.now() - t0;
@@ -224,7 +265,13 @@ async function main() {
     if (!parseTextToolCall('{"name": "brain_search", "arguments": {"query": "x"}}')) {
       throw new Error("interception parser failed");
     }
-    process.stdout.write(JSON.stringify({ ok: true, tools: tools.map((t) => t.name) }));
+    // Surface the bridge body the SAME helper builds for live execute, so
+    // tests can prove the internal flag rides every call (task 9f20b605).
+    process.stdout.write(JSON.stringify({
+      ok: true,
+      tools: tools.map((t) => t.name),
+      bridge_body: bridgeBody("conductor_advance", { id: "check" }),
+    }));
     return;
   }
 

--- a/services/prism-service/prism_service/web/pi-toolcall.d.mts
+++ b/services/prism-service/prism_service/web/pi-toolcall.d.mts
@@ -1,0 +1,16 @@
+/**
+ * Type surface for pi-toolcall.mjs (task c4bb21f8) — lets the SPA
+ * (src/lib/piAgent.ts, tsc strict) import the shared multi-call parser
+ * without duplicating it. Keep in sync with the runtime exports.
+ */
+
+/** One parsed text tool call: a catalog tool name + its argument object. */
+export type ParsedToolCall = { name: string; args: Record<string, unknown> };
+
+/** Parse an assistant text tool-call block into an ORDERED LIST of calls
+ * (single object, top-level array, or concatenated objects). [] when the
+ * text is not a JSON tool-call block. */
+export declare function parseTextToolCalls(text: string): ParsedToolCall[];
+
+/** Back-compat single-call contract: the FIRST parsed call, or null. */
+export declare function parseTextToolCall(text: string): ParsedToolCall | null;

--- a/services/prism-service/prism_service/web/pi-toolcall.mjs
+++ b/services/prism-service/prism_service/web/pi-toolcall.mjs
@@ -1,0 +1,104 @@
+/**
+ * Shared text-tool-call parser for PI's two interception surfaces
+ * (task c4bb21f8 — the "PI panel dumps raw tool-call JSON" bug, dup
+ * 4e5749bc). ONE source so a MULTI-call block parses identically on both
+ * the Node runner (web/pi-runtime.mjs) and the browser panel
+ * (web/src/lib/piAgent.ts) — same shared-module discipline as pi-expert.mjs.
+ *
+ * Small local models, asked to do several things in one turn (e.g. "search
+ * the brain for X THEN create a task"), emit the WHOLE plan as plain JSON
+ * TEXT instead of native tool_calls — as a single {name,arguments} object,
+ * a top-level ARRAY of such objects, or several objects concatenated
+ * (brace-adjacent `{..}{..}` or newline-separated). The single-object
+ * interceptor executed nothing on the array/concatenated shapes, so the
+ * raw JSON was shown and no tool ran.
+ *
+ * parseTextToolCalls returns an ORDERED LIST of {name,args}; the caller
+ * validates each name against the LIVE tool catalog and executes
+ * sequentially (unknown names skipped by the caller). parseTextToolCall
+ * keeps the single-object contract for back-compat.
+ */
+
+/** Coerce one parsed JSON value into a {name,args} call, or null when it
+ * is not a well-formed tool-call object (args must be a plain object). */
+function normalizeCall(obj) {
+  if (!obj || typeof obj !== "object" || Array.isArray(obj)) return null;
+  const name = obj.name;
+  if (typeof name !== "string" || !name) return null;
+  const args = obj.arguments ?? obj.args ?? obj.parameters ?? {};
+  if (typeof args !== "object" || args === null || Array.isArray(args)) return null;
+  return { name, args };
+}
+
+/** Scan a string for every TOP-LEVEL JSON container ({...} or [...]),
+ * brace-depth aware and string/escape aware so `{..}{..}`, `{..}\n{..}`,
+ * and nested braces/strings all split correctly. Malformed chunks are
+ * skipped, not thrown. */
+function scanJsonValues(text) {
+  const values = [];
+  let depth = 0;
+  let start = -1;
+  let inStr = false;
+  let esc = false;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === "\\") esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') { inStr = true; continue; }
+    if (ch === "{" || ch === "[") {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === "}" || ch === "]") {
+      if (depth > 0) {
+        depth--;
+        if (depth === 0 && start !== -1) {
+          try { values.push(JSON.parse(text.slice(start, i + 1))); } catch { /* skip */ }
+          start = -1;
+        }
+      }
+    }
+  }
+  return values;
+}
+
+/** Parse an assistant text that IS a tool-call block into an ORDERED LIST
+ * of {name,args}. Handles: a bare or ```json-fenced single object; a
+ * top-level array of objects; and multiple concatenated objects. Returns
+ * [] when the text is not a JSON tool-call block (plain prose, etc.). */
+export function parseTextToolCalls(text) {
+  let t = (text || "").trim();
+  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/.exec(t);
+  if (fence) t = fence[1].trim();
+  if (!t || !(t.startsWith("{") || t.startsWith("["))) return [];
+
+  let candidates = null;
+  try {
+    // Fast path: the whole block is ONE JSON value (object or array).
+    const parsed = JSON.parse(t);
+    candidates = Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // Concatenated objects ({..}{..} / {..}\n{..}): only meaningful when
+    // the block still closes a container — scan top-level JSON values.
+    if (t.endsWith("}") || t.endsWith("]")) {
+      candidates = scanJsonValues(t).flatMap((v) => (Array.isArray(v) ? v : [v]));
+    }
+  }
+  if (!candidates) return [];
+
+  const calls = [];
+  for (const c of candidates) {
+    const call = normalizeCall(c);
+    if (call) calls.push(call);
+  }
+  return calls;
+}
+
+/** Back-compat single-call contract: the FIRST parsed tool call, or null. */
+export function parseTextToolCall(text) {
+  const calls = parseTextToolCalls(text);
+  return calls.length ? calls[0] : null;
+}

--- a/services/prism-service/prism_service/web/pi-toolcall.test.mjs
+++ b/services/prism-service/prism_service/web/pi-toolcall.test.mjs
@@ -1,0 +1,74 @@
+/**
+ * Node unit check for the shared text-tool-call parser (task c4bb21f8).
+ * Exercises BOTH interception surfaces' parse logic at once, since
+ * pi-runtime.mjs and src/lib/piAgent.ts both import pi-toolcall.mjs.
+ *
+ * Run standalone: `node pi-toolcall.test.mjs` (exit 0 = pass, 1 = fail).
+ * Driven by tests/integration/test_pi_multicall_interception.py.
+ */
+
+import { parseTextToolCall, parseTextToolCalls } from "./pi-toolcall.mjs";
+
+let failures = 0;
+function check(label, cond) {
+  if (!cond) { failures++; process.stderr.write(`FAIL: ${label}\n`); }
+}
+
+// (1) Single object — the shape that already worked — still parses to one.
+const single = parseTextToolCalls('{"name": "brain_search", "arguments": {"query": "x"}}');
+check("single -> 1 call", single.length === 1);
+check("single name", single[0]?.name === "brain_search");
+check("single args", single[0]?.args?.query === "x");
+
+// (2) Fenced single object still parses.
+const fenced = parseTextToolCalls('```json\n{"name": "memory_recall", "args": {"q": "y"}}\n```');
+check("fenced -> 1 call", fenced.length === 1);
+check("fenced name", fenced[0]?.name === "memory_recall");
+
+// (3) Top-level ARRAY of tool calls -> ordered list (THE BUG).
+const arr = parseTextToolCalls(
+  '[{"name":"brain_search","arguments":{"query":"auth"}},' +
+  '{"name":"task_create","arguments":{"title":"Fix auth"}}]',
+);
+check("array -> 2 calls", arr.length === 2);
+check("array order[0]", arr[0]?.name === "brain_search");
+check("array order[1]", arr[1]?.name === "task_create");
+check("array args carried", arr[1]?.args?.title === "Fix auth");
+
+// (4) Concatenated objects, newline-separated -> ordered list.
+const catNl = parseTextToolCalls(
+  '{"name":"brain_search","arguments":{"query":"auth"}}\n' +
+  '{"name":"task_create","arguments":{"title":"Fix auth"}}',
+);
+check("concat(newline) -> 2 calls", catNl.length === 2);
+check("concat(newline) order", catNl[0]?.name === "brain_search" && catNl[1]?.name === "task_create");
+
+// (5) Concatenated objects, brace-adjacent -> ordered list.
+const catAdj = parseTextToolCalls(
+  '{"name":"brain_search","arguments":{"query":"a"}}{"name":"memory_recall","arguments":{"q":"b"}}',
+);
+check("concat(adjacent) -> 2 calls", catAdj.length === 2);
+check("concat(adjacent) order", catAdj[0]?.name === "brain_search" && catAdj[1]?.name === "memory_recall");
+
+// (6) Mixed valid + malformed element: keep the valid one, skip the junk.
+const mixed = parseTextToolCalls(
+  '[{"name":"brain_search","arguments":{"query":"a"}},{"noname":true},{"name":"task_create","arguments":{"title":"t"}}]',
+);
+check("mixed -> 2 valid calls", mixed.length === 2);
+check("mixed keeps names", mixed[0]?.name === "brain_search" && mixed[1]?.name === "task_create");
+
+// (7) Non-tool-call prose -> no calls (no false interception).
+check("prose -> 0", parseTextToolCalls("Sure, I searched the brain and found nothing.").length === 0);
+check("empty -> 0", parseTextToolCalls("").length === 0);
+
+// (8) Back-compat single accessor: first call, or null.
+check("parseTextToolCall single", parseTextToolCall('{"name":"brain_search","arguments":{}}')?.name === "brain_search");
+check("parseTextToolCall array-first", parseTextToolCall(
+  '[{"name":"first","arguments":{}},{"name":"second","arguments":{}}]')?.name === "first");
+check("parseTextToolCall prose null", parseTextToolCall("hello") === null);
+
+if (failures) {
+  process.stderr.write(`pi-toolcall.test.mjs: ${failures} assertion(s) failed\n`);
+  process.exit(1);
+}
+process.stdout.write("pi-toolcall.test.mjs: all checks passed\n");

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -23,6 +23,7 @@ const ConductorPage = lazy(() => import("@/pages/ConductorPage"));
 const SessionsPage = lazy(() => import("@/pages/SessionsPage"));
 const RetrievalsPage = lazy(() => import("@/pages/RetrievalsPage"));
 const LearningPage = lazy(() => import("@/pages/LearningPage"));
+const InternalAgentPage = lazy(() => import("@/pages/InternalAgentPage"));
 const ConsolidationPage = lazy(() => import("@/pages/ConsolidationPage"));
 const UnderstandPage = lazy(() => import("@/pages/UnderstandPage"));
 const ArtifactPage = lazy(() => import("@/pages/ArtifactPage"));
@@ -79,6 +80,10 @@ export default function App() {
             <Route path="/sessions" element={<SessionsPage />} />
             <Route path="/retrievals" element={<RetrievalsPage />} />
             <Route path="/learning" element={<LearningPage />} />
+            {/* Visual audit of internal pi/local inference runs — the
+                ledger behind /api/pi-runs (owner directive: internal
+                tools ship with an audit surface by default). */}
+            <Route path="/internal-agent" element={<InternalAgentPage />} />
             <Route path="/consolidation" element={<ConsolidationPage />} />
             <Route path="/understand" element={<UnderstandPage />} />
             {/* Unified artifact surface (xref S5): the single destination a

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -16,6 +16,7 @@ import LiveStatusStrip from "@/components/LiveStatusStrip";
 import DashboardPage from "@/pages/DashboardPage";
 const ExplorePage = lazy(() => import("@/pages/ExplorePage"));
 const TasksPage = lazy(() => import("@/pages/TasksPage"));
+const CompletedTasksPage = lazy(() => import("@/pages/CompletedTasksPage"));
 const TaskDetailPage = lazy(() => import("@/pages/TaskDetailPage"));
 const TaskTextPage = lazy(() => import("@/pages/TaskTextPage"));
 const ConductorPage = lazy(() => import("@/pages/ConductorPage"));
@@ -68,6 +69,10 @@ export default function App() {
             />
             <Route path="/okf" element={<Navigate to="/understand" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
+            {/* Static segment must precede /tasks/:id or the param route
+                would swallow it. Completed work lives here, off the board
+                (done-tasks-off-board doctrine, re-landed from bdb8bad). */}
+            <Route path="/tasks/completed" element={<CompletedTasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetailPage />} />
             <Route path="/tasks/:id/:section" element={<TaskTextPage />} />
             <Route path="/conductor" element={<ConductorPage />} />

--- a/services/prism-service/prism_service/web/src/components/PageHeader.tsx
+++ b/services/prism-service/prism_service/web/src/components/PageHeader.tsx
@@ -10,6 +10,7 @@ const TITLES: Record<string, string> = {
   "/sessions": "Sessions", "/retrievals": "Retrievals",
   "/learning": "Learning", "/consolidation": "Consolidation",
   "/understand": "Understand", "/settings": "Settings",
+  "/internal-agent": "Internal agent",
 };
 
 // v6.0.15 — match nested routes (e.g. /tasks/:id -> "Tasks",

--- a/services/prism-service/prism_service/web/src/components/Sidebar.tsx
+++ b/services/prism-service/prism_service/web/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
-  Activity, AppWindow, Brain, Eye, FolderTree, Info,
+  Activity, AppWindow, Bot, Brain, Eye, FolderTree, Info,
   Layers, LayoutDashboard, ListChecks, MessageSquare, Plug,
   ScrollText, Search, Settings, Sparkles, Workflow,
   type LucideIcon,
@@ -75,6 +75,9 @@ const MAIN_SECTIONS: Section[] = [
       { to: "/sessions", label: "Sessions", icon: MessageSquare },
       { to: "/consolidation", label: "Consolidation", icon: Layers },
       { to: "/learning", label: "Learning", icon: Sparkles },
+      // Visual audit of the internal pi/local inference runs that
+      // POWER the loop (reflection backend=pi/local, panel bridge).
+      { to: "/internal-agent", label: "Internal agent", icon: Bot },
     ],
   },
 ];

--- a/services/prism-service/prism_service/web/src/components/Sidebar.tsx
+++ b/services/prism-service/prism_service/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import {
   Activity, AppWindow, Brain, Eye, FolderTree, Info,
@@ -11,6 +11,11 @@ import { useProject } from "@/lib/project";
 import { useScanActivity } from "@/lib/scan-activity";
 import { useVersion } from "@/lib/version";
 import { cn } from "@/lib/utils";
+import { Tabs } from "@/components/ui";
+
+// Code-split: the pi runtime (pi-ai + pi-agent-core) loads only when the PI
+// tab is first opened — the NAV-only user never pays for it.
+const PiAgentPanel = lazy(() => import("@/components/pi/PiAgentPanel"));
 
 type StaleKey = "understand" | "graph" | "brain";
 
@@ -113,6 +118,9 @@ function useStaleness(project: string): Staleness {
 }
 
 
+type RailTab = "nav" | "pi";
+const RAIL_TAB_KEY = "prism.pi.railTab";
+
 export default function Sidebar() {
   const [project] = useProject();
   const stale = useStaleness(project);
@@ -120,6 +128,22 @@ export default function Sidebar() {
   const version = useVersion();
   const { pathname } = useLocation();
   const inSettings = pathname.startsWith("/settings");
+
+  // Rail tab: Agent (the omnipresent assistant, task 711d5235 — the
+  // DEFAULT) | Nav (the classic navigation). The choice survives reloads;
+  // the agent's conversation survives route changes because this component
+  // lives OUTSIDE <Routes> and the panel stays mounted (display-toggled,
+  // never unmounted) once opened.
+  const [railTab, setRailTab] = useState<RailTab>(() => {
+    try { return localStorage.getItem(RAIL_TAB_KEY) === "nav" ? "nav" : "pi"; }
+    catch { return "pi"; }
+  });
+  const [piOpened, setPiOpened] = useState(railTab === "pi");
+  const switchTab = (tab: RailTab) => {
+    setRailTab(tab);
+    if (tab === "pi") setPiOpened(true);
+    try { localStorage.setItem(RAIL_TAB_KEY, tab); } catch { /* best-effort */ }
+  };
 
   // Top item is always Dashboard. Below it: either Knowledge + Activity
   // (default) or the Settings categories (when in /settings/*). The
@@ -130,12 +154,48 @@ export default function Sidebar() {
   ];
 
   return (
-    <aside className="w-[240px] shrink-0 flex flex-col border-r border-[color:var(--border-default)] bg-[color:var(--surface-1)]">
+    <aside
+      className={cn(
+        "shrink-0 flex flex-col border-r border-[color:var(--border-default)] bg-[color:var(--surface-1)]",
+        "transition-[width] duration-300",
+        railTab === "pi" ? "w-[360px]" : "w-[240px]",
+      )}
+    >
       <div className="h-[80px] px-5 flex flex-col justify-center border-b border-[color:var(--border-default)]">
         <div className="font-serif text-2xl leading-none tracking-tight text-[color:var(--text-primary)]">PRISM</div>
         <div className="font-serif text-xl leading-none tracking-tight text-[color:var(--text-secondary)] mt-1">SERVICE</div>
       </div>
-      <nav className="flex-1 overflow-y-auto py-3">
+      <div className="border-b border-[color:var(--border-default)]">
+        <Tabs<RailTab>
+          className="rounded-none border-0 bg-transparent p-0 w-full"
+          segmentClassName="py-2.5 rounded-none"
+          value={railTab}
+          onChange={switchTab}
+          items={[
+            {
+              key: "pi",
+              label: (
+                <>
+                  <span>Agent</span>
+                  <span className="w-1.5 h-1.5 rounded-full bg-[color:var(--accent-emerald-fg)]" />
+                </>
+              ),
+              title: "The omnipresent PRISM agent (local small model)",
+            },
+            { key: "nav", label: "Nav" },
+          ]}
+        />
+      </div>
+      {piOpened && (
+        <div className={cn("flex-1 min-h-0 flex-col", railTab === "pi" ? "flex" : "hidden")}>
+          <Suspense
+            fallback={<div className="p-4 text-xs text-[color:var(--text-muted)] animate-pulse">loading PI…</div>}
+          >
+            <PiAgentPanel />
+          </Suspense>
+        </div>
+      )}
+      <nav className={cn("flex-1 overflow-y-auto py-3", railTab === "pi" && "hidden")}>
         {sections.map((section, i) => (
           // Match the divider style used between Settings and the version
           // footer below — same border-default line + same py-3 spacing —

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -100,6 +100,14 @@ export default function SdlcProgress({
   // "live" = the task is genuinely being worked (status in_progress) — the
   // honest basis for the shimmer + pulse, instead of a laggy token delta.
   const live = (status ?? "").toLowerCase() === "in_progress";
+  // A finished task's ticker must FREEZE: the server already froze in_step_s at
+  // completed_at (basis="done", pct=1). Without this the animation frame kept
+  // adding real wall-time to the frozen clock, so a done task's step counter
+  // ticked up forever and its terminal segment rendered as still-filling.
+  const taskDone =
+    (status ?? "").toLowerCase() === "done" ||
+    (phase?.pct ?? 0) >= 1 ||
+    (phase?.basis === "done");
 
   // Overall task progress toward DONE: completed steps + current phase fraction.
   const overallSeed = curIdx >= 0 ? (curIdx + seed) / steps.length : seed;
@@ -125,8 +133,10 @@ export default function SdlcProgress({
   const lastClockAt = useRef(0);
   useAnimationFrame((t) => {
     if (!phase || curIdx < 0) return;
-    const elapsedS = (performance.now() - anchor.current.t0) / 1000;
-    const wf = liveFraction(phase, elapsedS);
+    // Only a genuinely in-progress task accrues elapsed wall-time; a done or
+    // paused task stays pinned to the server's frozen in_step_s.
+    const elapsedS = live ? (performance.now() - anchor.current.t0) / 1000 : 0;
+    const wf = taskDone ? 1 : liveFraction(phase, elapsedS);
     segFill.set(wf);
     if (t - lastPctAt.current > 120) {
       lastPctAt.current = t;
@@ -143,8 +153,10 @@ export default function SdlcProgress({
       <div className="flex items-stretch gap-[3px] h-2.5">
         {steps.map((s, i) => {
           const isGate = s.type === "gate";
-          const done = curIdx >= 0 && i < curIdx;
-          const current = i === curIdx;
+          // A done task shows its terminal segment as complete (emerald), not
+          // as a live-filling current step.
+          const done = curIdx >= 0 && (i < curIdx || (i === curIdx && taskDone));
+          const current = i === curIdx && !taskDone;
           const base = "relative flex-1 rounded-full overflow-hidden";
           if (done) {
             return (

--- a/services/prism-service/prism_service/web/src/components/pi/PiAgentPanel.tsx
+++ b/services/prism-service/prism_service/web/src/components/pi/PiAgentPanel.tsx
@@ -3,15 +3,31 @@
  *
  * Renders the pi-agent-core event stream folded by lib/piAgent.ts: user and
  * assistant bubbles (Markdown bodies), one-line collapsed tool-call rows that
- * click-expand to their receipt (progressive disclosure — never a wall of
- * text), a model status chip + picker, and the explicit "learn this"
- * self-learning affordance. Inference is local-only; the footer says so.
+ * click-expand to per-tool renderers (progressive disclosure — never a wall
+ * of text), a model status chip + picker, per-exchange token stats, and the
+ * explicit "learn this" self-learning affordance. Inference is local-only;
+ * the footer says so.
+ *
+ * Rendering architecture — structure borrowed from @earendil-works/pi-web-ui
+ * (MIT, Mario Zechner), reimplemented for React/Hermes: settled transcript
+ * items live in a memoized list that only re-renders on structural changes
+ * (item count / a settled item), while the in-flight assistant text streams
+ * through an isolated component on the store's dedicated stream channel —
+ * no full-transcript re-render per token.
  *
  * pi toolkit: https://github.com/badlogic/pi-mono (MIT, Mario Zechner).
  */
-import { useEffect, useRef, useState, useSyncExternalStore } from "react";
-import { ChevronDown, ChevronRight, Hexagon, Send, Sparkles } from "lucide-react";
+import {
+  memo,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { ChevronDown, ChevronRight, Hexagon, Send, Sparkles, Square } from "lucide-react";
 import Markdown from "@/components/Markdown";
+import { TOOL_RENDERERS, prettyReceipt } from "@/components/pi/toolRenderers";
 import { useProject } from "@/lib/project";
 import { cn } from "@/lib/utils";
 import {
@@ -29,20 +45,23 @@ export default function PiAgentPanel() {
   useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion);
   const items = store.snapshot();
 
-  const [draft, setDraft] = useState("");
   const [pickerOpen, setPickerOpen] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+
+  // Stable/streaming split: while an assistant message is in flight it is
+  // rendered by <StreamingBubble> off the stream channel; everything before
+  // it is the settled, memoized transcript.
+  const tail = items[items.length - 1];
+  const streaming = store.busy && tail?.kind === "assistant" && !tail.done;
+  const settled = useMemo(
+    () => (streaming ? items.slice(0, -1) : items),
+    [items, streaming],
+  );
 
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
-  }, [items.length, store.busy]);
-
-  const send = (text: string) => {
-    if (!text.trim() || store.busy) return;
-    setDraft("");
-    void store.send(text);
-  };
+  }, [items, store.busy]);
 
   return (
     <div className="flex-1 min-h-0 flex flex-col">
@@ -60,7 +79,7 @@ export default function PiAgentPanel() {
                 <button
                   key={s}
                   type="button"
-                  onClick={() => send(s)}
+                  onClick={() => { if (!store.busy) void store.send(s); }}
                   className="text-left px-2.5 py-1.5 rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] hover:bg-[color:var(--surface-3)] transition-colors text-xs"
                 >
                   {s}
@@ -69,10 +88,9 @@ export default function PiAgentPanel() {
             </div>
           </div>
         )}
-        {items.map((item, i) => (
-          <PiItemRow key={i} item={item} index={i} store={store} />
-        ))}
-        {store.busy && items[items.length - 1]?.kind !== "assistant" && (
+        <SettledList items={settled} store={store} />
+        {streaming && <StreamingBubble store={store} />}
+        {store.busy && !streaming && (
           <div className="px-2 py-1 text-xs text-[color:var(--text-muted)] animate-pulse">thinking…</div>
         )}
         {store.lastError && (
@@ -82,29 +100,126 @@ export default function PiAgentPanel() {
         )}
       </div>
 
-      <div className="border-t border-[color:var(--border-default)] p-2.5 space-y-1.5">
-        <form
-          className="flex items-center gap-1.5"
-          onSubmit={(e) => { e.preventDefault(); send(draft); }}
-        >
-          <input
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="Ask about this project…"
-            className="flex-1 min-w-0 px-2.5 py-1.5 rounded-md text-sm bg-[color:var(--surface-0)] border border-[color:var(--border-default)] text-[color:var(--text-primary)] placeholder:text-[color:var(--text-disabled)] focus:outline-none focus:border-[color:var(--border-strong)]"
-          />
+      <Composer store={store} busy={store.busy} />
+    </div>
+  );
+}
+
+/**
+ * Settled transcript — memoized so it re-renders ONLY when the settled items
+ * array is replaced (the store recreates it exclusively on structural emits:
+ * item added, tool status change, exchange finished). Token-level streaming
+ * never touches this list.
+ */
+const SettledList = memo(function SettledList({
+  items, store,
+}: {
+  items: PiItem[];
+  store: PiStore;
+}) {
+  return (
+    <>
+      {items.map((item, i) => (
+        <PiItemRow key={i} item={item} index={i} store={store} />
+      ))}
+    </>
+  );
+});
+
+/**
+ * In-flight assistant text, isolated on the store's stream channel: each
+ * message_update fold bumps only the stream version, so this bubble is the
+ * ONLY component that re-renders per token.
+ */
+function StreamingBubble({ store }: { store: PiStore }) {
+  useSyncExternalStore(store.subscribeStream, store.getStreamVersion, store.getStreamVersion);
+  const text = store.streamingText;
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => { ref.current?.scrollIntoView({ block: "nearest" }); }, [text]);
+  return (
+    <div ref={ref} className="max-w-[96%] px-3 py-2 rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-subtle)]">
+      {text
+        ? <Markdown text={text} className="space-y-2" />
+        : <span className="text-xs text-[color:var(--text-muted)] animate-pulse">…</span>}
+    </div>
+  );
+}
+
+/** True when the browser auto-grows the textarea natively. */
+const FIELD_SIZING_SUPPORTED =
+  typeof CSS !== "undefined" && typeof CSS.supports === "function" &&
+  CSS.supports("field-sizing", "content");
+
+/**
+ * Input editor (pi-web-ui behavior): auto-growing textarea — CSS
+ * `field-sizing: content` where supported, scrollHeight JS fallback where
+ * not — Enter sends, Shift+Enter inserts a newline, and the send button
+ * becomes a stop button (agent.abort()) while a run is in flight. Draft
+ * state is local so typing never re-renders the transcript.
+ */
+function Composer({ store, busy }: { store: PiStore; busy: boolean }) {
+  const [draft, setDraft] = useState("");
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (FIELD_SIZING_SUPPORTED) taRef.current?.style.setProperty("field-sizing", "content");
+  }, []);
+
+  const autoGrow = () => {
+    const el = taRef.current;
+    if (!el || FIELD_SIZING_SUPPORTED) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 128)}px`;
+  };
+
+  const send = () => {
+    const text = draft.trim();
+    if (!text || busy) return;
+    setDraft("");
+    const el = taRef.current;
+    if (el && !FIELD_SIZING_SUPPORTED) el.style.height = "auto";
+    void store.send(text);
+  };
+
+  return (
+    <div className="border-t border-[color:var(--border-default)] p-2.5 space-y-1.5">
+      <form
+        className="flex items-end gap-1.5"
+        onSubmit={(e) => { e.preventDefault(); send(); }}
+      >
+        <textarea
+          ref={taRef}
+          rows={1}
+          value={draft}
+          onChange={(e) => { setDraft(e.target.value); autoGrow(); }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
+          }}
+          placeholder="Ask about this project…"
+          className="flex-1 min-w-0 px-2.5 py-1.5 rounded-md text-sm resize-none max-h-32 overflow-y-auto bg-[color:var(--surface-0)] border border-[color:var(--border-default)] text-[color:var(--text-primary)] placeholder:text-[color:var(--text-disabled)] focus:outline-none focus:border-[color:var(--border-strong)]"
+        />
+        {busy ? (
+          <button
+            type="button"
+            onClick={() => store.abort()}
+            title="Stop"
+            className="p-2 rounded-md border border-[color:var(--accent-rose-ring)] text-[color:var(--accent-rose-fg)] hover:bg-[color:var(--accent-rose-bg)] transition-colors"
+          >
+            <Square className="w-3.5 h-3.5" />
+          </button>
+        ) : (
           <button
             type="submit"
-            disabled={store.busy || !draft.trim()}
+            disabled={!draft.trim()}
             title="Send"
             className="p-2 rounded-md border border-[color:var(--border-default)] text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] disabled:opacity-40 disabled:pointer-events-none transition-colors"
           >
             <Send className="w-3.5 h-3.5" />
           </button>
-        </form>
-        <div className="px-0.5 text-[10px] uppercase tracking-wider text-[color:var(--text-disabled)]">
-          inference: local · 0 tokens sent to cloud
-        </div>
+        )}
+      </form>
+      <div className="px-0.5 text-[10px] uppercase tracking-wider text-[color:var(--text-disabled)]">
+        inference: local · 0 tokens sent to cloud
       </div>
     </div>
   );
@@ -197,20 +312,31 @@ function PiItemRow({ item, index, store }: { item: PiItem; index: number; store:
             : <span className="text-xs text-[color:var(--text-muted)] animate-pulse">…</span>}
         </div>
         {item.done && item.text && (
-          <button
-            type="button"
-            disabled={item.learned || item.learning}
-            onClick={() => void store.learn(index)}
-            className={cn(
-              "flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wider transition-colors",
-              item.learned
-                ? "bg-[color:var(--accent-emerald-bg)] text-[color:var(--accent-emerald-fg)] ring-1 ring-inset ring-[color:var(--accent-emerald-ring)]"
-                : "text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-2)]",
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={item.learned || item.learning}
+              onClick={() => void store.learn(index)}
+              className={cn(
+                "flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wider transition-colors",
+                item.learned
+                  ? "bg-[color:var(--accent-emerald-bg)] text-[color:var(--accent-emerald-fg)] ring-1 ring-inset ring-[color:var(--accent-emerald-ring)]"
+                  : "text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-2)]",
+              )}
+            >
+              <Sparkles className="w-3 h-3" />
+              {item.learned ? "in memory" : item.learning ? "storing…" : "learn this"}
+            </button>
+            {item.stats && (
+              <span
+                className="text-[10px] font-mono text-[color:var(--text-muted)]"
+                title={item.stats.estimated ? "estimated (text length / 4 — no usage in stream)" : "reported by the model stream"}
+              >
+                ↑{item.stats.input} ↓{item.stats.output} tok · {item.stats.seconds.toFixed(1)}s
+                {item.stats.estimated ? " ~" : ""}
+              </span>
             )}
-          >
-            <Sparkles className="w-3 h-3" />
-            {item.learned ? "in memory" : item.learning ? "storing…" : "learn this"}
-          </button>
+          </div>
         )}
       </div>
     );
@@ -221,10 +347,16 @@ function PiItemRow({ item, index, store }: { item: PiItem; index: number; store:
   );
 }
 
-/** One-line collapsed tool receipt; click to expand (progressive disclosure). */
+/** One-line collapsed tool receipt; click to expand (progressive disclosure).
+ * The expanded body goes through the per-tool renderer registry
+ * (toolRenderers.tsx); unknown tools / unexpected shapes fall back to the
+ * raw mono receipt. */
 function ToolRow({ item }: { item: Extract<PiItem, { kind: "tool" }> }) {
   const [open, setOpen] = useState(false);
   const argSummary = summarize(item.args);
+  const custom = open && item.status === "ok"
+    ? TOOL_RENDERERS.get(item.name)?.(item.result) ?? null
+    : null;
   return (
     <div className="mx-1">
       <button
@@ -248,11 +380,17 @@ function ToolRow({ item }: { item: Extract<PiItem, { kind: "tool" }> }) {
         </span>
       </button>
       {open && item.status !== "running" && (
-        <div className="mt-1 mb-1 mx-1 px-2.5 py-2 rounded-md bg-[color:var(--surface-0)] border border-[color:var(--border-default)] max-h-48 overflow-y-auto">
-          <div className="text-[10px] leading-relaxed font-mono text-[color:var(--text-secondary)] whitespace-pre-wrap break-words">
-            {pretty(item.result)}
+        custom != null ? (
+          <div className="mt-1 mb-1 mx-1 rounded-md bg-[color:var(--surface-1)] border border-[color:var(--border-subtle)] p-1 max-h-64 overflow-y-auto">
+            {custom}
           </div>
-        </div>
+        ) : (
+          <div className="mt-1 mb-1 mx-1 px-2.5 py-2 rounded-md bg-[color:var(--surface-0)] border border-[color:var(--border-default)] max-h-48 overflow-y-auto">
+            <div className="text-[10px] leading-relaxed font-mono text-[color:var(--text-secondary)] whitespace-pre-wrap break-words">
+              {prettyReceipt(item.result)}
+            </div>
+          </div>
+        )
       )}
     </div>
   );
@@ -265,15 +403,4 @@ function summarize(args: unknown): string {
   );
   const s = vals.join(", ");
   return s.length > 40 ? `${s.slice(0, 40)}…` : s;
-}
-
-function pretty(value: unknown): string {
-  if (value == null) return "(no result)";
-  if (typeof value === "string") return value;
-  try {
-    const s = JSON.stringify(value, null, 2);
-    return s.length > 4000 ? `${s.slice(0, 4000)}\n…(truncated)` : s;
-  } catch {
-    return String(value);
-  }
 }

--- a/services/prism-service/prism_service/web/src/components/pi/PiAgentPanel.tsx
+++ b/services/prism-service/prism_service/web/src/components/pi/PiAgentPanel.tsx
@@ -1,0 +1,279 @@
+/**
+ * PI agent chat panel — the omnipresent left-rail assistant (task 711d5235).
+ *
+ * Renders the pi-agent-core event stream folded by lib/piAgent.ts: user and
+ * assistant bubbles (Markdown bodies), one-line collapsed tool-call rows that
+ * click-expand to their receipt (progressive disclosure — never a wall of
+ * text), a model status chip + picker, and the explicit "learn this"
+ * self-learning affordance. Inference is local-only; the footer says so.
+ *
+ * pi toolkit: https://github.com/badlogic/pi-mono (MIT, Mario Zechner).
+ */
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { ChevronDown, ChevronRight, Hexagon, Send, Sparkles } from "lucide-react";
+import Markdown from "@/components/Markdown";
+import { useProject } from "@/lib/project";
+import { cn } from "@/lib/utils";
+import {
+  PI_MODEL_CHOICES,
+  piStore,
+  type PiItem,
+  type PiStore,
+} from "@/lib/piAgent";
+
+const SUGGESTED = ["What tasks are pending?", "What is in this project's brain?"];
+
+export default function PiAgentPanel() {
+  const [project] = useProject();
+  const store = piStore(project);
+  useSyncExternalStore(store.subscribe, store.getVersion, store.getVersion);
+  const items = store.snapshot();
+
+  const [draft, setDraft] = useState("");
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [items.length, store.busy]);
+
+  const send = (text: string) => {
+    if (!text.trim() || store.busy) return;
+    setDraft("");
+    void store.send(text);
+  };
+
+  return (
+    <div className="flex-1 min-h-0 flex flex-col">
+      <PanelHeader store={store} pickerOpen={pickerOpen} setPickerOpen={setPickerOpen} />
+
+      <div ref={scrollRef} className="flex-1 min-h-0 overflow-y-auto px-3 py-3 space-y-2">
+        {items.length === 0 && (
+          <div className="text-xs text-[color:var(--text-muted)] leading-relaxed px-1 space-y-3">
+            <p>
+              Answers come from this project's real data — brain, memory,
+              tasks — via self-executed PRISM tool calls on a small local model.
+            </p>
+            <div className="flex flex-col gap-1.5">
+              {SUGGESTED.map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => send(s)}
+                  className="text-left px-2.5 py-1.5 rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-2)] text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] hover:bg-[color:var(--surface-3)] transition-colors text-xs"
+                >
+                  {s}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        {items.map((item, i) => (
+          <PiItemRow key={i} item={item} index={i} store={store} />
+        ))}
+        {store.busy && items[items.length - 1]?.kind !== "assistant" && (
+          <div className="px-2 py-1 text-xs text-[color:var(--text-muted)] animate-pulse">thinking…</div>
+        )}
+        {store.lastError && (
+          <div className="mx-1 px-2.5 py-2 rounded-md border border-[color:var(--accent-rose-ring)] bg-[color:var(--accent-rose-bg)] text-[color:var(--accent-rose-fg)] text-xs break-words">
+            {store.lastError}
+          </div>
+        )}
+      </div>
+
+      <div className="border-t border-[color:var(--border-default)] p-2.5 space-y-1.5">
+        <form
+          className="flex items-center gap-1.5"
+          onSubmit={(e) => { e.preventDefault(); send(draft); }}
+        >
+          <input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Ask about this project…"
+            className="flex-1 min-w-0 px-2.5 py-1.5 rounded-md text-sm bg-[color:var(--surface-0)] border border-[color:var(--border-default)] text-[color:var(--text-primary)] placeholder:text-[color:var(--text-disabled)] focus:outline-none focus:border-[color:var(--border-strong)]"
+          />
+          <button
+            type="submit"
+            disabled={store.busy || !draft.trim()}
+            title="Send"
+            className="p-2 rounded-md border border-[color:var(--border-default)] text-[color:var(--text-secondary)] hover:text-[color:var(--text-primary)] hover:bg-[color:var(--surface-2)] disabled:opacity-40 disabled:pointer-events-none transition-colors"
+          >
+            <Send className="w-3.5 h-3.5" />
+          </button>
+        </form>
+        <div className="px-0.5 text-[10px] uppercase tracking-wider text-[color:var(--text-disabled)]">
+          inference: local · 0 tokens sent to cloud
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PanelHeader({
+  store, pickerOpen, setPickerOpen,
+}: {
+  store: PiStore;
+  pickerOpen: boolean;
+  setPickerOpen: (v: boolean) => void;
+}) {
+  const cfg = store.config;
+  const experimental = PI_MODEL_CHOICES.find((m) => m.id === cfg.modelId)?.experimental;
+  return (
+    <div className="relative border-b border-[color:var(--border-default)]">
+      {/* Model selector — a full-width bar directly under the rail's tab
+          toggle: reads as a second tab row, opens the picker. */}
+      <button
+        type="button"
+        onClick={() => { setPickerOpen(!pickerOpen); void store.probe(); }}
+        title={`Local model endpoint: ${cfg.baseUrl}`}
+        className="w-full flex items-center gap-2 px-4 py-2 text-[11px] text-[color:var(--accent-teal-fg)] hover:bg-[color:var(--accent-teal-bg)] transition-colors"
+      >
+        <Hexagon className="w-3 h-3 shrink-0" />
+        <span className="font-mono truncate">{cfg.modelId}</span>
+        <span
+          className={cn(
+            "ml-auto w-1.5 h-1.5 rounded-full shrink-0",
+            store.connected === true && "bg-[color:var(--accent-emerald-fg)] animate-pulse",
+            store.connected === false && "bg-[color:var(--accent-rose-fg)]",
+            store.connected === null && "bg-[color:var(--text-disabled)]",
+          )}
+        />
+      </button>
+      {experimental && (
+        <div className="px-4 pb-1.5 text-[10px] text-[color:var(--accent-amber-fg)]">
+          G5: probing smaller models — tool loops may fail
+        </div>
+      )}
+      {pickerOpen && (
+        <div className="absolute left-2 right-2 top-full mt-1 z-20 rounded-md border border-[color:var(--border-strong)] bg-[color:var(--surface-3)] shadow-xl py-1">
+          {PI_MODEL_CHOICES.map((m) => (
+            <button
+              key={m.id}
+              type="button"
+              onClick={() => { store.setModel(m.id); setPickerOpen(false); }}
+              className={cn(
+                "w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-[color:var(--surface-2)]",
+                m.id === cfg.modelId
+                  ? "text-[color:var(--text-primary)]"
+                  : "text-[color:var(--text-secondary)]",
+              )}
+            >
+              <span className="font-mono">{m.label}</span>
+              {m.hint && (
+                <span className={cn(
+                  "ml-2 text-[10px]",
+                  m.experimental
+                    ? "text-[color:var(--accent-amber-fg)]"
+                    : "text-[color:var(--text-muted)]",
+                )}>
+                  {m.hint}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function PiItemRow({ item, index, store }: { item: PiItem; index: number; store: PiStore }) {
+  if (item.kind === "user") {
+    return (
+      <div className="flex justify-end">
+        <div className="max-w-[92%] px-3 py-2 rounded-md bg-[color:var(--accent-violet-bg)] ring-1 ring-inset ring-[color:var(--accent-violet-ring)] text-sm text-[color:var(--text-primary)] whitespace-pre-wrap break-words">
+          {item.text}
+        </div>
+      </div>
+    );
+  }
+  if (item.kind === "assistant") {
+    return (
+      <div className="space-y-1">
+        <div className="max-w-[96%] px-3 py-2 rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-subtle)]">
+          {item.text
+            ? <Markdown text={item.text} className="space-y-2" />
+            : <span className="text-xs text-[color:var(--text-muted)] animate-pulse">…</span>}
+        </div>
+        {item.done && item.text && (
+          <button
+            type="button"
+            disabled={item.learned || item.learning}
+            onClick={() => void store.learn(index)}
+            className={cn(
+              "flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wider transition-colors",
+              item.learned
+                ? "bg-[color:var(--accent-emerald-bg)] text-[color:var(--accent-emerald-fg)] ring-1 ring-inset ring-[color:var(--accent-emerald-ring)]"
+                : "text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-2)]",
+            )}
+          >
+            <Sparkles className="w-3 h-3" />
+            {item.learned ? "in memory" : item.learning ? "storing…" : "learn this"}
+          </button>
+        )}
+      </div>
+    );
+  }
+  if (item.kind === "tool") return <ToolRow item={item} />;
+  return (
+    <div className="px-2 text-[10px] text-[color:var(--text-muted)] font-mono">{item.text}</div>
+  );
+}
+
+/** One-line collapsed tool receipt; click to expand (progressive disclosure). */
+function ToolRow({ item }: { item: Extract<PiItem, { kind: "tool" }> }) {
+  const [open, setOpen] = useState(false);
+  const argSummary = summarize(item.args);
+  return (
+    <div className="mx-1">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className={cn(
+          "w-full flex items-center gap-1.5 px-2 py-1 rounded-md text-[11px] font-mono transition-colors text-left",
+          item.status === "error"
+            ? "text-[color:var(--accent-rose-fg)] bg-[color:var(--accent-rose-bg)]"
+            : "text-[color:var(--accent-teal-fg)] hover:bg-[color:var(--accent-teal-bg)]",
+          item.status === "running" && "animate-pulse",
+        )}
+      >
+        {open ? <ChevronDown className="w-3 h-3 shrink-0" /> : <ChevronRight className="w-3 h-3 shrink-0" />}
+        <span className="truncate">
+          {item.name}
+          {argSummary && <span className="text-[color:var(--text-muted)]"> · {argSummary}</span>}
+        </span>
+        <span className="ml-auto shrink-0 text-[color:var(--text-muted)]">
+          {item.status === "running" ? "running…" : item.ms != null ? `${item.ms}ms` : item.status}
+        </span>
+      </button>
+      {open && item.status !== "running" && (
+        <div className="mt-1 mb-1 mx-1 px-2.5 py-2 rounded-md bg-[color:var(--surface-0)] border border-[color:var(--border-default)] max-h-48 overflow-y-auto">
+          <div className="text-[10px] leading-relaxed font-mono text-[color:var(--text-secondary)] whitespace-pre-wrap break-words">
+            {pretty(item.result)}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function summarize(args: unknown): string {
+  if (!args || typeof args !== "object") return "";
+  const vals = Object.values(args as Record<string, unknown>).filter(
+    (v): v is string => typeof v === "string" && v.length > 0,
+  );
+  const s = vals.join(", ");
+  return s.length > 40 ? `${s.slice(0, 40)}…` : s;
+}
+
+function pretty(value: unknown): string {
+  if (value == null) return "(no result)";
+  if (typeof value === "string") return value;
+  try {
+    const s = JSON.stringify(value, null, 2);
+    return s.length > 4000 ? `${s.slice(0, 4000)}\n…(truncated)` : s;
+  } catch {
+    return String(value);
+  }
+}

--- a/services/prism-service/prism_service/web/src/components/pi/piSession.ts
+++ b/services/prism-service/prism_service/web/src/components/pi/piSession.ts
@@ -1,0 +1,79 @@
+/**
+ * PI session persistence — display-level conversation snapshots.
+ *
+ * Structure borrowed from @earendil-works/pi-web-ui (MIT, Mario Zechner),
+ * reimplemented for React/Hermes.
+ *
+ * One snapshot per project under the key `prism.pi.session.{project}`,
+ * stored in IndexedDB (localStorage fallback when IDB is unavailable or
+ * errors, e.g. private-mode quotas). A page reload restores the visible
+ * transcript only: the agent's LLM context deliberately restarts fresh —
+ * the human keeps the conversation, the model begins a new run. That is
+ * enough (and safer: no replaying stale tool receipts into a small model).
+ */
+import type { PiItem } from "@/lib/piAgent";
+
+export type PiSessionSnapshot = {
+  items: PiItem[];
+  /** Minimal agent context: which model the exchange ran on. */
+  modelId: string;
+  savedAt: number;
+};
+
+const DB_NAME = "prism-pi";
+const DB_STORE = "sessions";
+
+const key = (project: string) => `prism.pi.session.${project}`;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, 1);
+    req.onupgradeneeded = () => { req.result.createObjectStore(DB_STORE); };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error ?? new Error("indexedDB open failed"));
+  });
+}
+
+async function idb<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest): Promise<T> {
+  const db = await openDb();
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const req = run(db.transaction(DB_STORE, mode).objectStore(DB_STORE));
+      req.onsuccess = () => resolve(req.result as T);
+      req.onerror = () => reject(req.error ?? new Error("indexedDB request failed"));
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function saveSession(project: string, snap: PiSessionSnapshot): Promise<void> {
+  try {
+    if (typeof indexedDB !== "undefined") {
+      await idb("readwrite", (s) => s.put(snap, key(project)));
+      return;
+    }
+  } catch { /* fall through to localStorage */ }
+  try { localStorage.setItem(key(project), JSON.stringify(snap)); } catch { /* best-effort */ }
+}
+
+export async function loadSession(project: string): Promise<PiSessionSnapshot | null> {
+  try {
+    if (typeof indexedDB !== "undefined") {
+      const got = await idb<PiSessionSnapshot | undefined>("readonly", (s) => s.get(key(project)));
+      if (got?.items) return got;
+    }
+  } catch { /* fall through to localStorage */ }
+  try {
+    const raw = localStorage.getItem(key(project));
+    if (raw) return JSON.parse(raw) as PiSessionSnapshot;
+  } catch { /* best-effort */ }
+  return null;
+}
+
+export async function clearSession(project: string): Promise<void> {
+  try {
+    if (typeof indexedDB !== "undefined") await idb("readwrite", (s) => s.delete(key(project)));
+  } catch { /* best-effort */ }
+  try { localStorage.removeItem(key(project)); } catch { /* best-effort */ }
+}

--- a/services/prism-service/prism_service/web/src/components/pi/toolRenderers.tsx
+++ b/services/prism-service/prism_service/web/src/components/pi/toolRenderers.tsx
@@ -1,0 +1,178 @@
+/**
+ * PI tool-renderer registry — per-tool expanded bodies for tool-call rows.
+ *
+ * Structure borrowed from @earendil-works/pi-web-ui (MIT, Mario Zechner):
+ * its Map<toolName, renderer> registry replacing a one-size-fits-all tool
+ * body. Reimplemented for React + Hermes tokens (CSS custom properties from
+ * src/index.css — no hardcoded colors).
+ *
+ * Contract: a renderer returns null when the payload doesn't match the
+ * shape it knows; the caller (ToolRow in PiAgentPanel) then falls back to
+ * the default collapsed mono receipt. Every renderer keeps progressive
+ * disclosure — one-line rows, click to expand the raw receipt.
+ */
+import { useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type ToolRenderer = (result: unknown) => ReactNode | null;
+
+// ------------------------------------------------------------- shared
+
+export function prettyReceipt(value: unknown): string {
+  if (value == null) return "(no result)";
+  if (typeof value === "string") return value;
+  try {
+    const s = JSON.stringify(value, null, 2);
+    return s.length > 4000 ? `${s.slice(0, 4000)}\n…(truncated)` : s;
+  } catch {
+    return String(value);
+  }
+}
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
+/** Non-empty array of plain objects, else null (→ raw-receipt fallback). */
+function asRows(result: unknown): Record<string, unknown>[] | null {
+  if (!Array.isArray(result) || result.length === 0) return null;
+  if (!result.every((x) => x !== null && typeof x === "object" && !Array.isArray(x))) return null;
+  return result as Record<string, unknown>[];
+}
+
+function Receipt({ value }: { value: unknown }) {
+  return (
+    <div className="mx-1.5 my-1 px-2 py-1.5 rounded bg-[color:var(--surface-0)] border border-[color:var(--border-subtle)] max-h-40 overflow-y-auto">
+      <div className="text-[10px] leading-relaxed font-mono text-[color:var(--text-secondary)] whitespace-pre-wrap break-words">
+        {prettyReceipt(value)}
+      </div>
+    </div>
+  );
+}
+
+// -------------------------------------------------------- brain_search
+
+function BrainHitRow({ hit }: { hit: Record<string, unknown> }) {
+  const [open, setOpen] = useState(false);
+  const path = str(hit.source_file) || str(hit.doc_id) || "(unknown source)";
+  const snippet = str(hit.content).split("\n").map((l) => l.trim()).find(Boolean) ?? "";
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full text-left px-1.5 py-1 rounded hover:bg-[color:var(--surface-2)] transition-colors"
+      >
+        <div className="text-[10px] font-mono text-[color:var(--accent-teal-fg)] truncate">{path}</div>
+        {snippet && (
+          <div className="text-[10px] font-mono text-[color:var(--text-muted)] truncate">{snippet}</div>
+        )}
+      </button>
+      {open && <Receipt value={hit} />}
+    </div>
+  );
+}
+
+function renderBrainSearch(result: unknown): ReactNode | null {
+  const hits = asRows(result);
+  if (!hits) return null;
+  return (
+    <div className="space-y-0.5">
+      {hits.map((h, i) => <BrainHitRow key={i} hit={h} />)}
+    </div>
+  );
+}
+
+// ------------------------------------------------------- memory_recall
+
+function MemoryRow({ entry }: { entry: Record<string, unknown> }) {
+  const [open, setOpen] = useState(false);
+  const name = str(entry.name) || str(entry.id) || "memory";
+  const domain = str(entry.domain);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-1.5 px-1.5 py-1 text-left rounded hover:bg-[color:var(--surface-2)] transition-colors min-w-0"
+      >
+        <span className="px-1.5 py-0.5 rounded-full text-[10px] font-mono truncate bg-[color:var(--accent-violet-bg)] text-[color:var(--accent-violet-fg)] ring-1 ring-inset ring-[color:var(--accent-violet-ring)]">
+          {name}
+        </span>
+        {domain && (
+          <span className="px-1.5 py-0.5 rounded-full text-[10px] shrink-0 bg-[color:var(--accent-slate-bg)] text-[color:var(--accent-slate-fg)] ring-1 ring-inset ring-[color:var(--accent-slate-ring)]">
+            {domain}
+          </span>
+        )}
+      </button>
+      {open && <Receipt value={entry} />}
+    </div>
+  );
+}
+
+function renderMemoryRecall(result: unknown): ReactNode | null {
+  const entries = asRows(result);
+  if (!entries) return null;
+  return (
+    <div className="space-y-0.5">
+      {entries.map((e, i) => <MemoryRow key={i} entry={e} />)}
+    </div>
+  );
+}
+
+// ----------------------------------------------------------- task_list
+
+// Tailwind's scanner needs full literal class strings — never template
+// the tone into `var(--accent-${tone}-bg)` (memory: colors from OKF source).
+const STATUS_PILL: Record<string, string> = {
+  pending: "bg-[color:var(--accent-amber-bg)] text-[color:var(--accent-amber-fg)] ring-[color:var(--accent-amber-ring)]",
+  in_progress: "bg-[color:var(--accent-teal-bg)] text-[color:var(--accent-teal-fg)] ring-[color:var(--accent-teal-ring)]",
+  blocked: "bg-[color:var(--accent-rose-bg)] text-[color:var(--accent-rose-fg)] ring-[color:var(--accent-rose-ring)]",
+  done: "bg-[color:var(--accent-emerald-bg)] text-[color:var(--accent-emerald-fg)] ring-[color:var(--accent-emerald-ring)]",
+};
+const STATUS_PILL_DEFAULT =
+  "bg-[color:var(--accent-slate-bg)] text-[color:var(--accent-slate-fg)] ring-[color:var(--accent-slate-ring)]";
+
+function TaskRow({ task }: { task: Record<string, unknown> }) {
+  const [open, setOpen] = useState(false);
+  const status = str(task.status) || "pending";
+  const title = str(task.title) || str(task.id) || "(untitled task)";
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-1.5 px-1.5 py-1 text-left rounded hover:bg-[color:var(--surface-2)] transition-colors min-w-0"
+      >
+        <span
+          className={cn(
+            "px-1.5 py-0.5 rounded-full text-[9px] uppercase tracking-wider ring-1 ring-inset shrink-0",
+            STATUS_PILL[status] ?? STATUS_PILL_DEFAULT,
+          )}
+        >
+          {status.replace(/_/g, " ")}
+        </span>
+        <span className="text-[11px] text-[color:var(--text-secondary)] truncate">{title}</span>
+      </button>
+      {open && <Receipt value={task} />}
+    </div>
+  );
+}
+
+function renderTaskList(result: unknown): ReactNode | null {
+  const tasks = asRows(result);
+  if (!tasks) return null;
+  return (
+    <div className="space-y-0.5">
+      {tasks.map((t, i) => <TaskRow key={i} task={t} />)}
+    </div>
+  );
+}
+
+// ------------------------------------------------------------ registry
+
+export const TOOL_RENDERERS: Map<string, ToolRenderer> = new Map([
+  ["brain_search", renderBrainSearch],
+  ["memory_recall", renderMemoryRecall],
+  ["task_list", renderTaskList],
+]);

--- a/services/prism-service/prism_service/web/src/components/pi/toolRenderers.tsx
+++ b/services/prism-service/prism_service/web/src/components/pi/toolRenderers.tsx
@@ -169,10 +169,64 @@ function renderTaskList(result: unknown): ReactNode | null {
   );
 }
 
+// -------------------------------------- conductor / task-mutation receipts
+
+/** One-line transition summary for conductor_advance / conductor_gate /
+ * task_update receipts — "from → to" for advances, "gate → state" for gate
+ * decisions, "step · status" for task updates — with the raw receipt kept
+ * underneath. Any shape it doesn't recognize returns null (→ default raw
+ * receipt fallback), so it is safe as a catch-all for mutation tools. */
+function renderConductorReceipt(result: unknown): ReactNode | null {
+  if (result === null || typeof result !== "object" || Array.isArray(result)) return null;
+  const r = result as Record<string, unknown>;
+  const parts: string[] = [];
+  const fromStep = str(r.from_step);
+  const toStep = str(r.to_step);
+  if (fromStep || toStep) {
+    // conductor_advance: {ok, task_id, from_step, to_step, gate_state}
+    parts.push(`${fromStep || "<start>"} → ${toStep || "?"}`);
+    if (str(r.gate_state) && r.gate_state !== "none") parts.push(`gate ${str(r.gate_state)}`);
+  } else if (str(r.gate_step) || (str(r.gate_state) && r.ok !== undefined)) {
+    // conductor_gate: {ok, task_id, gate_step, gate_state, reason?}
+    parts.push(`${str(r.gate_step) || "gate"} → ${str(r.gate_state) || "?"}`);
+  } else if (str(r.workflow_step) || str(r.status)) {
+    // task_update: the updated task row (workflow_step / status / title).
+    if (str(r.workflow_step)) parts.push(`step ${str(r.workflow_step)}`);
+    if (str(r.status)) parts.push(str(r.status));
+  }
+  if (parts.length === 0) return null;
+  const refused = r.ok === false;
+  const reason = str(r.reason);
+  return (
+    <div className="space-y-0.5">
+      <div
+        className={cn(
+          "px-1.5 py-1 text-[11px] font-mono break-words",
+          refused
+            ? "text-[color:var(--accent-rose-fg)]"
+            : "text-[color:var(--text-secondary)]",
+        )}
+      >
+        {refused && <span className="uppercase tracking-wider text-[9px] mr-1.5">refused</span>}
+        {parts.join(" · ")}
+        {reason && (
+          <span className="text-[color:var(--text-muted)]">
+            {" — "}{reason.length > 160 ? `${reason.slice(0, 160)}…` : reason}
+          </span>
+        )}
+      </div>
+      <Receipt value={result} />
+    </div>
+  );
+}
+
 // ------------------------------------------------------------ registry
 
 export const TOOL_RENDERERS: Map<string, ToolRenderer> = new Map([
   ["brain_search", renderBrainSearch],
   ["memory_recall", renderMemoryRecall],
   ["task_list", renderTaskList],
+  ["conductor_advance", renderConductorReceipt],
+  ["conductor_gate", renderConductorReceipt],
+  ["task_update", renderConductorReceipt],
 ]);

--- a/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
+++ b/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
@@ -1,31 +1,38 @@
-import { useState } from "react";
+import { useState, type ReactNode } from "react";
 import { Empty } from "@/components/ui";
 import Markdown from "@/components/Markdown";
 import Mermaid from "./Mermaid";
 
 /**
  * Renders a task plan as TABS in one place — Prototype (the clickable mock,
- * iframed), Diagram (Mermaid), and Proposed change (markdown) share the same
- * slot, toggled by a tab bar. Full-width (max-w-none) so the task page uses
- * the whole screen like /understand. Default tab is the Prototype when present.
+ * iframed), Diagram (Mermaid), Proposed change (markdown), and Metrics (the
+ * per-phase SDLC breakdown) share the same slot, toggled by a tab bar.
+ * Full-width (max-w-none) so the task page uses the whole screen like
+ * /understand. Default tab is the Prototype when present.
  */
 export default function PlanView({
   diagram,
   doc,
   prototypeSrc,
+  metrics,
 }: {
   diagram?: string;
   doc?: string;
   prototypeSrc?: string;
+  // Per-phase metrics card (task bd1c2289) rendered as a peer tab alongside
+  // Diagram / Proposed change, so effort lives in the same plan surface.
+  metrics?: ReactNode;
 }) {
   const hasDiagram = !!diagram?.trim();
   const hasDoc = !!doc?.trim();
   const hasProto = !!prototypeSrc;
+  const hasMetrics = !!metrics;
 
   const tabs: { key: string; label: string }[] = [];
   if (hasProto) tabs.push({ key: "prototype", label: "Prototype" });
   if (hasDiagram) tabs.push({ key: "diagram", label: "Diagram" });
   if (hasDoc) tabs.push({ key: "doc", label: "Proposed change" });
+  if (hasMetrics) tabs.push({ key: "metrics", label: "Metrics" });
 
   const [active, setActive] = useState(tabs[0]?.key ?? "doc");
   if (tabs.length === 0) return <Empty>No plan yet.</Empty>;
@@ -78,6 +85,9 @@ export default function PlanView({
       {cur === "doc" && hasDoc && (
         // full-width (max-w-none): whole screen like /understand, not 840px.
         <Markdown text={doc!} className="space-y-4 max-w-none" />
+      )}
+      {cur === "metrics" && hasMetrics && (
+        <div className="pt-1">{metrics}</div>
       )}
     </div>
   );

--- a/services/prism-service/prism_service/web/src/components/tasks/TaskTree.tsx
+++ b/services/prism-service/prism_service/web/src/components/tasks/TaskTree.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { motion, AnimatePresence } from "motion/react";
+import { type PillTone } from "@/components/ui";
+import { SPRING_SNAPPY, DUR, EASE_OUT } from "@/lib/motion";
+
+// Recursive, collapsible task tree (task e72aba6d). PRISM stores a task tree
+// via parent_id but every consumer used to look ONE level deep; this renders
+// the WHOLE subtree to ANY depth — each parent node gets an expand/collapse
+// chevron that reveals its own children, which are themselves TaskTreeNodes.
+
+export type TreeTask = {
+  id?: string;
+  title?: string;
+  status?: string;
+  priority?: number | string;
+  parent_id?: string;
+};
+
+const STATUS_TONE: Record<string, PillTone> = {
+  pending: "amber",
+  in_progress: "teal",
+  blocked: "rose",
+  done: "emerald",
+};
+
+// Shared done Checkbox — same emerald-fill + spring-tick as the detail page,
+// Hermes tokens only (no invented palette).
+function Checkbox({ done, reduced }: { done: boolean; reduced: boolean | null }) {
+  return (
+    <span
+      className="inline-flex items-center justify-center h-4 w-4 rounded shrink-0"
+      style={{
+        background: done ? "var(--accent-emerald-bg)" : "var(--surface-3)",
+        boxShadow: `inset 0 0 0 1px var(--accent-${done ? "emerald" : "slate"}-ring)`,
+      }}
+    >
+      <AnimatePresence>
+        {done && (
+          <motion.svg
+            key="tick"
+            viewBox="0 0 16 16"
+            className="h-3 w-3"
+            initial={reduced ? { opacity: 0 } : { scale: 0, opacity: 0 }}
+            animate={reduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={reduced ? { duration: 0 } : SPRING_SNAPPY}
+          >
+            <path d="M3.5 8.5l3 3 6-6.5" fill="none" stroke="var(--accent-emerald-fg)"
+              strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+          </motion.svg>
+        )}
+      </AnimatePresence>
+    </span>
+  );
+}
+
+// parent_id -> [children] index from a flat task list.
+export function buildChildMap(tasks: TreeTask[]): Map<string, TreeTask[]> {
+  const m = new Map<string, TreeTask[]>();
+  for (const t of tasks) {
+    const pid = t.parent_id ?? "";
+    if (!pid) continue;
+    const arr = m.get(pid);
+    if (arr) arr.push(t);
+    else m.set(pid, [t]);
+  }
+  return m;
+}
+
+// Whole-subtree descendant count for one node (cycle-guarded via a seen-set).
+export function subtreeCount(map: Map<string, TreeTask[]>, id: string): number {
+  let n = 0;
+  const seen = new Set<string>([id]);
+  const queue = [...(map.get(id) ?? [])];
+  while (queue.length) {
+    const node = queue.shift()!;
+    if (!node.id || seen.has(node.id)) continue;
+    seen.add(node.id);
+    n += 1;
+    queue.push(...(map.get(node.id) ?? []));
+  }
+  return n;
+}
+
+function StatusPill({ status }: { status: string }) {
+  const tone = STATUS_TONE[status] ?? "slate";
+  return (
+    <span
+      className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded shrink-0"
+      style={{
+        background: `var(--accent-${tone}-bg)`,
+        color: `var(--accent-${tone}-fg)`,
+        boxShadow: `inset 0 0 0 1px var(--accent-${tone}-ring)`,
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+// One node + (when expanded) its recursively-rendered children — the recursion
+// that makes the tree render to ANY depth.
+function TaskTreeNode({
+  node, map, depth, rootFrom, reduced,
+}: {
+  node: TreeTask;
+  map: Map<string, TreeTask[]>;
+  depth: number;
+  rootFrom: string;
+  reduced: boolean | null;
+}) {
+  const navigate = useNavigate();
+  const children = node.id ? map.get(node.id) ?? [] : [];
+  const hasChildren = children.length > 0;
+  // Top level is open by default; deeper levels collapse so a wide tree stays
+  // scannable until the operator drills in.
+  const [open, setOpen] = useState(depth < 1);
+  const count = hasChildren && node.id ? subtreeCount(map, node.id) : 0;
+
+  return (
+    <div>
+      <div
+        className="flex items-center gap-1.5 rounded-md hover:bg-[color:var(--background-base)]/50 transition-colors"
+        style={{ paddingLeft: `${depth * 1.15}rem` }}
+      >
+        {hasChildren ? (
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            aria-label={open ? "collapse" : "expand"}
+            className="h-5 w-5 flex items-center justify-center opacity-60 hover:opacity-100 shrink-0"
+          >
+            <span
+              className="inline-block text-[11px] transition-transform"
+              style={{ transform: open ? "rotate(90deg)" : "none" }}
+            >
+              ▸
+            </span>
+          </button>
+        ) : (
+          <span className="h-5 w-5 shrink-0" />
+        )}
+        <button
+          type="button"
+          onClick={() => node.id && navigate(`/tasks/${node.id}`, { state: { from: `/tasks/${rootFrom}` } })}
+          className="flex items-center gap-2 min-w-0 flex-1 text-left py-1.5 pr-2"
+        >
+          <Checkbox done={(node.status ?? "") === "done"} reduced={reduced} />
+          <span className="text-sm truncate">{node.title ?? node.id}</span>
+          {hasChildren && (
+            <span
+              title={`${count} descendant task(s)`}
+              className="shrink-0 text-[10px] font-mono leading-none px-1.5 py-0.5 rounded-full"
+              style={{
+                background: "var(--accent-violet-bg)",
+                color: "var(--accent-violet-fg)",
+                boxShadow: "inset 0 0 0 1px var(--accent-violet-ring)",
+              }}
+            >
+              {count}
+            </span>
+          )}
+          <span className="ml-auto shrink-0">
+            <StatusPill status={node.status ?? "pending"} />
+          </span>
+        </button>
+      </div>
+      <AnimatePresence initial={false}>
+        {open && hasChildren && (
+          <motion.div
+            key="kids"
+            initial={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+            animate={reduced ? { opacity: 1 } : { opacity: 1, height: "auto" }}
+            exit={reduced ? { opacity: 0 } : { opacity: 0, height: 0 }}
+            transition={{ duration: reduced ? 0 : DUR.enter, ease: EASE_OUT }}
+            className="overflow-hidden border-l border-[color:var(--midground-base)]/15 ml-2.5"
+          >
+            {children.map((c) => (
+              <TaskTreeNode
+                key={c.id}
+                node={c}
+                map={map}
+                depth={depth + 1}
+                rootFrom={rootFrom}
+                reduced={reduced}
+              />
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// Render the whole subtree rooted at `rootId`, built from a flat task list
+// (a single GET /api/tasks the detail page already fetches).
+export default function TaskTree({
+  tasks, rootId, reduced = false,
+}: {
+  tasks: TreeTask[];
+  rootId: string;
+  reduced?: boolean | null;
+}) {
+  const map = buildChildMap(tasks);
+  const roots = map.get(rootId) ?? [];
+  if (roots.length === 0) return null;
+  return (
+    <div className="space-y-0.5 mt-2">
+      {roots.map((r) => (
+        <TaskTreeNode key={r.id} node={r} map={map} depth={0} rootFrom={rootId} reduced={reduced} />
+      ))}
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/components/ui.tsx
+++ b/services/prism-service/prism_service/web/src/components/ui.tsx
@@ -124,6 +124,60 @@ export function toneFromLabel(label: string): PillTone {
   return HASH_TONES[h % HASH_TONES.length];
 }
 
+/** Segmented tab strip — the SPA's first Tabs primitive (task 711d5235,
+ * born for the left rail's NAV | PI switch). Mirrors Pill's neutral
+ * tone language: active segment lifts to surface-2 + text-primary,
+ * inactive stays muted. Equal-width segments so a two-tab strip reads
+ * as one control, not two buttons.
+ */
+export type TabItem<K extends string = string> = {
+  key: K;
+  label: ReactNode;
+  title?: string;
+};
+
+export function Tabs<K extends string>({
+  items, value, onChange, className, segmentClassName,
+}: {
+  items: TabItem<K>[];
+  value: K;
+  onChange: (key: K) => void;
+  className?: string;
+  /** Extra classes per segment button (e.g. taller full-bleed rail tabs). */
+  segmentClassName?: string;
+}) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "flex rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-0)] p-0.5",
+        className,
+      )}
+    >
+      {items.map(({ key, label, title }) => (
+        <button
+          key={key}
+          role="tab"
+          type="button"
+          aria-selected={value === key}
+          title={title}
+          onClick={() => onChange(key)}
+          className={cn(
+            "flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-[4px]",
+            "text-[11px] uppercase tracking-wider transition-colors",
+            value === key
+              ? "bg-[color:var(--surface-2)] text-[color:var(--text-primary)]"
+              : "text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)]",
+            segmentClassName,
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export const Empty = ({ children }: { children: ReactNode }) => (
   <div className="rounded-md border border-dashed border-[color:var(--border-default)] px-5 py-8 text-center text-sm text-[color:var(--text-muted)]">
     {children}

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -32,6 +32,10 @@ import { clearSession, loadSession, saveSession } from "@/components/pi/piSessio
 // the Node runner (web/pi-runtime.mjs) and this panel. Types come from
 // the sibling pi-expert.d.mts declaration.
 import { EXPERT_SYSTEM_PROMPT, EXPERT_TOOL_DEFS } from "../../pi-expert.mjs";
+// Shared multi-call parser (task c4bb21f8): ONE source with the Node runner
+// (web/pi-runtime.mjs) so an array / concatenated tool-call block parses
+// identically. parseTextToolCalls returns an ORDERED LIST of {name,args}.
+import { parseTextToolCall, parseTextToolCalls } from "../../pi-toolcall.mjs";
 
 // ---------------------------------------------------------------- config
 
@@ -207,7 +211,9 @@ export class PiStore {
   lastError = "";
 
   private tools: AgentTool[];
-  /** Guard against a model that answers every injection with more JSON. */
+  /** TOTAL-call cap across the exchange (task c4bb21f8): decremented per
+   * EXECUTED tool call so a multi-call block can't run away, and a model
+   * that answers every injection with more JSON eventually stops. */
   private interceptBudget = 0;
   /** True while feeding a synthetic tool-result message back to the model. */
   private injecting = false;
@@ -368,7 +374,7 @@ export class PiStore {
     if (!prompt || this.busy) return;
     this.interacted = true; // from here on, a late rehydrate must no-op
     this.lastError = "";
-    this.interceptBudget = 3;
+    this.interceptBudget = 6;
     try {
       await this.agent.prompt(prompt);
     } catch (e) {
@@ -387,49 +393,85 @@ export class PiStore {
     try { this.agent.abort(); } catch { this.stopping = false; }
   }
 
-  /** If the final assistant text IS a JSON tool call for a known tool,
-   * swap the bubble for a tool row, run the tool, and continue the run
-   * with the result. Returns true when an interception was started. */
+  /** If the final assistant text IS a tool-call block — a single object, a
+   * top-level ARRAY, or concatenated objects (task c4bb21f8) — swap the raw
+   * bubble for an ORDERED list of tool rows, run each known tool in
+   * sequence (unknown names skipped with a note), feed the combined
+   * results back, then let the model answer in prose. Returns true when an
+   * interception was started. Budget is a TOTAL-call cap: only known calls
+   * within budget execute; the rest are noted, so a multi-call block can't
+   * run away. */
   private tryInterceptTextToolCall(): boolean {
     if (this.interceptBudget <= 0) return false;
     const idx = this.items.length - 1;
     const last = this.items[idx];
     if (!last || last.kind !== "assistant" || !last.text) return false;
-    const call = parseTextToolCall(last.text);
-    if (!call) return false;
-    const tool = this.tools.find((t) => t.name === call.name);
-    if (!tool) return false;
+    const calls = parseTextToolCalls(last.text);
+    if (!calls.length) return false;
+    // At least one call must map to a real tool AND fit the budget, else
+    // this is not an interceptable block (don't consume a raw bubble for
+    // pure hallucination or once the cap is spent).
+    const runnable = calls.filter((c) => this.tools.some((t) => t.name === c.name));
+    if (!runnable.length) return false;
 
-    this.interceptBudget--;
     this.busy = true;
-    const row: Extract<PiItem, { kind: "tool" }> = {
-      kind: "tool", callId: `text-${Date.now()}`, name: call.name,
-      label: call.name, args: call.args, status: "running",
-    };
-    this.items[idx] = row; // the raw-JSON bubble BECOMES the tool row
+
+    // Build the ordered plan: known+in-budget calls become running tool
+    // rows; unknown names and over-budget calls become quiet notes. The
+    // single raw-JSON bubble is replaced by the WHOLE plan.
+    type Step = { call: { name: string; args: Record<string, unknown> };
+                  row?: Extract<PiItem, { kind: "tool" }> };
+    const plan: Step[] = [];
+    const newItems: PiItem[] = [];
+    for (const call of calls) {
+      const known = this.tools.some((t) => t.name === call.name);
+      if (known && this.interceptBudget > 0) {
+        this.interceptBudget--;
+        const row: Extract<PiItem, { kind: "tool" }> = {
+          kind: "tool", callId: `text-${Date.now()}-${plan.length}`,
+          name: call.name, label: call.name, args: call.args, status: "running",
+        };
+        newItems.push(row);
+        plan.push({ call, row });
+      } else {
+        const why = known ? "intercept budget exhausted" : "not a known PRISM tool";
+        newItems.push({ kind: "note", text: `skipped ${call.name} — ${why}` });
+        plan.push({ call });
+      }
+    }
+    this.items.splice(idx, 1, ...newItems);
     this.emit();
 
     void (async () => {
-      let resultText: string;
-      try {
-        const res = await tool.execute(row.callId, call.args);
-        row.status = "ok";
-        const details = (res as { details?: { result?: unknown; ms?: number } }).details;
-        row.result = details?.result ?? res;
-        row.ms = details?.ms;
-        resultText = res.content
-          .filter((c): c is { type: "text"; text: string } => c.type === "text")
-          .map((c) => c.text).join("\n");
-      } catch (e) {
-        row.status = "error";
-        row.result = e instanceof Error ? e.message : String(e);
-        resultText = `ERROR: ${row.result}`;
+      const resultTexts: string[] = [];
+      for (const step of plan) {
+        const tool = step.row && this.tools.find((t) => t.name === step.call.name);
+        if (!tool || !step.row) {
+          resultTexts.push(`[${step.call.name} skipped]`);
+          continue;
+        }
+        const row = step.row;
+        try {
+          const res = await tool.execute(row.callId, step.call.args);
+          row.status = "ok";
+          const details = (res as { details?: { result?: unknown; ms?: number } }).details;
+          row.result = details?.result ?? res;
+          row.ms = details?.ms;
+          const text = res.content
+            .filter((c): c is { type: "text"; text: string } => c.type === "text")
+            .map((c) => c.text).join("\n");
+          resultTexts.push(`[${row.name} result]\n${text}`);
+        } catch (e) {
+          row.status = "error";
+          row.result = e instanceof Error ? e.message : String(e);
+          resultTexts.push(`[${row.name} error] ${row.result}`);
+        }
+        this.emit();
       }
-      this.emit();
       try {
         this.injecting = true; // hide the synthetic result message from the log
         await this.agent.prompt(
-          `[${call.name} result]\n${resultText}\n\nAnswer the user's original question from this result, in plain prose. Do NOT output JSON.`,
+          `${resultTexts.join("\n\n")}\n\nAnswer the user's original question from these results, in plain prose. Do NOT output JSON.`,
         );
       } catch (e) {
         this.lastError = e instanceof Error ? e.message : String(e);
@@ -601,24 +643,10 @@ export class PiStore {
   }
 }
 
-/** Recognize an assistant text that IS a tool call — bare or fenced JSON
- * shaped {"name": "...", "arguments"|"args"|"parameters": {...}}. */
-export function parseTextToolCall(text: string): { name: string; args: Record<string, unknown> } | null {
-  let t = text.trim();
-  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/.exec(t);
-  if (fence) t = fence[1].trim();
-  if (!t.startsWith("{") || !t.endsWith("}")) return null;
-  try {
-    const obj = JSON.parse(t) as Record<string, unknown>;
-    const name = obj.name;
-    if (typeof name !== "string" || !name) return null;
-    const args = obj.arguments ?? obj.args ?? obj.parameters ?? {};
-    if (typeof args !== "object" || args === null || Array.isArray(args)) return null;
-    return { name, args: args as Record<string, unknown> };
-  } catch {
-    return null;
-  }
-}
+// parseTextToolCall / parseTextToolCalls now live in the shared
+// pi-toolcall.mjs module (imported at the top). Re-exported here so
+// existing importers of this symbol are unaffected.
+export { parseTextToolCall };
 
 function messageText(message: unknown): string {
   const content = (message as { content?: unknown }).content;

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -198,7 +198,7 @@ export type PiTelemetry = { model: string; ok: boolean; at: number };
  * via subscribe/getSnapshot (useSyncExternalStore).
  */
 export class PiStore {
-  readonly project: string;
+  private _project: string;
   private agent: Agent;
   private model: Model<"openai-completions">;
   private cfg: PiConfig;
@@ -216,7 +216,7 @@ export class PiStore {
   private injecting = false;
 
   constructor(project: string) {
-    this.project = project;
+    this._project = project;
     this.cfg = loadPiConfig();
     this.model = installProvider(this.cfg);
     this.tools = buildTools(project);
@@ -233,6 +233,26 @@ export class PiStore {
     });
     this.agent.subscribe((event) => this.onEvent(event));
     void this.probe();
+  }
+
+  get project(): string { return this._project; }
+
+  /** True once anything is on screen (or a prompt is in flight) — i.e. there
+   * is a conversation a store swap would orphan. */
+  hasConversation(): boolean { return this.items.length > 0 || this.busy; }
+
+  /**
+   * Re-key this store to another project (first-paint promotion rescue —
+   * see piStore below). The visible conversation is preserved; FUTURE tool
+   * calls and memory writes target the new project. A tool call already in
+   * flight keeps the project it was started under (its closure captured it),
+   * which is correct: that is where the exchange actually began.
+   */
+  rekey(project: string) {
+    this._project = project;
+    this.tools = buildTools(project);
+    this.agent.state.tools = this.tools;
+    this.emit();
   }
 
   // -- external-store plumbing
@@ -479,8 +499,37 @@ function messageText(message: unknown): string {
 
 const stores = new Map<string, PiStore>();
 
+/** One-shot latch: only the FIRST default→real-project flip may rescue the
+ * "default" store. Deliberate header-picker switches later in the session
+ * always get their own per-project store. */
+let defaultRescueSpent = false;
+
+/**
+ * The SPA's project identity settles AFTER first paint: `useProject` starts
+ * from "default" and is promoted automatically (?project= deep-link mirror,
+ * resolveInitialProject cold-start pick — see lib/project.ts). An exchange
+ * started in that window lives in the "default"-keyed store; when the panel
+ * re-renders under the promoted project it must NOT come up against a fresh
+ * empty store with the running conversation orphaned. So the first time a
+ * non-"default" project resolves, if the "default" store already holds a
+ * conversation (and the new project has none), MIGRATE it: same store, same
+ * items, re-keyed so future tool calls hit the promoted project.
+ */
 export function piStore(project: string): PiStore {
   let s = stores.get(project);
-  if (!s) { s = new PiStore(project); stores.set(project, s); }
+  if (!s) {
+    s = rescueDefaultStore(project) ?? new PiStore(project);
+    stores.set(project, s);
+  }
   return s;
+}
+
+function rescueDefaultStore(project: string): PiStore | null {
+  if (defaultRescueSpent || project === "default") return null;
+  defaultRescueSpent = true; // consumed by the first real-project resolution
+  const d = stores.get("default");
+  if (!d || !d.hasConversation()) return null; // nothing to orphan
+  stores.delete("default"); // move, don't alias — "default" gets a fresh store if ever revisited
+  d.rekey(project);
+  return d;
 }

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -38,10 +38,10 @@ export type PiModelChoice = {
 // are exactly what G5 (task 9f8e7bf7, "smallest model PRISM can carry")
 // probes with the telemetry this panel records.
 export const PI_MODEL_CHOICES: PiModelChoice[] = [
-  { id: "qwen2.5-coder:7b", label: "qwen2.5-coder:7b", hint: "recommended · smallest reliable" },
-  { id: "llama3.1:8b", label: "llama3.1:8b" },
-  { id: "qwen3:4b", label: "qwen3:4b", hint: "experimental", experimental: true },
-  { id: "gpt-oss:20b", label: "gpt-oss:20b" },
+  { id: "qwen2.5-coder:7b", label: "qwen2.5-coder:7b", hint: "recommended · chat + tools" },
+  { id: "qwen3:0.6b", label: "qwen3:0.6b", hint: "micro · self-learning bench winner", experimental: true },
+  { id: "qwen3:1.7b", label: "qwen3:1.7b", hint: "micro" },
+  { id: "llama3.2:3b", label: "llama3.2:3b" },
 ];
 
 export type PiConfig = { baseUrl: string; modelId: string };

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -9,6 +9,10 @@
  * Inference is browser -> LOCAL endpoint only (default Ollama :11434); no
  * cloud key exists anywhere in this path (INV-1). The agent's tool calls go
  * through PRISM's whitelisted passthrough POST /api/agent/tool.
+ *
+ * Stable/streaming split, per-exchange usage stats, abort, and session
+ * restore: structure borrowed from @earendil-works/pi-web-ui (MIT, Mario
+ * Zechner), reimplemented for React/Hermes.
  */
 
 import {
@@ -23,6 +27,7 @@ import {
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { api } from "@/lib/api";
+import { clearSession, loadSession, saveSession } from "@/components/pi/piSession";
 
 // ---------------------------------------------------------------- config
 
@@ -183,9 +188,14 @@ const SYSTEM_PROMPT = [
 
 // ------------------------------------------------------------ the store
 
+/** Per-exchange token stats (↑input ↓output · seconds). `estimated` marks
+ * the text-length/4 fallback used when the stream reported no usage. */
+export type PiExchangeStats = { input: number; output: number; seconds: number; estimated?: boolean };
+
 export type PiItem =
   | { kind: "user"; text: string }
-  | { kind: "assistant"; text: string; done: boolean; learned?: boolean; learning?: boolean }
+  | { kind: "assistant"; text: string; done: boolean; learned?: boolean; learning?: boolean;
+      stats?: PiExchangeStats }
   | { kind: "tool"; callId: string; name: string; label: string; args: unknown;
       status: "running" | "ok" | "error"; result?: unknown; ms?: number }
   | { kind: "note"; text: string };
@@ -214,6 +224,20 @@ export class PiStore {
   private interceptBudget = 0;
   /** True while feeding a synthetic tool-result message back to the model. */
   private injecting = false;
+  /** True between abort() and the agent_end it forces. */
+  private stopping = false;
+
+  // Streaming channel (pi-web-ui split): message_update token folds notify
+  // ONLY these listeners; the settled/global channel stays quiet, so the
+  // memoized transcript list never re-renders per token.
+  private streamListeners = new Set<() => void>();
+  private streamVersion = 0;
+
+  // Per-exchange accounting (pi-web-ui stats line): wall-clock from the
+  // run's first agent_start, usage summed over every assistant message_end
+  // in the run (a run can span tool turns + the text-tool-call injection).
+  private runStart = 0;
+  private runUsage = { input: 0, output: 0 };
 
   constructor(project: string) {
     this._project = project;
@@ -233,6 +257,40 @@ export class PiStore {
     });
     this.agent.subscribe((event) => this.onEvent(event));
     void this.probe();
+    void this.rehydrate();
+  }
+
+  /**
+   * Restore the last saved conversation for this project (pi-web-ui-style
+   * session persistence). DISPLAY-LEVEL ONLY by design: the items reappear
+   * but the agent's LLM context restarts fresh — good enough for a left-rail
+   * assistant, and it avoids replaying stale tool receipts into a small
+   * local model. Skipped if an exchange already started while loading.
+   */
+  private async rehydrate() {
+    try {
+      const snap = await loadSession(this._project);
+      if (!snap?.items?.length) return;
+      if (this.items.length > 0 || this.busy) return; // live conversation wins
+      this.items = snap.items.map((it): PiItem => {
+        if (it.kind === "assistant") return { ...it, done: true, learning: false };
+        if (it.kind === "tool" && it.status === "running") {
+          return { ...it, status: "error", result: "(interrupted by reload)" };
+        }
+        return it;
+      });
+      this.emit();
+    } catch { /* a lost session is never an error */ }
+  }
+
+  /** Persist the display items + minimal agent context (model id). Called
+   * on agent_end, when nothing is in flight — items are settled. */
+  private persist() {
+    void saveSession(this._project, {
+      items: this.items,
+      modelId: this.cfg.modelId,
+      savedAt: Date.now(),
+    });
   }
 
   get project(): string { return this._project; }
@@ -249,9 +307,14 @@ export class PiStore {
    * which is correct: that is where the exchange actually began.
    */
   rekey(project: string) {
+    const old = this._project;
     this._project = project;
     this.tools = buildTools(project);
     this.agent.state.tools = this.tools;
+    // Move the persisted session with the store: future saves target the
+    // promoted project; the old key must not rehydrate a stale twin later.
+    this.persist();
+    void clearSession(old);
     this.emit();
   }
 
@@ -264,6 +327,19 @@ export class PiStore {
     this.version++;
     this.items = [...this.items];
     for (const fn of this.listeners) fn();
+  }
+
+  // -- streaming channel (in-flight assistant text only)
+  subscribeStream = (fn: () => void) => { this.streamListeners.add(fn); return () => { this.streamListeners.delete(fn); }; };
+  getStreamVersion = () => this.streamVersion;
+  /** Text of the assistant message currently being streamed ("" when idle). */
+  get streamingText(): string {
+    const last = [...this.items].reverse().find((i) => i.kind === "assistant");
+    return last && last.kind === "assistant" && !last.done ? last.text : "";
+  }
+  private emitStream() {
+    this.streamVersion++;
+    for (const fn of this.streamListeners) fn();
   }
 
   /** Reachability probe for the model chip's status dot. */
@@ -297,6 +373,15 @@ export class PiStore {
       this.busy = false;
       this.emit();
     }
+  }
+
+  /** Stop the in-flight run (the composer's stop button). agent.abort()
+   * forces a stopReason:"aborted" agent_end, which resets busy and folds
+   * whatever streamed so far into the transcript as a settled item. */
+  abort() {
+    if (!this.busy) return;
+    this.stopping = true;
+    try { this.agent.abort(); } catch { this.stopping = false; }
   }
 
   /** If the final assistant text IS a JSON tool call for a known tool,
@@ -381,6 +466,7 @@ export class PiStore {
       Object.assign(item, { learning: false });
       this.items.push({ kind: "note", text: `memory_store failed: ${e instanceof Error ? e.message : e}` });
     }
+    this.persist(); // the "in memory" badge should survive a reload
     this.emit();
   }
 
@@ -390,21 +476,40 @@ export class PiStore {
   private onEvent(event: Parameters<Parameters<Agent["subscribe"]>[0]>[0]) {
     switch (event.type) {
       case "agent_start":
+        // A fresh exchange (busy=false here) resets the stats clock; the
+        // text-tool-call injection re-enters with busy=true and keeps
+        // accumulating into the SAME exchange.
+        if (!this.busy) {
+          this.runStart = performance.now();
+          this.runUsage = { input: 0, output: 0 };
+        }
         this.busy = true;
         break;
       case "agent_end": {
         this.busy = false;
-        const err = this.agent.state.errorMessage;
+        const stopped = this.stopping;
+        this.stopping = false;
+        const err = stopped ? "" : this.agent.state.errorMessage;
         if (err) this.lastError = err;
         // Small-model resilience (senpi-style, the G5 reality): weak local
         // stacks emit the tool call as PLAIN JSON TEXT instead of a native
         // tool_call (seen live: Ollama 0.30.7 + qwen2.5-coder). Intercept
         // it, execute the tool app-side, feed the result back as a new turn.
-        if (!err && this.tryInterceptTextToolCall()) return;
+        if (!err && !stopped && this.tryInterceptTextToolCall()) return;
         this.interceptBudget = 0;
-        const last = this.items[this.items.length - 1];
-        if (last?.kind === "assistant") last.done = true;
+        const last = [...this.items].reverse().find((i) => i.kind === "assistant");
+        if (last && last.kind === "assistant") {
+          last.done = true;
+          if (last.text) last.stats = this.finishStats(last.text);
+        }
+        if (stopped) {
+          // Drop an empty aborted bubble; leave a quiet note instead.
+          const tail = this.items[this.items.length - 1];
+          if (tail?.kind === "assistant" && !tail.text) this.items.pop();
+          this.items.push({ kind: "note", text: "stopped" });
+        }
         this.recordTelemetry(!err);
+        this.persist();
         break;
       }
       case "message_start": {
@@ -423,12 +528,22 @@ export class PiStore {
         if ((event.message as { role?: string }).role !== "assistant") break;
         const last = [...this.items].reverse().find((i) => i.kind === "assistant");
         if (last && last.kind === "assistant") last.text = messageText(event.message);
-        break;
+        // Token folds notify ONLY the streaming channel: the settled list
+        // (keyed off items identity) must not re-render per token.
+        this.emitStream();
+        return;
       }
       case "message_end": {
         if ((event.message as { role?: string }).role !== "assistant") break;
         const last = [...this.items].reverse().find((i) => i.kind === "assistant");
         if (last && last.kind === "assistant") last.text = messageText(event.message);
+        // pi-ai 0.80: the completed AssistantMessage carries Usage
+        // ({ input, output, totalTokens, ... }) — sum it per exchange.
+        const usage = (event.message as { usage?: { input?: number; output?: number } }).usage;
+        if (usage) {
+          this.runUsage.input += usage.input ?? 0;
+          this.runUsage.output += usage.output ?? 0;
+        }
         break;
       }
       case "tool_execution_start":
@@ -453,6 +568,22 @@ export class PiStore {
         return; // turn_start/turn_end etc — no display impact
     }
     this.emit();
+  }
+
+  /** Close the exchange's stats. Local stacks that omit stream usage
+   * (stream_options quirks) get the classic length/4 token estimate. */
+  private finishStats(answerText: string): PiExchangeStats {
+    const seconds = this.runStart ? (performance.now() - this.runStart) / 1000 : 0;
+    if (this.runUsage.input > 0 || this.runUsage.output > 0) {
+      return { input: this.runUsage.input, output: this.runUsage.output, seconds };
+    }
+    const lastUser = [...this.items].reverse().find((i) => i.kind === "user");
+    return {
+      input: Math.ceil((lastUser?.kind === "user" ? lastUser.text.length : 0) / 4),
+      output: Math.ceil(answerText.length / 4),
+      seconds,
+      estimated: true,
+    };
   }
 
   /** G5 feed: per-exchange model id + tool-loop success (localStorage ring). */

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -236,6 +236,17 @@ export class PiStore {
   // in the run (a run can span tool turns + the text-tool-call injection).
   private runStart = 0;
   private runUsage = { input: 0, output: 0 };
+  // Task-attributed telemetry (task fc08da8d): the task this exchange acted
+  // on — the LAST id/task_id seen on a conductor/task tool call — plus the
+  // tool receipts, POSTed to /api/agent/run on the terminal agent_end so the
+  // PI agent's local-inference burn attributes to the driven task on the
+  // /conductor tile + task detail. null task -> adhoc (still recorded).
+  private runTaskId: string | null = null;
+  private runTools: { name: string; ms: number; ok: boolean }[] = [];
+  /** Conductor/task tools whose id/task_id arg attributes the exchange. */
+  private static readonly TASK_TOOLS = new Set([
+    "conductor_advance", "conductor_gate", "task_update", "task_list",
+  ]);
 
   constructor(project: string) {
     this._project = project;
@@ -451,12 +462,14 @@ export class PiStore {
           continue;
         }
         const row = step.row;
+        this.captureTaskAttribution(step.call.name, step.call.args);
         try {
           const res = await tool.execute(row.callId, step.call.args);
           row.status = "ok";
           const details = (res as { details?: { result?: unknown; ms?: number } }).details;
           row.result = details?.result ?? res;
           row.ms = details?.ms;
+          this.runTools.push({ name: row.name, ms: row.ms ?? 0, ok: true });
           const text = res.content
             .filter((c): c is { type: "text"; text: string } => c.type === "text")
             .map((c) => c.text).join("\n");
@@ -464,6 +477,7 @@ export class PiStore {
         } catch (e) {
           row.status = "error";
           row.result = e instanceof Error ? e.message : String(e);
+          this.runTools.push({ name: row.name, ms: row.ms ?? 0, ok: false });
           resultTexts.push(`[${row.name} error] ${row.result}`);
         }
         this.emit();
@@ -528,6 +542,8 @@ export class PiStore {
         if (!this.busy) {
           this.runStart = performance.now();
           this.runUsage = { input: 0, output: 0 };
+          this.runTaskId = null;
+          this.runTools = [];
         }
         this.busy = true;
         break;
@@ -555,6 +571,11 @@ export class PiStore {
           this.items.push({ kind: "note", text: "stopped" });
         }
         this.recordTelemetry(!err);
+        // Task-attributed backend telemetry: mirror the implement.js
+        // agent_runs idea for the PI panel — the local-inference tokens
+        // never reach a Claude transcript, so POST them (with the detected
+        // task) to the pi_runs ledger for the conductor tile + task detail.
+        void this.postTelemetry(!err);
         this.persist();
         break;
       }
@@ -593,6 +614,7 @@ export class PiStore {
         break;
       }
       case "tool_execution_start":
+        this.captureTaskAttribution(event.toolName, event.args);
         this.items.push({
           kind: "tool", callId: event.toolCallId, name: event.toolName,
           label: event.toolName, args: event.args, status: "running",
@@ -607,6 +629,7 @@ export class PiStore {
           const details = (event.result as { details?: { result?: unknown; ms?: number } })?.details;
           row.result = details?.result ?? event.result;
           row.ms = details?.ms;
+          this.runTools.push({ name: row.name, ms: row.ms ?? 0, ok: !event.isError });
         }
         break;
       }
@@ -630,6 +653,38 @@ export class PiStore {
       seconds,
       estimated: true,
     };
+  }
+
+  /** Record the driven-task attribution for this exchange: the LAST
+   * id/task_id seen on a conductor/task tool call wins (mirrors implement.js
+   * capturing the step's task_id). Non-task tools are ignored. */
+  private captureTaskAttribution(name: string, args: unknown) {
+    if (!PiStore.TASK_TOOLS.has(name)) return;
+    const a = (args ?? {}) as Record<string, unknown>;
+    const id = a.id ?? a.task_id;
+    if (typeof id === "string" && id) this.runTaskId = id;
+  }
+
+  /** POST this exchange's usage + task attribution to the pi_runs ledger
+   * (task fc08da8d). Best-effort: never blocks the UI, swallows all errors —
+   * a telemetry failure must not disturb the chat. Recorded even with no
+   * detected task (adhoc, empty task_id). */
+  private async postTelemetry(ok: boolean) {
+    try {
+      const seconds = this.runStart ? (performance.now() - this.runStart) / 1000 : 0;
+      await api.post(
+        `/api/agent/run?project=${encodeURIComponent(this._project)}`,
+        {
+          task_id: this.runTaskId ?? "",
+          model: this.cfg.modelId,
+          input_tokens: this.runUsage.input,
+          output_tokens: this.runUsage.output,
+          ms: Math.round(seconds * 1000),
+          tools_used: this.runTools,
+          ok,
+        },
+      );
+    } catch { /* telemetry is advisory only — never disturb the UI */ }
   }
 
   /** G5 feed: per-exchange model id + tool-loop success (localStorage ring). */

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -1,0 +1,486 @@
+/**
+ * PI — PRISM's omnipresent left-rail agent (task 711d5235).
+ *
+ * Built on Mario Zechner's pi toolkit (MIT):
+ *   @earendil-works/pi-ai         — unified LLM API (OpenAI-compatible local endpoints)
+ *   @earendil-works/pi-agent-core — agent loop + tool execution + event stream
+ * https://github.com/badlogic/pi-mono — MIT License, Copyright (c) Mario Zechner.
+ *
+ * Inference is browser -> LOCAL endpoint only (default Ollama :11434); no
+ * cloud key exists anywhere in this path (INV-1). The agent's tool calls go
+ * through PRISM's whitelisted passthrough POST /api/agent/tool.
+ */
+
+import {
+  Agent,
+  type AgentTool,
+} from "@earendil-works/pi-agent-core";
+import {
+  createModels,
+  createProvider,
+  Type,
+  type Model,
+} from "@earendil-works/pi-ai";
+import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
+import { api } from "@/lib/api";
+
+// ---------------------------------------------------------------- config
+
+export type PiModelChoice = {
+  id: string;
+  label: string;
+  hint?: string;
+  /** G5 candidate — smaller than the documented-reliable floor. */
+  experimental?: boolean;
+};
+
+// Smallest documented tool-calling-reliable model first; qwen3:4b and below
+// are exactly what G5 (task 9f8e7bf7, "smallest model PRISM can carry")
+// probes with the telemetry this panel records.
+export const PI_MODEL_CHOICES: PiModelChoice[] = [
+  { id: "qwen2.5-coder:7b", label: "qwen2.5-coder:7b", hint: "recommended · smallest reliable" },
+  { id: "llama3.1:8b", label: "llama3.1:8b" },
+  { id: "qwen3:4b", label: "qwen3:4b", hint: "experimental", experimental: true },
+  { id: "gpt-oss:20b", label: "gpt-oss:20b" },
+];
+
+export type PiConfig = { baseUrl: string; modelId: string };
+
+const CONFIG_KEY = "prism.pi.config";
+const DEFAULT_CONFIG: PiConfig = {
+  baseUrl: "http://localhost:11434/v1",
+  modelId: "qwen2.5-coder:7b",
+};
+
+export function loadPiConfig(): PiConfig {
+  try {
+    const raw = localStorage.getItem(CONFIG_KEY);
+    if (raw) return { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
+  } catch { /* fall through to default */ }
+  return { ...DEFAULT_CONFIG };
+}
+
+function savePiConfig(cfg: PiConfig) {
+  try { localStorage.setItem(CONFIG_KEY, JSON.stringify(cfg)); } catch { /* best-effort */ }
+}
+
+// ------------------------------------------------------------- provider
+
+function buildModel(cfg: PiConfig): Model<"openai-completions"> {
+  return {
+    id: cfg.modelId,
+    name: cfg.modelId,
+    api: "openai-completions",
+    provider: "pi-local",
+    baseUrl: cfg.baseUrl,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 4096,
+    // Local OpenAI-compatible servers (Ollama/vLLM/LM Studio): system role,
+    // no reasoning_effort, no strict tool mode.
+    compat: {
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsStrictMode: false,
+    },
+  };
+}
+
+const models = createModels();
+
+function installProvider(cfg: PiConfig): Model<"openai-completions"> {
+  const model = buildModel(cfg);
+  models.setProvider(createProvider({
+    id: "pi-local",
+    name: "Local (OpenAI-compatible)",
+    baseUrl: cfg.baseUrl,
+    // Keyless local server — pi-ai treats an empty ModelAuth as "not
+    // configured" ("No API key for provider"), so resolve a dummy key;
+    // Ollama/LM Studio/vLLM ignore the Authorization header.
+    auth: { apiKey: { name: "local endpoint (keyless)", resolve: async () => ({ auth: { apiKey: "local-keyless" }, source: "local" }) } },
+    models: [model],
+    api: openAICompletionsApi(),
+  }));
+  return model;
+}
+
+// ------------------------------------------------------- PRISM tools
+
+function toolText(payload: unknown): string {
+  const text = typeof payload === "string" ? payload : JSON.stringify(payload, null, 1);
+  // Small models drown in giant receipts — cap what goes back to the LLM.
+  return text.length > 6000 ? `${text.slice(0, 6000)}\n…(truncated)` : text;
+}
+
+type PassthroughResponse = { name: string; result: unknown; raw: string };
+
+function prismTool(
+  project: string,
+  name: string,
+  label: string,
+  description: string,
+  parameters: AgentTool["parameters"],
+): AgentTool {
+  return {
+    name,
+    label,
+    description,
+    parameters,
+    execute: async (_id, params) => {
+      const started = performance.now();
+      const res = await api.post<PassthroughResponse>(
+        `/api/agent/tool?project=${encodeURIComponent(project)}`,
+        { name, args: params ?? {} },
+      );
+      return {
+        content: [{ type: "text", text: toolText(res.result) }],
+        details: { result: res.result, ms: Math.round(performance.now() - started) },
+      };
+    },
+  };
+}
+
+function buildTools(project: string): AgentTool[] {
+  return [
+    prismTool(project, "brain_search", "Brain search",
+      "Search the project's code/knowledge base (hybrid BM25 + vector + graph). Use for any question about the codebase.",
+      Type.Object({ query: Type.String({ description: "Search query" }) })),
+    prismTool(project, "memory_recall", "Memory recall",
+      "Recall the team's long-term memory: conventions, decisions, failures, expertise.",
+      Type.Object({ query: Type.String({ description: "Natural-language query" }) })),
+    prismTool(project, "memory_store", "Memory store",
+      "Store a durable memory entry the team should keep (conventions, decisions, learnings).",
+      Type.Object({
+        domain: Type.String({ description: "Expertise domain, e.g. conventions, architecture" }),
+        name: Type.String({ description: "Short kebab-case name" }),
+        description: Type.String({ description: "Detailed description with concrete evidence" }),
+        type: Type.String({ description: "pattern | convention | failure | decision" }),
+        classification: Type.String({ description: "tactical | foundational | strategic" }),
+      })),
+    prismTool(project, "task_list", "Task list",
+      "List tasks in the PRISM tracker. Optionally filter by status: pending, in_progress, done, blocked.",
+      Type.Object({ status: Type.Optional(Type.String({ description: "Status filter" })) })),
+    prismTool(project, "task_create", "Task create",
+      "Create a new task in the PRISM tracker.",
+      Type.Object({
+        title: Type.String({ description: "Short human-friendly title" }),
+        description: Type.Optional(Type.String({ description: "Details" })),
+      })),
+    prismTool(project, "prism_status", "PRISM status",
+      "Check the project's Brain/Graph index health (doc counts, staleness).",
+      Type.Object({})),
+  ];
+}
+
+const SYSTEM_PROMPT = [
+  "You are PI, PRISM's omnipresent assistant living in the app's left rail.",
+  "PRISM is a software-engineering knowledge service (brain index, long-term memory, task tracker, conductor SDLC).",
+  "Use your tools to answer from the project's REAL data — brain_search for code questions, memory_recall for conventions/decisions, task_list for work state. Never invent project facts a tool could check.",
+  "Be concise: short paragraphs, no filler. You run on a small local model — prefer one good tool call over many.",
+].join(" ");
+
+// ------------------------------------------------------------ the store
+
+export type PiItem =
+  | { kind: "user"; text: string }
+  | { kind: "assistant"; text: string; done: boolean; learned?: boolean; learning?: boolean }
+  | { kind: "tool"; callId: string; name: string; label: string; args: unknown;
+      status: "running" | "ok" | "error"; result?: unknown; ms?: number }
+  | { kind: "note"; text: string };
+
+export type PiTelemetry = { model: string; ok: boolean; at: number };
+
+/**
+ * Module-level store: ONE agent conversation per project, alive for the whole
+ * SPA session regardless of route — the omnipresence contract. React reads it
+ * via subscribe/getSnapshot (useSyncExternalStore).
+ */
+export class PiStore {
+  readonly project: string;
+  private agent: Agent;
+  private model: Model<"openai-completions">;
+  private cfg: PiConfig;
+  private items: PiItem[] = [];
+  private listeners = new Set<() => void>();
+  private version = 0;
+  busy = false;
+  connected: boolean | null = null;
+  lastError = "";
+
+  private tools: AgentTool[];
+  /** Guard against a model that answers every injection with more JSON. */
+  private interceptBudget = 0;
+  /** True while feeding a synthetic tool-result message back to the model. */
+  private injecting = false;
+
+  constructor(project: string) {
+    this.project = project;
+    this.cfg = loadPiConfig();
+    this.model = installProvider(this.cfg);
+    this.tools = buildTools(project);
+    this.agent = new Agent({
+      initialState: {
+        systemPrompt: SYSTEM_PROMPT,
+        model: this.model,
+        thinkingLevel: "off",
+        tools: this.tools,
+      },
+      streamFn: (m, c, o) => models.streamSimple(m, c, o),
+      // Belt-and-braces for the keyless local provider (see installProvider).
+      getApiKey: () => "local-keyless",
+    });
+    this.agent.subscribe((event) => this.onEvent(event));
+    void this.probe();
+  }
+
+  // -- external-store plumbing
+  subscribe = (fn: () => void) => { this.listeners.add(fn); return () => { this.listeners.delete(fn); }; };
+  getVersion = () => this.version;
+  snapshot(): PiItem[] { return this.items; }
+  get config(): PiConfig { return this.cfg; }
+  private emit() {
+    this.version++;
+    this.items = [...this.items];
+    for (const fn of this.listeners) fn();
+  }
+
+  /** Reachability probe for the model chip's status dot. */
+  async probe() {
+    try {
+      const res = await fetch(`${this.cfg.baseUrl.replace(/\/$/, "")}/models`, { method: "GET" });
+      this.connected = res.ok;
+    } catch {
+      this.connected = false;
+    }
+    this.emit();
+  }
+
+  setModel(modelId: string) {
+    this.cfg = { ...this.cfg, modelId };
+    savePiConfig(this.cfg);
+    this.model = installProvider(this.cfg);
+    this.agent.state.model = this.model;
+    this.emit();
+  }
+
+  async send(text: string) {
+    const prompt = text.trim();
+    if (!prompt || this.busy) return;
+    this.lastError = "";
+    this.interceptBudget = 3;
+    try {
+      await this.agent.prompt(prompt);
+    } catch (e) {
+      this.lastError = e instanceof Error ? e.message : String(e);
+      this.busy = false;
+      this.emit();
+    }
+  }
+
+  /** If the final assistant text IS a JSON tool call for a known tool,
+   * swap the bubble for a tool row, run the tool, and continue the run
+   * with the result. Returns true when an interception was started. */
+  private tryInterceptTextToolCall(): boolean {
+    if (this.interceptBudget <= 0) return false;
+    const idx = this.items.length - 1;
+    const last = this.items[idx];
+    if (!last || last.kind !== "assistant" || !last.text) return false;
+    const call = parseTextToolCall(last.text);
+    if (!call) return false;
+    const tool = this.tools.find((t) => t.name === call.name);
+    if (!tool) return false;
+
+    this.interceptBudget--;
+    this.busy = true;
+    const row: Extract<PiItem, { kind: "tool" }> = {
+      kind: "tool", callId: `text-${Date.now()}`, name: call.name,
+      label: call.name, args: call.args, status: "running",
+    };
+    this.items[idx] = row; // the raw-JSON bubble BECOMES the tool row
+    this.emit();
+
+    void (async () => {
+      let resultText: string;
+      try {
+        const res = await tool.execute(row.callId, call.args);
+        row.status = "ok";
+        const details = (res as { details?: { result?: unknown; ms?: number } }).details;
+        row.result = details?.result ?? res;
+        row.ms = details?.ms;
+        resultText = res.content
+          .filter((c): c is { type: "text"; text: string } => c.type === "text")
+          .map((c) => c.text).join("\n");
+      } catch (e) {
+        row.status = "error";
+        row.result = e instanceof Error ? e.message : String(e);
+        resultText = `ERROR: ${row.result}`;
+      }
+      this.emit();
+      try {
+        this.injecting = true; // hide the synthetic result message from the log
+        await this.agent.prompt(
+          `[${call.name} result]\n${resultText}\n\nAnswer the user's original question from this result, in plain prose. Do NOT output JSON.`,
+        );
+      } catch (e) {
+        this.lastError = e instanceof Error ? e.message : String(e);
+        this.busy = false;
+        this.emit();
+      }
+    })();
+    return true;
+  }
+
+  /** Explicit self-learning: distill the exchange into a memory_store write. */
+  async learn(index: number) {
+    const item = this.items[index];
+    if (!item || item.kind !== "assistant" || item.learned || item.learning) return;
+    const question = [...this.items.slice(0, index)].reverse()
+      .find((i): i is Extract<PiItem, { kind: "user" }> => i.kind === "user")?.text ?? "";
+    Object.assign(item, { learning: true });
+    this.emit();
+    try {
+      const name = `pi-${question.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 40) || "exchange"}`;
+      await api.post<PassthroughResponse>(
+        `/api/agent/tool?project=${encodeURIComponent(this.project)}`,
+        {
+          name: "memory_store",
+          args: {
+            domain: "pi-agent",
+            name,
+            description: `Learned from a PI panel exchange (model ${this.cfg.modelId}).\nQ: ${question}\nA: ${item.text}`,
+            type: "pattern",
+            classification: "tactical",
+          },
+        },
+      );
+      Object.assign(item, { learning: false, learned: true });
+      this.items.push({ kind: "note", text: `memory_store → stored (model ${this.cfg.modelId})` });
+    } catch (e) {
+      Object.assign(item, { learning: false });
+      this.items.push({ kind: "note", text: `memory_store failed: ${e instanceof Error ? e.message : e}` });
+    }
+    this.emit();
+  }
+
+  toggleToolExpand() { /* expansion is component-local state; kept here for symmetry */ }
+
+  // -- agent event fold
+  private onEvent(event: Parameters<Parameters<Agent["subscribe"]>[0]>[0]) {
+    switch (event.type) {
+      case "agent_start":
+        this.busy = true;
+        break;
+      case "agent_end": {
+        this.busy = false;
+        const err = this.agent.state.errorMessage;
+        if (err) this.lastError = err;
+        // Small-model resilience (senpi-style, the G5 reality): weak local
+        // stacks emit the tool call as PLAIN JSON TEXT instead of a native
+        // tool_call (seen live: Ollama 0.30.7 + qwen2.5-coder). Intercept
+        // it, execute the tool app-side, feed the result back as a new turn.
+        if (!err && this.tryInterceptTextToolCall()) return;
+        this.interceptBudget = 0;
+        const last = this.items[this.items.length - 1];
+        if (last?.kind === "assistant") last.done = true;
+        this.recordTelemetry(!err);
+        break;
+      }
+      case "message_start": {
+        const m = event.message as { role?: string };
+        if (m.role === "user") {
+          // Synthetic tool-result injections (text-tool-call fallback) are
+          // context for the model, not conversation for the human.
+          if (this.injecting) { this.injecting = false; break; }
+          this.items.push({ kind: "user", text: messageText(event.message) });
+        } else if (m.role === "assistant") {
+          this.items.push({ kind: "assistant", text: "", done: false });
+        }
+        break;
+      }
+      case "message_update": {
+        if ((event.message as { role?: string }).role !== "assistant") break;
+        const last = [...this.items].reverse().find((i) => i.kind === "assistant");
+        if (last && last.kind === "assistant") last.text = messageText(event.message);
+        break;
+      }
+      case "message_end": {
+        if ((event.message as { role?: string }).role !== "assistant") break;
+        const last = [...this.items].reverse().find((i) => i.kind === "assistant");
+        if (last && last.kind === "assistant") last.text = messageText(event.message);
+        break;
+      }
+      case "tool_execution_start":
+        this.items.push({
+          kind: "tool", callId: event.toolCallId, name: event.toolName,
+          label: event.toolName, args: event.args, status: "running",
+        });
+        break;
+      case "tool_execution_end": {
+        const row = this.items.find(
+          (i): i is Extract<PiItem, { kind: "tool" }> => i.kind === "tool" && i.callId === event.toolCallId,
+        );
+        if (row) {
+          row.status = event.isError ? "error" : "ok";
+          const details = (event.result as { details?: { result?: unknown; ms?: number } })?.details;
+          row.result = details?.result ?? event.result;
+          row.ms = details?.ms;
+        }
+        break;
+      }
+      default:
+        return; // turn_start/turn_end etc — no display impact
+    }
+    this.emit();
+  }
+
+  /** G5 feed: per-exchange model id + tool-loop success (localStorage ring). */
+  private recordTelemetry(ok: boolean) {
+    try {
+      const key = "prism.pi.telemetry";
+      const ring: PiTelemetry[] = JSON.parse(localStorage.getItem(key) ?? "[]");
+      ring.push({ model: this.cfg.modelId, ok, at: Date.now() });
+      localStorage.setItem(key, JSON.stringify(ring.slice(-50)));
+    } catch { /* advisory only */ }
+  }
+}
+
+/** Recognize an assistant text that IS a tool call — bare or fenced JSON
+ * shaped {"name": "...", "arguments"|"args"|"parameters": {...}}. */
+export function parseTextToolCall(text: string): { name: string; args: Record<string, unknown> } | null {
+  let t = text.trim();
+  const fence = /^```(?:json)?\s*([\s\S]*?)\s*```$/.exec(t);
+  if (fence) t = fence[1].trim();
+  if (!t.startsWith("{") || !t.endsWith("}")) return null;
+  try {
+    const obj = JSON.parse(t) as Record<string, unknown>;
+    const name = obj.name;
+    if (typeof name !== "string" || !name) return null;
+    const args = obj.arguments ?? obj.args ?? obj.parameters ?? {};
+    if (typeof args !== "object" || args === null || Array.isArray(args)) return null;
+    return { name, args: args as Record<string, unknown> };
+  } catch {
+    return null;
+  }
+}
+
+function messageText(message: unknown): string {
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .filter((p): p is { type: "text"; text: string } => (p as { type?: string }).type === "text")
+      .map((p) => p.text)
+      .join("");
+  }
+  return "";
+}
+
+const stores = new Map<string, PiStore>();
+
+export function piStore(project: string): PiStore {
+  let s = stores.get(project);
+  if (!s) { s = new PiStore(project); stores.set(project, s); }
+  return s;
+}

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -226,6 +226,11 @@ export class PiStore {
   private injecting = false;
   /** True between abort() and the agent_end it forces. */
   private stopping = false;
+  /** True once send() has ever run. Rehydrate keys off this, not busy/items:
+   * between send() and the first agent event, busy is still false and items
+   * still empty, so a slow IndexedDB load resolving in that window would
+   * pass those guards and splice a stale snapshot into a live exchange. */
+  private interacted = false;
 
   // Streaming channel (pi-web-ui split): message_update token folds notify
   // ONLY these listeners; the settled/global channel stays quiet, so the
@@ -271,7 +276,9 @@ export class PiStore {
     try {
       const snap = await loadSession(this._project);
       if (!snap?.items?.length) return;
-      if (this.items.length > 0 || this.busy) return; // live conversation wins
+      // Live conversation wins — including one whose first agent event
+      // hasn't landed yet (interacted covers the send()->agent_start gap).
+      if (this.items.length > 0 || this.busy || this.interacted) return;
       this.items = snap.items.map((it): PiItem => {
         if (it.kind === "assistant") return { ...it, done: true, learning: false };
         if (it.kind === "tool" && it.status === "running") {
@@ -284,8 +291,11 @@ export class PiStore {
   }
 
   /** Persist the display items + minimal agent context (model id). Called
-   * on agent_end, when nothing is in flight — items are settled. */
+   * on agent_end, when nothing is in flight — items are settled. Never
+   * writes an empty transcript: an itemless store (e.g. rekey during the
+   * pre-first-message window) must not clobber a real saved session. */
   private persist() {
+    if (this.items.length === 0) return;
     void saveSession(this._project, {
       items: this.items,
       modelId: this.cfg.modelId,
@@ -313,8 +323,13 @@ export class PiStore {
     this.agent.state.tools = this.tools;
     // Move the persisted session with the store: future saves target the
     // promoted project; the old key must not rehydrate a stale twin later.
-    this.persist();
-    void clearSession(old);
+    // Only when there is something to move — a busy-but-itemless store
+    // (rescued before its first message landed) must neither write [] over
+    // the target's saved session nor delete the old key's.
+    if (this.items.length > 0) {
+      this.persist();
+      void clearSession(old);
+    }
     this.emit();
   }
 
@@ -364,6 +379,7 @@ export class PiStore {
   async send(text: string) {
     const prompt = text.trim();
     if (!prompt || this.busy) return;
+    this.interacted = true; // from here on, a late rehydrate must no-op
     this.lastError = "";
     this.interceptBudget = 3;
     try {
@@ -647,11 +663,22 @@ let defaultRescueSpent = false;
  * items, re-keyed so future tool calls hit the promoted project.
  */
 export function piStore(project: string): PiStore {
-  let s = stores.get(project);
-  if (!s) {
-    s = rescueDefaultStore(project) ?? new PiStore(project);
-    stores.set(project, s);
+  const existing = stores.get(project);
+  if (existing) {
+    // The target store existing is not enough — if it is EMPTY while the
+    // "default" store holds the live conversation, binding the empty store
+    // would orphan that conversation just as surely as a missing one.
+    if (!existing.hasConversation()) {
+      const rescued = rescueDefaultStore(project);
+      if (rescued) {
+        stores.set(project, rescued);
+        return rescued;
+      }
+    }
+    return existing;
   }
+  const s = rescueDefaultStore(project) ?? new PiStore(project);
+  stores.set(project, s);
   return s;
 }
 

--- a/services/prism-service/prism_service/web/src/lib/piAgent.ts
+++ b/services/prism-service/prism_service/web/src/lib/piAgent.ts
@@ -22,12 +22,16 @@ import {
 import {
   createModels,
   createProvider,
-  Type,
   type Model,
 } from "@earendil-works/pi-ai";
 import { openAICompletionsApi } from "@earendil-works/pi-ai/api/openai-completions.lazy";
 import { api } from "@/lib/api";
 import { clearSession, loadSession, saveSession } from "@/components/pi/piSession";
+// The shared expert module (task e70cdcda): ONE source for the system
+// prompt + the full 18-tool PRISM catalog, imported by BOTH surfaces —
+// the Node runner (web/pi-runtime.mjs) and this panel. Types come from
+// the sibling pi-expert.d.mts declaration.
+import { EXPERT_SYSTEM_PROMPT, EXPERT_TOOL_DEFS } from "../../pi-expert.mjs";
 
 // ---------------------------------------------------------------- config
 
@@ -137,7 +141,10 @@ function prismTool(
       const started = performance.now();
       const res = await api.post<PassthroughResponse>(
         `/api/agent/tool?project=${encodeURIComponent(project)}`,
-        { name, args: params ?? {} },
+        // internal:true matches the Node runner's call shape. Harmless:
+        // task e70cdcda retired the internal-only gate (INTERNAL_ONLY_TOOLS
+        // is empty), the flag is kept for call-shape parity.
+        { name, args: params ?? {}, internal: true },
       );
       return {
         content: [{ type: "text", text: toolText(res.result) }],
@@ -147,44 +154,24 @@ function prismTool(
   };
 }
 
+/** The panel carries the FULL expert catalog — the exact 18 tools the Node
+ * runner executes with, from the shared pi-expert module. Never re-declare
+ * a tool here; additions/removals happen in web/pi-expert.mjs (mirrored by
+ * api/agent.py's AGENT_TOOL_WHITELIST). */
 function buildTools(project: string): AgentTool[] {
-  return [
-    prismTool(project, "brain_search", "Brain search",
-      "Search the project's code/knowledge base (hybrid BM25 + vector + graph). Use for any question about the codebase.",
-      Type.Object({ query: Type.String({ description: "Search query" }) })),
-    prismTool(project, "memory_recall", "Memory recall",
-      "Recall the team's long-term memory: conventions, decisions, failures, expertise.",
-      Type.Object({ query: Type.String({ description: "Natural-language query" }) })),
-    prismTool(project, "memory_store", "Memory store",
-      "Store a durable memory entry the team should keep (conventions, decisions, learnings).",
-      Type.Object({
-        domain: Type.String({ description: "Expertise domain, e.g. conventions, architecture" }),
-        name: Type.String({ description: "Short kebab-case name" }),
-        description: Type.String({ description: "Detailed description with concrete evidence" }),
-        type: Type.String({ description: "pattern | convention | failure | decision" }),
-        classification: Type.String({ description: "tactical | foundational | strategic" }),
-      })),
-    prismTool(project, "task_list", "Task list",
-      "List tasks in the PRISM tracker. Optionally filter by status: pending, in_progress, done, blocked.",
-      Type.Object({ status: Type.Optional(Type.String({ description: "Status filter" })) })),
-    prismTool(project, "task_create", "Task create",
-      "Create a new task in the PRISM tracker.",
-      Type.Object({
-        title: Type.String({ description: "Short human-friendly title" }),
-        description: Type.Optional(Type.String({ description: "Details" })),
-      })),
-    prismTool(project, "prism_status", "PRISM status",
-      "Check the project's Brain/Graph index health (doc counts, staleness).",
-      Type.Object({})),
-  ];
+  return Object.entries(EXPERT_TOOL_DEFS).map(([name, def]) =>
+    prismTool(project, name, def.label, def.description, def.parameters),
+  );
 }
 
-const SYSTEM_PROMPT = [
-  "You are PI, PRISM's omnipresent assistant living in the app's left rail.",
-  "PRISM is a software-engineering knowledge service (brain index, long-term memory, task tracker, conductor SDLC).",
-  "Use your tools to answer from the project's REAL data — brain_search for code questions, memory_recall for conventions/decisions, task_list for work state. Never invent project facts a tool could check.",
-  "Be concise: short paragraphs, no filler. You run on a small local model — prefer one good tool call over many.",
+/** Panel persona on top of the shared expertise: this surface is a chat
+ * rail on a small local model — concision + one-good-tool-call economy. */
+const PANEL_PREAMBLE = [
+  "You are answering in PRISM's left-rail chat panel.",
+  "Be concise: short paragraphs, no filler. You run on a small local model — prefer one well-aimed tool call over many exploratory ones, then answer in plain prose.",
 ].join(" ");
+
+const SYSTEM_PROMPT = `${EXPERT_SYSTEM_PROMPT}\n\n${PANEL_PREAMBLE}`;
 
 // ------------------------------------------------------------ the store
 
@@ -467,6 +454,7 @@ export class PiStore {
         `/api/agent/tool?project=${encodeURIComponent(this.project)}`,
         {
           name: "memory_store",
+          internal: true,
           args: {
             domain: "pi-agent",
             name,

--- a/services/prism-service/prism_service/web/src/pages/CompletedTasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/CompletedTasksPage.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "@/lib/api";
+import { useProject } from "@/lib/project";
+import { Page, Card, SectionLabel, Empty, toneFromLabel } from "@/components/ui";
+import Markdown from "@/components/Markdown";
+
+type Task = {
+  id?: string;
+  title?: string;
+  description?: string;
+  status?: string;
+  tags?: string[];
+  completed_at?: string;
+  parent_id?: string;
+};
+
+// Completed tasks never sit on the active board (TasksPage dropped the Done
+// column — the done-tasks-off-board doctrine). They land here instead: ones
+// the reflection worker absorbed link into Memory, the rest are archived.
+// This is the "remove where it doesn't make sense, absorb where it does"
+// surface, re-landed from stranded commit bdb8bad.
+export default function CompletedTasksPage() {
+  const [project] = useProject();
+  const navigate = useNavigate();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [memCounts, setMemCounts] = useState<Record<string, number>>({});
+
+  // memory_counts is optional in the payload (the backend half of 2caae5d is
+  // not on this branch); absent -> {} and every card reads "archived".
+  const load = useCallback(() => {
+    api.get<{ tasks: Task[]; memory_counts?: Record<string, number> }>(`/api/tasks?project=${project}`)
+      .then((d) => { setTasks(d.tasks); setMemCounts(d.memory_counts ?? {}); })
+      .catch(() => { setTasks([]); setMemCounts({}); });
+  }, [project]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const done = tasks
+    .filter((t) => !t.parent_id && (t.status ?? "") === "done")
+    .sort((a, b) => (b.completed_at ?? "").localeCompare(a.completed_at ?? ""));
+  const absorbed = done.filter((t) => (memCounts[t.id ?? ""] ?? 0) > 0).length;
+
+  return (
+    <Page>
+      <button
+        onClick={() => navigate("/tasks")}
+        className="text-xs uppercase tracking-wider opacity-60 hover:opacity-100 transition-opacity w-fit"
+      >
+        ← Back to board
+      </button>
+
+      <Card>
+        <SectionLabel>Completed — {done.length} task{done.length === 1 ? "" : "s"} ({absorbed} in memory)</SectionLabel>
+        <p className="text-xs opacity-60 mt-1">
+          Finished work lives here, off the active board. Tasks the learning loop
+          absorbed are linked into Memory; the rest are archived.
+        </p>
+      </Card>
+
+      {done.length === 0 ? (
+        <Empty>No completed tasks yet.</Empty>
+      ) : (
+        <div className="space-y-2">
+          {done.map((t) => {
+            const n = memCounts[t.id ?? ""] ?? 0;
+            return (
+              <button
+                key={t.id}
+                onClick={() => t.id && navigate(`/tasks/${t.id}`, { state: { from: "/tasks/completed" } })}
+                className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="text-sm font-medium">{t.title ?? "—"}</div>
+                  {n > 0 ? (
+                    <span
+                      title={`${n} memory(ies) minted from this task — absorbed into Memory`}
+                      onClick={(e) => { e.stopPropagation(); navigate("/memory"); }}
+                      className="shrink-0 text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ring-1 ring-inset cursor-pointer"
+                      style={{
+                        background: "var(--accent-emerald-bg)",
+                        color: "var(--accent-emerald-fg)",
+                        boxShadow: "inset 0 0 0 1px var(--accent-emerald-ring)",
+                      }}
+                    >
+                      in memory ✓
+                    </span>
+                  ) : (
+                    <span className="shrink-0 text-[10px] uppercase tracking-wider opacity-40">archived</span>
+                  )}
+                </div>
+                {t.description && (
+                  // Same structured-description preview the active board cards
+                  // ship (Markdown rework v6.5.3) — clamped, full doc on the
+                  // detail page. The preview survives on the completed screen.
+                  <div className="mt-1.5 max-h-28 overflow-hidden [mask-image:linear-gradient(to_bottom,black_70%,transparent)]">
+                    <Markdown text={t.description} className="space-y-1.5 text-left" />
+                  </div>
+                )}
+                {(t.tags ?? []).length > 0 && (
+                  <div className="flex items-center gap-2 mt-2 flex-wrap">
+                    {(t.tags ?? []).slice(0, 4).map((tag) => {
+                      const tone = toneFromLabel(tag);
+                      return (
+                        <span key={tag} className="text-[10px] font-mono px-1.5 py-0.5 rounded"
+                          style={{ background: `var(--accent-${tone}-bg)`, color: `var(--accent-${tone}-fg)` }}>
+                          #{tag}
+                        </span>
+                      );
+                    })}
+                  </div>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </Page>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/ConsolidationPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConsolidationPage.tsx
@@ -354,7 +354,7 @@ export default function ConsolidationPage() {
         <Card>
           <SectionLabel>What we've extracted</SectionLabel>
           <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mt-2">
-            <Kpi label="Sessions scanned" value={rollup.sessions_scanned} />
+            <Kpi label="Candidates scanned" value={rollup.sessions_scanned} />
             <Kpi label="Pushbacks" value={rollup.pushbacks} />
             <Kpi label="Tool failures" value={rollup.tool_failures} />
             <Kpi label="Bg signals" value={rollup.bg_signals} />

--- a/services/prism-service/prism_service/web/src/pages/DashboardPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/DashboardPage.tsx
@@ -243,7 +243,7 @@ export default function DashboardPage() {
         <TrendKpi label="Queries" series={act?.series.searches ?? []} color={TONE.teal} />
         <TrendKpi label="Docs indexed" series={act?.series.indexing ?? []} color={TONE.sage} />
         <TrendKpi label="Workflow events" series={act?.series.workflow ?? []} color={TONE.violet} />
-        <TrendKpi label="Tasks shipped" series={act?.flow.completed ?? []} color={TONE.emerald} />
+        <TrendKpi label="Tasks shipped (incl. subtasks)" series={act?.flow.completed ?? []} color={TONE.emerald} />
         <TrendKpi label="Tokens (14d)" series={act?.tokens.per_day ?? []} color={TONE.amber} fmt={compact} />
       </section>
 
@@ -278,7 +278,7 @@ export default function DashboardPage() {
           <div className="flex gap-3 mb-3">
             <Stat label="gate pass-rate" value={gatePct != null ? `${gatePct}%` : "—"} tone={gatePct === 100 ? TONE.emerald : gatePct != null ? TONE.amber : undefined} />
             <Stat label="cycle time" value={act?.flow.cycle_days != null ? `${act.flow.cycle_days} d` : "—"} />
-            <Stat label="shipped" value={nf(sum(act?.flow.completed ?? []))} />
+            <Stat label="shipped (incl. subtasks)" value={nf(sum(act?.flow.completed ?? []))} />
             <Stat label="active" value={nf(data?.kpis.tasks_active ?? 0)} />
           </div>
           {flowChart && <PlotFigure options={flowChart} className="w-full mb-3" />}

--- a/services/prism-service/prism_service/web/src/pages/DashboardPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/DashboardPage.tsx
@@ -35,7 +35,14 @@ function TrendKpi({ label, series, color, fmt }: { label: string; series: number
   const total = sum(series);
   const today = series[series.length - 1] ?? 0;
   const prev = series[series.length - 2] ?? 0;
-  const up = today >= prev;
+  // Day-over-day delta: the arrow sign AND the number both derive from
+  // (today - prev), so a KPI whose total rose today never shows the bare
+  // absolute count behind a red down-arrow (task 855ef8aa). Previously the
+  // arrow encoded rate direction while the number was today's absolute
+  // count — "▼ 9 today" read as a loss even though 9 were just added.
+  const delta = today - prev;
+  const up = delta >= 0;
+  const signed = `${up ? "+" : "−"}${(fmt ?? nf)(Math.abs(delta))}`;
   return (
     <div className="flex-1 min-w-[170px] rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-1)] p-4">
       <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-label)] mb-2">{label}</div>
@@ -44,7 +51,7 @@ function TrendKpi({ label, series, color, fmt }: { label: string; series: number
         <Sparkline data={series} color={color} />
       </div>
       <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] mt-2">
-        <span style={{ color }}>{up ? "▲" : "▼"} {nf(today)}</span> today
+        <span style={{ color }}>{up ? "▲" : "▼"} {signed}</span> vs prev day
       </div>
     </div>
   );

--- a/services/prism-service/prism_service/web/src/pages/InternalAgentPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/InternalAgentPage.tsx
@@ -1,0 +1,216 @@
+/**
+ * Internal agent audit view — /internal-agent.
+ *
+ * Every internal pi/local inference run (pi_agent jobs incl. reflection
+ * backend=pi, local_llm completions) lands in the pi_run_log ledger;
+ * this page renders it: KPI strip (runs today, avg ms, tokens today,
+ * error rate) + newest-first run rows. A row click expands the
+ * tools_used receipts as one-line rows (progressive disclosure — never
+ * a wall of JSON). 10s poll + /sse/sessions refresh nudge.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { api } from "@/lib/api";
+import { useProject } from "@/lib/project";
+import { Card, Empty, Kpi, Page, SectionLabel } from "@/components/ui";
+
+type ToolReceipt = { name: string; ms: number; ok: boolean };
+
+type PiRun = {
+  run_id: string;
+  ts: number;
+  duration_ms: number;
+  backend: string; // "pi" | "local"
+  model: string;
+  purpose: string; // "reflect" | "panel-bridge" | "adhoc"
+  project: string;
+  prompt_chars: number;
+  tools_used: ToolReceipt[];
+  turns: number;
+  tokens: number;
+  ok: boolean;
+  error: string;
+};
+
+const BACKEND_TONE: Record<string, string> = {
+  pi: "bg-[color:var(--accent-violet-bg)] text-[color:var(--accent-violet-fg)] ring-1 ring-inset ring-[color:var(--accent-violet-ring)]",
+  local: "bg-[color:var(--accent-teal-bg)] text-[color:var(--accent-teal-fg)] ring-1 ring-inset ring-[color:var(--accent-teal-ring)]",
+};
+
+function fmtMs(ms: number): string {
+  if (!ms) return "0ms";
+  return ms >= 10_000 ? `${(ms / 1000).toFixed(1)}s` : `${Math.round(ms)}ms`;
+}
+
+function fmtWhen(epochS: number): string {
+  const d = new Date(epochS * 1000);
+  const today = new Date();
+  const sameDay = d.toDateString() === today.toDateString();
+  const hm = d.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+  return sameDay ? hm : `${d.toLocaleDateString([], { month: "short", day: "numeric" })} ${hm}`;
+}
+
+function RunRow({ run }: { run: PiRun }) {
+  const [open, setOpen] = useState(false);
+  const receipts = run.tools_used ?? [];
+  const Chevron = open ? ChevronDown : ChevronRight;
+  return (
+    <div className="py-2">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-3 text-left text-sm hover:bg-[color:var(--surface-2)] rounded-md px-2 py-1.5 transition-colors"
+        title={open ? "Collapse run detail" : "Expand run detail"}
+      >
+        <Chevron className="w-3.5 h-3.5 shrink-0 text-[color:var(--text-muted)]" />
+        <span className="text-[11px] font-mono text-[color:var(--text-muted)] whitespace-nowrap w-[86px]">
+          {fmtWhen(run.ts)}
+        </span>
+        <span
+          className={`px-2 py-0.5 rounded-full text-[10px] uppercase tracking-wider whitespace-nowrap ${
+            BACKEND_TONE[run.backend] ?? "bg-[color:var(--surface-2)] text-[color:var(--text-secondary)]"
+          }`}
+        >
+          {run.backend || "?"}
+        </span>
+        <span className="font-mono text-[11px] px-2 py-0.5 rounded bg-[color:var(--surface-2)] text-[color:var(--text-secondary)] truncate max-w-[180px]">
+          {run.model || "—"}
+        </span>
+        <span className="text-[11px] uppercase tracking-wider text-[color:var(--text-secondary)] whitespace-nowrap flex-1 truncate">
+          {run.purpose || "adhoc"}
+        </span>
+        {receipts.length > 0 && (
+          <span className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] whitespace-nowrap">
+            {receipts.length} tool{receipts.length === 1 ? "" : "s"}
+          </span>
+        )}
+        <span className="text-xs font-mono text-[color:var(--text-secondary)] whitespace-nowrap w-[64px] text-right">
+          {fmtMs(run.duration_ms)}
+        </span>
+        <span className="text-xs font-mono text-[color:var(--text-secondary)] whitespace-nowrap w-[64px] text-right">
+          {run.tokens} tok
+        </span>
+        <span
+          className={`text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full whitespace-nowrap ${
+            run.ok
+              ? "bg-[color:var(--accent-emerald-bg)] text-[color:var(--accent-emerald-fg)]"
+              : "bg-[color:var(--accent-rose-bg)] text-[color:var(--accent-rose-fg)]"
+          }`}
+        >
+          {run.ok ? "ok" : "error"}
+        </span>
+      </button>
+      {open && (
+        <div className="mt-1 ml-[26px] pl-3 border-l border-[color:var(--border-default)] space-y-1">
+          <div className="text-[10px] uppercase tracking-wider text-[color:var(--text-muted)] font-mono">
+            run {run.run_id} · project {run.project || "—"} · {run.prompt_chars} prompt chars
+            {run.turns > 0 && ` · ${run.turns} turns`}
+          </div>
+          {run.error && (
+            <div className="text-xs font-mono text-[color:var(--accent-rose-fg)] break-all">
+              {run.error}
+            </div>
+          )}
+          {receipts.length === 0 ? (
+            <div className="text-xs text-[color:var(--text-muted)]">
+              no tool calls (plain completion)
+            </div>
+          ) : (
+            receipts.map((t, i) => (
+              <div key={`${run.run_id}-${i}`} className="flex items-center gap-3 text-xs">
+                <span
+                  className={`w-1.5 h-1.5 rounded-full shrink-0 ${
+                    t.ok
+                      ? "bg-[color:var(--accent-emerald-fg)]"
+                      : "bg-[color:var(--accent-rose-fg)]"
+                  }`}
+                  aria-label={t.ok ? "tool ok" : "tool failed"}
+                />
+                <span className="font-mono text-[color:var(--text-secondary)] flex-1 truncate">
+                  {t.name}
+                </span>
+                <span className="font-mono text-[color:var(--text-muted)] w-[64px] text-right">
+                  {fmtMs(t.ms)}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function InternalAgentPage() {
+  const [project] = useProject();
+  const [runs, setRuns] = useState<PiRun[]>([]);
+  const [error, setError] = useState(false);
+
+  const load = useCallback(() => {
+    api
+      .get<{ runs: PiRun[] }>(`/api/pi-runs?project=${encodeURIComponent(project)}&limit=100`)
+      .then((d) => { setRuns(d.runs ?? []); setError(false); })
+      .catch(() => setError(true));
+  }, [project]);
+
+  // 10s poll — the ledger is file-backed and cheap to read.
+  useEffect(() => {
+    load();
+    const t = setInterval(load, 10_000);
+    return () => clearInterval(t);
+  }, [load]);
+
+  // Refresh nudge: internal runs are usually triggered by session
+  // activity (reflection, panel work), so any /sse/sessions event is a
+  // hint that fresh rows may exist — reload ahead of the next poll tick.
+  useEffect(() => {
+    const es = new EventSource(`/sse/sessions?project=${encodeURIComponent(project)}`);
+    es.onmessage = () => load();
+    return () => es.close();
+  }, [project, load]);
+
+  const kpis = useMemo(() => {
+    const midnight = new Date();
+    midnight.setHours(0, 0, 0, 0);
+    const dayStart = midnight.getTime() / 1000;
+    const today = runs.filter((r) => r.ts >= dayStart);
+    const avgMs = runs.length
+      ? runs.reduce((s, r) => s + (r.duration_ms || 0), 0) / runs.length
+      : 0;
+    const tokensToday = today.reduce((s, r) => s + (r.tokens || 0), 0);
+    const errors = runs.filter((r) => !r.ok).length;
+    const errorRate = runs.length ? Math.round((errors / runs.length) * 100) : 0;
+    return { runsToday: today.length, avgMs, tokensToday, errorRate, errors };
+  }, [runs]);
+
+  return (
+    <Page>
+      <div className="flex flex-wrap gap-4">
+        <Kpi label="Runs today" value={kpis.runsToday} hint="pi + local backends" />
+        <Kpi label="Avg duration" value={fmtMs(kpis.avgMs)} hint={`across last ${runs.length} runs`} />
+        <Kpi label="Tokens today" value={kpis.tokensToday.toLocaleString()} hint="completion tokens" />
+        <Kpi
+          label="Error rate"
+          value={`${kpis.errorRate}%`}
+          hint={kpis.errors ? `${kpis.errors} failed run${kpis.errors === 1 ? "" : "s"}` : "no failures"}
+        />
+      </div>
+      <Card className="mt-4">
+        <SectionLabel>Internal inference runs</SectionLabel>
+        {error ? (
+          <Empty>Could not load the internal-agent ledger.</Empty>
+        ) : runs.length === 0 ? (
+          <Empty>
+            No internal agent runs recorded yet — reflection (backend=pi/local)
+            and local completions will land here as they happen.
+          </Empty>
+        ) : (
+          <div className="divide-y divide-[color:var(--border-default)]">
+            {runs.map((r) => (
+              <RunRow key={r.run_id} run={r} />
+            ))}
+          </div>
+        )}
+      </Card>
+    </Page>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/LearningPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/LearningPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, SectionLabel, Empty } from "@/components/ui";
@@ -315,9 +316,17 @@ export default function LearningPage() {
         </div>
         {agentRuns.length === 0 ? (
           <Empty>
-            No agent runs yet — they populate as the{" "}
-            <span className="font-mono">implement</span> workflow drives steps
-            and POSTs telemetry to <span className="font-mono">/api/agent-runs/ingest</span>.
+            No <span className="font-mono">implement</span>-workflow agent runs
+            yet — they populate as the workflow drives steps and POSTs telemetry
+            to <span className="font-mono">/api/agent-runs/ingest</span>. This is
+            distinct from internal inference: internal pi/local runs are tracked
+            on the{" "}
+            <Link
+              to="/internal-agent"
+              className="underline decoration-dotted underline-offset-2 text-[color:var(--accent-emerald-fg)] hover:text-[color:var(--text-strong)]"
+            >
+              Internal agent page →
+            </Link>
           </Empty>
         ) : (
           <div className="divide-y divide-[color:var(--border-default)]/40">

--- a/services/prism-service/prism_service/web/src/pages/SessionsPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/SessionsPage.tsx
@@ -70,9 +70,13 @@ export default function SessionsPage() {
   const tokens = outcomes.map((o) => o.tokens ?? o.tokens_used ?? 0).filter(Boolean);
   // API returns duration in SECONDS (column duration_s aliased to "duration").
   const durSec = outcomes.map((o) => o.duration ?? o.duration_s ?? 0).filter(Boolean);
-  const files = outcomes.map((o) => o.files_modified ?? 0).filter(Boolean);
-  const totalFiles = files.reduce((a, b) => a + b, 0) || 1;
   const totalTokens = tokens.reduce((a, b) => a + b, 0);
+  // 'Tokens / file' = tokens across all sessions divided by files READ (the
+  // context each session actually consumed). files_modified is 0 for most
+  // scored sessions, so dividing by it hit the `|| 1` fallback and mislabeled
+  // the raw token SUM as a per-file figure (task 8c596af6).
+  const totalFiles = outcomes.map((o) => o.files_read ?? 0)
+    .reduce((a, b) => a + b, 0) || 1;
   const fmtTs = (s?: string) =>
     s ? s.replace("T", " ").replace(/\.\d+/, "").slice(0, 19) : "";
 

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -5,7 +5,7 @@ import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, SectionLabel, Empty, toneFromLabel, type PillTone } from "@/components/ui";
 import {
-  stepChipClass, gateChipClass, gateLabel, stepLabel,
+  stepChipClass, gateChipClass, gateLabel, stepLabel, type GateState,
 } from "@/lib/workflowChips";
 import PlanView from "@/components/plan/PlanView";
 import Markdown from "@/components/Markdown";
@@ -63,6 +63,9 @@ type Task = {
   plan_doc?: string;
   plan_diagram?: string;
   phase_progress?: PhaseProgress | null;
+  // Per-phase metrics (task bd1c2289): the representation layer over the
+  // fc08da8d telemetry — one entry per visited SDLC step + a task total.
+  phase_metrics?: PhaseMetrics | null;
   has_prototype?: boolean;
   // Whole-subtree roll-up (task e72aba6d): descendant totals ride the detail
   // payload's top level (like phase_progress) so the tree header shows a
@@ -97,6 +100,24 @@ type SessionRow = {
   files_read?: number;
   files_modified?: number;
   skills_invoked?: number;
+};
+
+// Per-phase metrics (task bd1c2289): one entry per VISITED SDLC step —
+// duration + tokens + turns + actor + gate outcome — plus a task total.
+type PhaseStep = {
+  step: string;
+  entered_at?: string | null;
+  duration_s: number;
+  tokens_in: number;
+  tokens_out: number;
+  turns: number;
+  actor?: string;
+  model?: string;
+  gate_outcome?: string | null;
+};
+type PhaseMetrics = {
+  steps: PhaseStep[];
+  total: { wall_duration_s: number; total_tokens: number; tok_s: number };
 };
 
 // PI-agent activity (task fc08da8d): a task-attributed pi_runs ledger row —
@@ -347,6 +368,71 @@ function Timeline({ rows, tokens }: { rows: HistoryRow[]; tokens?: number }) {
   );
 }
 
+// ── Phase metrics (task bd1c2289) ──────────────────────────────────────
+// A per-phase breakdown of the SDLC: one row per VISITED step showing its
+// duration (as a bar relative to the longest step), tokens (↑in ↓out), a
+// per-step tok/s rate, the actor, and a gate-outcome pill for gate steps.
+// The header carries the task total (wall duration · tokens · tok/s). Reads
+// task.phase_metrics; Hermes accent tokens only, reusing the shared step +
+// gate chip helpers (no invented palette).
+function fmtDur(s: number): string {
+  return fmtGap((Number.isFinite(s) ? s : 0) * 1000) || "0s";
+}
+
+function GateOutcomePill({ outcome }: { outcome?: string | null }) {
+  if (!outcome || outcome === "none") return null;
+  const state = (outcome === "passed" || outcome === "failed" ? outcome : "pending") as GateState;
+  return <span className={gateChipClass(state)}>{outcome}</span>;
+}
+
+function PhaseMetricsCard({ metrics }: { metrics: PhaseMetrics }) {
+  const steps = metrics.steps ?? [];
+  const total = metrics.total ?? { wall_duration_s: 0, total_tokens: 0, tok_s: 0 };
+  const maxDur = Math.max(1, ...steps.map((s) => s.duration_s || 0));
+  return (
+    <div className="mt-2">
+      <div className="flex items-center gap-x-4 gap-y-1 flex-wrap text-[11px] opacity-60 mb-3">
+        <span>{steps.length} phase{steps.length === 1 ? "" : "s"}</span>
+        <span>· {fmtDur(total.wall_duration_s)} wall</span>
+        <span>· {fmtTokens(total.total_tokens)} tokens</span>
+        <span>· {total.tok_s.toFixed(total.tok_s >= 10 ? 0 : 1)} tok/s</span>
+      </div>
+      <ul className="space-y-2">
+        {steps.map((s) => {
+          const tps = s.duration_s > 0 ? (s.tokens_in + s.tokens_out) / s.duration_s : 0;
+          const barPct = Math.max(2, Math.round((s.duration_s / maxDur) * 100));
+          const who = s.model || s.actor || "";
+          return (
+            <li key={s.step} className="grid grid-cols-1 md:grid-cols-[10rem_1fr_auto] gap-x-3 gap-y-1 items-center">
+              <div className="flex items-center gap-1.5 min-w-0">
+                <span className={stepChipClass(s.step)}>{stepLabel(s.step)}</span>
+              </div>
+              {/* duration bar (relative to the longest step) */}
+              <div className="relative h-5 rounded bg-[color:var(--midground-base)]/10 overflow-hidden">
+                <div
+                  className="absolute inset-y-0 left-0 rounded"
+                  style={{ width: `${barPct}%`, background: "var(--accent-teal-bg)" }}
+                />
+                <span className="absolute inset-0 flex items-center px-2 gap-2 text-[10px] font-mono">
+                  <span className="opacity-80">{fmtDur(s.duration_s)}</span>
+                  {(s.tokens_in + s.tokens_out) > 0 && (
+                    <span className="opacity-60">↑{fmtTokens(s.tokens_in)} ↓{fmtTokens(s.tokens_out)}</span>
+                  )}
+                  {tps > 0 && <span className="opacity-50">{tps.toFixed(tps >= 10 ? 0 : 1)} tok/s</span>}
+                </span>
+              </div>
+              <div className="flex items-center gap-1.5 justify-end shrink-0">
+                {who && <span className="text-[10px] font-mono opacity-60 px-1.5 py-0.5 rounded bg-[color:var(--midground-base)]/10">{who}</span>}
+                <GateOutcomePill outcome={s.gate_outcome} />
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
 const STATUS_CYCLE: Record<string, string[]> = {
   pending: ["in_progress", "blocked", "done"],
   in_progress: ["done", "blocked", "pending"],
@@ -407,13 +493,14 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; pi_activity?: PiActivityRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean; descendant_count?: number; descendant_done?: number }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; pi_activity?: PiActivityRow[]; phase_progress?: PhaseProgress | null; phase_metrics?: PhaseMetrics | null; timeline?: Timeline | null; has_prototype?: boolean; descendant_count?: number; descendant_done?: number }>(
         `/api/tasks/${id}?project=${project}`,
       );
-      // phase_progress + has_prototype + descendant_* ride at the TOP LEVEL of
-      // the response (not nested in task) — merge onto the task so the SDLC bar,
-      // the prototype iframe, and the subtree roll-up header read them off task.*.
-      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, has_prototype: d.has_prototype ?? false, descendant_count: d.descendant_count ?? 0, descendant_done: d.descendant_done ?? 0 } : d.task);
+      // phase_progress + phase_metrics + has_prototype + descendant_* ride at
+      // the TOP LEVEL of the response (not nested in task) — merge onto the task
+      // so the SDLC bar, the Phase-metrics card, the prototype iframe, and the
+      // subtree roll-up header read them off task.*.
+      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, phase_metrics: d.phase_metrics ?? d.task.phase_metrics ?? null, has_prototype: d.has_prototype ?? false, descendant_count: d.descendant_count ?? 0, descendant_done: d.descendant_done ?? 0 } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
       setPiActivity(d.pi_activity ?? []);
@@ -758,6 +845,15 @@ export default function TaskDetailPage() {
               </div>
             </div>
           )}
+        </Card>
+        </Stagger>
+      )}
+
+      {(task.phase_metrics?.steps?.length ?? 0) > 0 && (
+        <Stagger i={1} reduced={reduced}>
+        <Card>
+          <SectionLabel>Phase metrics — per-step effort across the SDLC</SectionLabel>
+          <PhaseMetricsCard metrics={task.phase_metrics as PhaseMetrics} />
         </Card>
         </Stagger>
       )}

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -849,22 +849,18 @@ export default function TaskDetailPage() {
         </Stagger>
       )}
 
-      {(task.phase_metrics?.steps?.length ?? 0) > 0 && (
-        <Stagger i={1} reduced={reduced}>
-        <Card>
-          <SectionLabel>Phase metrics — per-step effort across the SDLC</SectionLabel>
-          <PhaseMetricsCard metrics={task.phase_metrics as PhaseMetrics} />
-        </Card>
-        </Stagger>
-      )}
-
-      {(task.plan_doc || task.plan_diagram || task.has_prototype) ? (
+      {(task.plan_doc || task.plan_diagram || task.has_prototype || (task.phase_metrics?.steps?.length ?? 0) > 0) ? (
         <Stagger i={1} reduced={reduced}>
         <Card>
           <SectionLabel>Plan</SectionLabel>
           <div className="mt-2">
+            {/* Metrics rides as a peer tab (Diagram / Proposed change / Metrics)
+                so the per-phase SDLC breakdown lives in the same plan surface. */}
             <PlanView diagram={task.plan_diagram} doc={task.plan_doc}
-              prototypeSrc={task.has_prototype ? `/api/tasks/${id}/prototype` : undefined} />
+              prototypeSrc={task.has_prototype ? `/api/tasks/${id}/prototype` : undefined}
+              metrics={(task.phase_metrics?.steps?.length ?? 0) > 0
+                ? <PhaseMetricsCard metrics={task.phase_metrics as PhaseMetrics} />
+                : undefined} />
           </div>
         </Card>
         </Stagger>

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -11,7 +11,8 @@ import PlanView from "@/components/plan/PlanView";
 import Markdown from "@/components/Markdown";
 import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
 import TaskActivityGantt, { type Timeline } from "@/components/conductor/TaskActivityGantt";
-import { EASE_OUT, DUR, SPRING_SNAPPY, staggerDelay } from "@/lib/motion";
+import TaskTree, { type TreeTask } from "@/components/tasks/TaskTree";
+import { EASE_OUT, DUR, staggerDelay } from "@/lib/motion";
 
 // Same status → tone map as TasksPage so the detail-page status chip
 // matches the kanban column header it came from.
@@ -63,15 +64,11 @@ type Task = {
   plan_diagram?: string;
   phase_progress?: PhaseProgress | null;
   has_prototype?: boolean;
-};
-
-// Slim shape for the child-task list — only what the row renders.
-type ChildTask = {
-  id?: string;
-  title?: string;
-  status?: string;
-  priority?: number | string;
-  parent_id?: string;
+  // Whole-subtree roll-up (task e72aba6d): descendant totals ride the detail
+  // payload's top level (like phase_progress) so the tree header shows a
+  // subtree-deep done count, not just direct children.
+  descendant_count?: number;
+  descendant_done?: number;
 };
 
 // Matches the /api/tasks/:id history rows: an append-only audit log where
@@ -114,44 +111,6 @@ function Stagger({ i, reduced, children }: { i: number; reduced: boolean | null;
     >
       {children}
     </motion.div>
-  );
-}
-
-// Animated checkbox for the child-task checklist — empty square when pending,
-// emerald fill + spring-tick check when the child is done (feeds the
-// current-segment sub-step fill server-side via children_done/total).
-function Checkbox({ done, reduced }: { done: boolean; reduced: boolean | null }) {
-  return (
-    <span
-      className="inline-flex items-center justify-center h-4 w-4 rounded shrink-0"
-      style={{
-        background: done ? "var(--accent-emerald-bg)" : "var(--surface-3)",
-        boxShadow: `inset 0 0 0 1px var(--accent-${done ? "emerald" : "slate"}-ring)`,
-      }}
-    >
-      <AnimatePresence>
-        {done && (
-          <motion.svg
-            key="tick"
-            viewBox="0 0 16 16"
-            className="h-3 w-3"
-            initial={reduced ? { opacity: 0 } : { scale: 0, opacity: 0 }}
-            animate={reduced ? { opacity: 1 } : { scale: 1, opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={reduced ? { duration: 0 } : SPRING_SNAPPY}
-          >
-            <path
-              d="M3.5 8.5l3 3 6-6.5"
-              fill="none"
-              stroke="var(--accent-emerald-fg)"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-          </motion.svg>
-        )}
-      </AnimatePresence>
-    </span>
   );
 }
 
@@ -401,7 +360,9 @@ export default function TaskDetailPage() {
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   const [timeline, setTimeline] = useState<Timeline | null>(null);
-  const [children, setChildren] = useState<ChildTask[]>([]);
+  // Whole flat task list, used to build the recursive subtree tree client-side
+  // (parent_id links) rooted at this task — a single GET the page already made.
+  const [allTasks, setAllTasks] = useState<TreeTask[]>([]);
   const [busy, setBusy] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -432,24 +393,24 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean; descendant_count?: number; descendant_done?: number }>(
         `/api/tasks/${id}?project=${project}`,
       );
-      // phase_progress + has_prototype ride at the TOP LEVEL of the response
-      // (not nested in task) — merge onto the task so the SDLC bar and the
-      // prototype iframe read them off task.*.
-      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, has_prototype: d.has_prototype ?? false } : d.task);
+      // phase_progress + has_prototype + descendant_* ride at the TOP LEVEL of
+      // the response (not nested in task) — merge onto the task so the SDLC bar,
+      // the prototype iframe, and the subtree roll-up header read them off task.*.
+      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, has_prototype: d.has_prototype ?? false, descendant_count: d.descendant_count ?? 0, descendant_done: d.descendant_done ?? 0 } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
       setTimeline(d.timeline ?? null);
       setError(null);
-      // Children aren't on the detail payload — derive them from the task
-      // list (parent_id === this id). Cheap, and keeps the API unchanged.
+      // The recursive subtree tree is built client-side from the flat task list
+      // (parent_id links) rooted at this task — one GET, no per-node re-walk.
       try {
-        const all = await api.get<{ tasks: ChildTask[] }>(`/api/tasks?project=${project}`);
-        setChildren((all.tasks ?? []).filter((t) => t.parent_id === id));
+        const all = await api.get<{ tasks: TreeTask[] }>(`/api/tasks?project=${project}`);
+        setAllTasks(all.tasks ?? []);
       } catch {
-        setChildren([]);
+        setAllTasks([]);
       }
     } catch (e) {
       setError((e as Error).message ?? "task not found");
@@ -907,43 +868,16 @@ export default function TaskDetailPage() {
         </Card>
       )}
 
-      {children.length > 0 && (
+      {(task.descendant_count ?? 0) > 0 && (
         <Card>
           <SectionLabel>
-            Child tasks ({children.filter((c) => (c.status ?? "") === "done").length}/{children.length} done)
+            Subtree ({task.descendant_done ?? 0}/{task.descendant_count ?? 0} done)
           </SectionLabel>
-          <div className="space-y-2 mt-2">
-            {children.map((c) => {
-              const cTone = STATUS_TONE[c.status ?? "pending"] ?? "slate";
-              return (
-                <button
-                  key={c.id}
-                  onClick={() => c.id && navigate(`/tasks/${c.id}`, { state: { from: `/tasks/${id}` } })}
-                  className="w-full text-left rounded-md border border-[color:var(--midground-base)]/10 bg-[color:var(--background-base)]/30 p-3 hover:border-[color:var(--midground-base)]/40 hover:bg-[color:var(--background-base)]/50 transition-colors flex items-center justify-between gap-3"
-                >
-                  <span className="flex items-center gap-3 min-w-0">
-                    <Checkbox done={(c.status ?? "") === "done"} reduced={reduced} />
-                    <span className="text-sm font-medium truncate">{c.title ?? c.id}</span>
-                  </span>
-                  <span className="flex items-center gap-2 shrink-0">
-                    {typeof c.priority !== "undefined" && (
-                      <span className="text-[10px] opacity-50 font-mono">p{c.priority}</span>
-                    )}
-                    <span
-                      className="text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded"
-                      style={{
-                        background: `var(--accent-${cTone}-bg)`,
-                        color: `var(--accent-${cTone}-fg)`,
-                        boxShadow: `inset 0 0 0 1px var(--accent-${cTone}-ring)`,
-                      }}
-                    >
-                      {c.status ?? "pending"}
-                    </span>
-                  </span>
-                </button>
-              );
-            })}
-          </div>
+          {/* Recursive collapsible tree of the WHOLE subtree to ANY depth: each
+              parent node reveals its own children via a chevron. The header
+              roll-up (descendant_done/descendant_count) is subtree-deep, not
+              just direct children. */}
+          <TaskTree tasks={allTasks} rootId={id} reduced={reduced} />
         </Card>
       )}
 

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -99,6 +99,19 @@ type SessionRow = {
   skills_invoked?: number;
 };
 
+// PI-agent activity (task fc08da8d): a task-attributed pi_runs ledger row —
+// the browser PI agent's per-exchange token + tool usage for this task.
+type PiActivityRow = {
+  run_id: string;
+  ts?: number;
+  model?: string;
+  tokens?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  duration_ms?: number;
+  tools_used?: { name: string; ms?: number; ok?: boolean }[];
+};
+
 // Staggered Card-stack wrapper: each card fades + rises into place with a
 // capped per-index delay, so the detail page assembles top-to-bottom on mount
 // instead of snapping in all at once. Collapses to opacity-only when reduced.
@@ -359,6 +372,7 @@ export default function TaskDetailPage() {
   const [task, setTask] = useState<Task | null>(null);
   const [history, setHistory] = useState<HistoryRow[]>([]);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [piActivity, setPiActivity] = useState<PiActivityRow[]>([]);
   const [timeline, setTimeline] = useState<Timeline | null>(null);
   // Whole flat task list, used to build the recursive subtree tree client-side
   // (parent_id links) rooted at this task — a single GET the page already made.
@@ -393,7 +407,7 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean; descendant_count?: number; descendant_done?: number }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; pi_activity?: PiActivityRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean; descendant_count?: number; descendant_done?: number }>(
         `/api/tasks/${id}?project=${project}`,
       );
       // phase_progress + has_prototype + descendant_* ride at the TOP LEVEL of
@@ -402,6 +416,7 @@ export default function TaskDetailPage() {
       setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, has_prototype: d.has_prototype ?? false, descendant_count: d.descendant_count ?? 0, descendant_done: d.descendant_done ?? 0 } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
+      setPiActivity(d.pi_activity ?? []);
       setTimeline(d.timeline ?? null);
       setError(null);
       // The recursive subtree tree is built client-side from the flat task list
@@ -954,6 +969,51 @@ export default function TaskDetailPage() {
           </ul>
         )}
       </Card>
+
+      {piActivity.length > 0 && (
+        <Card>
+          <SectionLabel>PI agent ({piActivity.length})</SectionLabel>
+          <ul className="divide-y divide-[color:var(--midground-base)]/10 mt-2">
+            {piActivity.map((r) => (
+              <li key={r.run_id} className="py-3">
+                <div className="flex items-baseline justify-between gap-3 flex-wrap">
+                  <span className="font-mono text-[12px]">{r.model || "pi-agent"}</span>
+                  <span className="text-[11px] opacity-50">
+                    {r.ts ? new Date(r.ts * 1000).toISOString().slice(0, 19).replace("T", " ") : "—"}
+                  </span>
+                </div>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {[
+                    ["↑in", String(r.input_tokens ?? 0)],
+                    ["↓out", String(r.output_tokens ?? r.tokens ?? 0)],
+                    ["ms", String(Math.round(r.duration_ms ?? 0))],
+                  ].map(([label, value]) => (
+                    <span
+                      key={label}
+                      className="text-[11px] px-2 py-0.5 rounded bg-[color:var(--midground-base)]/10"
+                    >
+                      <span className="opacity-50">{label}</span>{" "}
+                      <span className="font-mono">{value}</span>
+                    </span>
+                  ))}
+                </div>
+                {(r.tools_used ?? []).length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mt-2">
+                    {(r.tools_used ?? []).map((t, i) => (
+                      <span
+                        key={`${r.run_id}-${t.name}-${i}`}
+                        className={`text-[10px] font-mono px-1.5 py-0.5 rounded ${t.ok === false ? "bg-[color:var(--danger-base,#c0392b)]/20" : "bg-[color:var(--accent-base)]/15"}`}
+                      >
+                        {t.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
 
       <Card>
         <SectionLabel>Timeline ({history.length})</SectionLabel>

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -37,11 +37,14 @@ const STATUS_TONE: Record<string, PillTone> = {
   done: "emerald",
 };
 
+// The board is a view of ACTIVE work only. Completed tasks never accumulate
+// here — they live on their own /tasks/completed screen (absorbed ones link
+// into Memory, the rest are archived there). This is why there is no "Done"
+// column: done work moving off the board is the whole point.
 const COLUMNS: { key: string; label: string }[] = [
   { key: "pending", label: "Pending" },
   { key: "in_progress", label: "In Progress" },
   { key: "blocked", label: "Blocked" },
-  { key: "done", label: "Done" },
 ];
 
 // Priority bands → tone. Lower number = higher priority by convention,
@@ -82,6 +85,9 @@ export default function TasksPage() {
     if (t.parent_id) childCount.set(t.parent_id, (childCount.get(t.parent_id) ?? 0) + 1);
   }
   const roots = tasks.filter((t) => !t.parent_id);
+  // Completed work never sits on the board; it's counted here and reached via
+  // the clickable "Completed" tile → /tasks/completed.
+  const doneCount = roots.filter((t) => (t.status ?? "") === "done").length;
 
   return (
     <Page>
@@ -89,6 +95,13 @@ export default function TasksPage() {
         {COLUMNS.map((c) => (
           <Kpi key={c.key} label={c.label} value={roots.filter((t) => (t.status ?? "pending") === c.key).length} />
         ))}
+        <button
+          onClick={() => navigate("/tasks/completed")}
+          className="text-left hover:opacity-100 opacity-90 transition-opacity"
+          title="Completed tasks live on their own screen — absorbed ones link into Memory, the rest are archived"
+        >
+          <Kpi label="Completed →" value={doneCount} />
+        </button>
       </section>
 
       <Card>
@@ -106,7 +119,7 @@ export default function TasksPage() {
         )}
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
         {COLUMNS.map((col) => {
           const items = roots.filter((t) => (t.status ?? "pending") === col.key);
           const colTone = STATUS_TONE[col.key] ?? "slate";

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -78,11 +78,32 @@ export default function TasksPage() {
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
 
   // Hierarchy: the board shows only root tasks (no parent_id). A parent's
-  // children are reached by clicking into its detail page. childCount maps
-  // each task id → how many tasks name it as parent, for the corner badge.
-  const childCount = new Map<string, number>();
+  // subtree is reached by clicking into its detail page. The corner badge
+  // counts the WHOLE descendant subtree (task e72aba6d), not just direct
+  // children, so an epic card shows ALL the encapsulated work at a glance.
+  // Built from the flat list: a parent_id→children index walked per root.
+  const childrenByParent = new Map<string, string[]>();
   for (const t of tasks) {
-    if (t.parent_id) childCount.set(t.parent_id, (childCount.get(t.parent_id) ?? 0) + 1);
+    if (t.parent_id && t.id) {
+      const arr = childrenByParent.get(t.parent_id);
+      if (arr) arr.push(t.id);
+      else childrenByParent.set(t.parent_id, [t.id]);
+    }
+  }
+  const descendantCount = new Map<string, number>();
+  for (const t of tasks) {
+    if (!t.id) continue;
+    let n = 0;
+    const seen = new Set<string>([t.id]);
+    const queue = [...(childrenByParent.get(t.id) ?? [])];
+    while (queue.length) {
+      const cid = queue.shift()!;
+      if (seen.has(cid)) continue; // cycle-guard
+      seen.add(cid);
+      n += 1;
+      queue.push(...(childrenByParent.get(cid) ?? []));
+    }
+    descendantCount.set(t.id, n);
   }
   const roots = tasks.filter((t) => !t.parent_id);
   // Completed work never sits on the board; it's counted here and reached via
@@ -177,9 +198,9 @@ export default function TasksPage() {
                       >
                         <div className="flex items-start justify-between gap-2">
                           <div className="text-sm font-medium">{t.title ?? "—"}</div>
-                          {(childCount.get(t.id ?? "") ?? 0) > 0 && (
+                          {(descendantCount.get(t.id ?? "") ?? 0) > 0 && (
                             <span
-                              title={`${childCount.get(t.id ?? "")} child task(s) — open to view`}
+                              title={`${descendantCount.get(t.id ?? "")} descendant task(s) — open to view the tree`}
                               className="shrink-0 text-[10px] font-mono leading-none px-1.5 py-1 rounded-full ring-1 ring-inset"
                               style={{
                                 background: "var(--accent-violet-bg)",
@@ -187,7 +208,7 @@ export default function TasksPage() {
                                 boxShadow: "inset 0 0 0 1px var(--accent-violet-ring)",
                               }}
                             >
-                              {childCount.get(t.id ?? "")}
+                              {descendantCount.get(t.id ?? "")}
                             </span>
                           )}
                         </div>

--- a/services/prism-service/tests/integration/test_agent_tool_api.py
+++ b/services/prism-service/tests/integration/test_agent_tool_api.py
@@ -127,3 +127,115 @@ def test_missing_name_rejected_422(client):
         "/api/agent/tool", params={"project": "agenttest"}, json={"args": {}}
     )
     assert r.status_code == 422, r.text
+
+
+# ----------------------------------------------------------------------
+# Task 4f76beb9 — machine-legible tool errors, never a 200-wrapped raw
+# Python exception. The pi agent loop consumes this endpoint; an
+# AttributeError string dressed as "result" is indistinguishable from a
+# real tool result, so the micro-model treats stack noise as knowledge.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "tool,args",
+    [
+        pytest.param("brain_search", {"query": {"nested": {"deep": [1]}}},
+                     id="brain_search-dict"),
+        pytest.param("brain_search", {"query": 12345}, id="brain_search-int"),
+        pytest.param("memory_recall", {"query": {"x": 1}},
+                     id="memory_recall-dict"),
+    ],
+)
+def test_type_confused_args_return_machine_legible_error(client, tool, args):
+    """AC-1/AC-2: the three filed repros. Type-confused args must come back
+    as HTTP 200 {"name", "ok": false, "error": "<message>"} — the in-band
+    dispatch error surfaced as a MACHINE-legible field, never a raw
+    'Error: AttributeError: ...' string under "result"."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": tool, "args": args},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("name") == tool
+    assert body.get("ok") is False, body
+    assert isinstance(body.get("error"), str) and body["error"].strip(), body
+    # The raw exception text must NOT masquerade as a tool result.
+    assert "Error:" not in str(body.get("result", "")), body
+
+
+def test_success_shape_carries_ok_true(client):
+    """AC-3: a valid whitelisted call keeps its shape and gains ok=true so
+    `ok` is a reliable success/error discriminator for the agent loop."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "prism_status", "args": {}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is True, body
+    assert "result" in body and "error" not in body, body
+
+
+def test_args_as_string_still_422(client):
+    """AC-4: the existing args-shape validation is unchanged."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "brain_search", "args": "not-an-object"},
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_dispatch_exception_returns_clean_500(client, monkeypatch):
+    """AC-5: a truly exceptional path (the dispatcher itself raising, not an
+    in-band tool error) is HTTP 500 with a clean detail naming the exception
+    type + message — never a traceback body."""
+    import prism_service.mcp.tools as mcp_tools
+
+    async def boom(name, arguments, *, project_id="default"):
+        raise RuntimeError("dispatcher exploded")
+
+    monkeypatch.setattr(mcp_tools, "handle_tool", boom)
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "prism_status", "args": {}},
+    )
+    assert r.status_code == 500, r.text
+    detail = str(r.json().get("detail", ""))
+    assert "RuntimeError" in detail and "dispatcher exploded" in detail, detail
+    assert "Traceback" not in detail and "File \"" not in detail, detail
+
+
+def test_error_behind_reflection_nudge_detected(client, monkeypatch):
+    """AC-6: handle_tool may prepend the PRISM_REFLECTION_PENDING nudge
+    header to the FIRST content — an in-band error behind it must still be
+    detected as an error, not parsed/returned as a result."""
+    import prism_service.mcp.tools as mcp_tools
+    from mcp.types import TextContent
+
+    nudged = (
+        "⚠️ PRISM_REFLECTION_PENDING candidate=c1 task=t1\n"
+        "Before continuing, spawn the `prism-reflect` subagent. Call "
+        "`janitor_check` to fetch the brief, submit via `janitor_submit`.\n"
+        "---\n"
+        "Error: AttributeError: 'dict' object has no attribute 'split'"
+    )
+
+    async def nudged_error(name, arguments, *, project_id="default"):
+        return [TextContent(type="text", text=nudged)]
+
+    monkeypatch.setattr(mcp_tools, "handle_tool", nudged_error)
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "brain_search", "args": {"query": "x"}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is False, body
+    assert "'dict' object has no attribute 'split'" in str(body.get("error")), body

--- a/services/prism-service/tests/integration/test_agent_tool_api.py
+++ b/services/prism-service/tests/integration/test_agent_tool_api.py
@@ -20,7 +20,11 @@ def client(tmp_path, monkeypatch):
 
     from prism_service.main import app
 
-    return TestClient(app)
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "agenttest"})
+    return c
 
 
 def test_whitelisted_tool_dispatches_in_process(client):

--- a/services/prism-service/tests/integration/test_agent_tool_api.py
+++ b/services/prism-service/tests/integration/test_agent_tool_api.py
@@ -50,7 +50,10 @@ def test_memory_store_then_recall_roundtrip(client):
             "name": "memory_store",
             "args": {
                 "domain": "pi-agent",
-                "content": "PI panel roundtrip probe memory",
+                "name": "roundtrip-probe",
+                "description": "PI panel roundtrip probe memory",
+                "type": "convention",
+                "classification": "tactical",
             },
         },
     )

--- a/services/prism-service/tests/integration/test_agent_tool_api.py
+++ b/services/prism-service/tests/integration/test_agent_tool_api.py
@@ -78,6 +78,40 @@ def test_non_whitelisted_tool_rejected_403(client):
     assert r.status_code == 403, r.text
 
 
+@pytest.mark.parametrize("name", [
+    "janitor_check", "janitor_submit", "janitor_abandon",
+    "prism_sync", "okf_index", "okf_get", "okf_graph",
+    "prism_onboard", "register_claude_source",
+])
+def test_excluded_admin_tools_still_403(client, name):
+    """AC-3 (task e70cdcda): the expert-surface widening is EXACT — the
+    admin/destructive tools stay excluded even though the whitelist grew
+    to the full 18-tool expert catalog."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": name, "args": {}},
+    )
+    assert r.status_code == 403, f"{name}: {r.text}"
+
+
+def test_whitelist_is_exactly_the_expert_catalog():
+    """Task e70cdcda FR-3: AGENT_TOOL_WHITELIST == the 18-name expert
+    catalog, and the internal-only gate is retired (empty seam)."""
+    from prism_service.api.agent import AGENT_TOOL_WHITELIST, INTERNAL_ONLY_TOOLS
+
+    expected = {
+        "brain_search", "brain_understand", "brain_find_symbol",
+        "brain_outline", "brain_find_references", "brain_call_chain",
+        "memory_recall", "memory_store", "memory_invalidate",
+        "task_list", "task_next", "task_create", "task_update",
+        "conductor_advance", "conductor_gate",
+        "workflow_state", "context_bundle", "prism_status",
+    }
+    assert set(AGENT_TOOL_WHITELIST) == expected
+    assert INTERNAL_ONLY_TOOLS == frozenset()
+
+
 def test_unknown_tool_rejected_403(client):
     """A made-up tool name never reaches the dispatcher."""
     r = client.post(

--- a/services/prism-service/tests/integration/test_agent_tool_api.py
+++ b/services/prism-service/tests/integration/test_agent_tool_api.py
@@ -1,0 +1,92 @@
+"""Integration tests for the PI agent tool passthrough (api/agent.py).
+
+Task 711d5235 (Omnipresent PI assistant in the left rail): the browser-side
+pi agent does its own tool calling against PRISM's MCP tool surface through
+ONE endpoint — POST /api/agent/tool {name, args} — which dispatches
+in-process via mcp.tools.handle_tool, gated to a whitelist. AC-6: a
+non-whitelisted tool name is rejected with 403.
+
+Exercises the real FastAPI router via TestClient against an isolated
+PRISM_DATA_DIR so no real project stores are touched.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+def test_whitelisted_tool_dispatches_in_process(client):
+    """prism_status is whitelisted — the passthrough must return the real
+    in-process handle_tool result (a JSON payload with doc counts)."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "prism_status", "args": {}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("name") == "prism_status"
+    # handle_tool returns the tool's JSON text; the route surfaces it parsed.
+    assert "result" in body, body
+    assert "docs" in str(body["result"]), body
+
+
+def test_memory_store_then_recall_roundtrip(client):
+    """memory_store + memory_recall are both whitelisted (the self-learning
+    write path). A stored memory must be recallable through the same
+    passthrough — proves real dispatch, not a mocked echo."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={
+            "name": "memory_store",
+            "args": {
+                "domain": "pi-agent",
+                "content": "PI panel roundtrip probe memory",
+            },
+        },
+    )
+    assert r.status_code == 200, r.text
+    r2 = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "memory_recall", "args": {"query": "roundtrip probe"}},
+    )
+    assert r2.status_code == 200, r2.text
+    assert "roundtrip probe" in str(r2.json().get("result")), r2.text
+
+
+def test_non_whitelisted_tool_rejected_403(client):
+    """AC-6 oracle: janitor_abandon is a real MCP tool but NOT whitelisted
+    for the PI agent — the passthrough must refuse with 403."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "janitor_abandon", "args": {"ticket_id": "x"}},
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_unknown_tool_rejected_403(client):
+    """A made-up tool name never reaches the dispatcher."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "agenttest"},
+        json={"name": "definitely_not_a_tool", "args": {}},
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_missing_name_rejected_422(client):
+    r = client.post(
+        "/api/agent/tool", params={"project": "agenttest"}, json={"args": {}}
+    )
+    assert r.status_code == 422, r.text

--- a/services/prism-service/tests/integration/test_api_agent_run_telemetry.py
+++ b/services/prism-service/tests/integration/test_api_agent_run_telemetry.py
@@ -1,0 +1,79 @@
+"""RED — POST /api/agent/run records a task-attributed PI-panel row (fc08da8d).
+
+The browser PI agent runs inference locally; its per-exchange usage never
+reaches a Claude transcript. A new endpoint — POST /api/agent/run — takes the
+exchange USAGE (task_id, model, input/output tokens, ms, tools_used) and records
+one pi_runs row with backend='panel', purpose='panel-drive', task_id set, so the
+conductor tile burn + task detail can attribute the PI agent's work.
+
+Distinct from POST /api/agent/tool (which DISPATCHES an MCP tool): this endpoint
+records usage, it does not call a tool.
+
+FAIL today: the /api/agent/run route does not exist (405/404).
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+
+    c = TestClient(app)
+    c.post("/api/projects", json={"name": "runtel"})
+    return c
+
+
+def test_run_endpoint_records_task_attributed_row(client):
+    import prism_service.services.pi_run_log as prl
+
+    r = client.post(
+        "/api/agent/run",
+        params={"project": "runtel"},
+        json={
+            "task_id": "fc08da8d-drive",
+            "model": "qwen3:0.6b",
+            "input_tokens": 30,
+            "output_tokens": 45,
+            "ms": 1234,
+            "tools_used": [{"name": "conductor_advance", "ms": 12.0, "ok": True}],
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is True
+    run_id = body.get("run_id")
+    assert run_id
+
+    rows = prl.list_recent(limit=10, project="runtel", task_id="fc08da8d-drive")
+    assert len(rows) == 1, rows
+    row = rows[0]
+    assert row["backend"] == "panel"
+    assert row["purpose"] == "panel-drive"
+    assert row["task_id"] == "fc08da8d-drive"
+    assert row["model"] == "qwen3:0.6b"
+    assert row["output_tokens"] == 45
+    assert row["input_tokens"] == 30
+    assert row["tools_used"] == [{"name": "conductor_advance", "ms": 12.0, "ok": True}]
+
+
+def test_run_endpoint_records_adhoc_when_no_task(client):
+    """No detected task -> still recorded (empty task_id), never a 500."""
+    import prism_service.services.pi_run_log as prl
+
+    r = client.post(
+        "/api/agent/run",
+        params={"project": "runtel"},
+        json={"model": "m", "output_tokens": 5},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json().get("ok") is True
+    rows = prl.list_recent(limit=10, project="runtel")
+    assert any(row["task_id"] == "" and row["backend"] == "panel" for row in rows)

--- a/services/prism-service/tests/integration/test_api_pi_runs.py
+++ b/services/prism-service/tests/integration/test_api_pi_runs.py
@@ -1,0 +1,78 @@
+"""RED scaffold — GET /api/pi-runs backs the /internal-agent audit view.
+
+Exercises the REAL FastAPI app (route reachable through the registered
+api_router — mounted via api/__init__.py, not just defined): the list
+endpoint returns ledger rows newest-first honoring limit + project
+passthrough, and the detail endpoint 404s on unknown run ids.
+
+ALL FAIL today: api/pi_runs.py does not exist and nothing is mounted
+at /api/pi-runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """TestClient over the real app with the pi ledger repointed at
+    tmp_path (module-level path patch works regardless of how early
+    prism_service.config resolved DATA_DIR in a full-suite run)."""
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+    return TestClient(app)
+
+
+def _seed(project: str, model: str) -> str:
+    import prism_service.services.pi_run_log as prl
+    return prl.record_run(
+        backend="pi", model=model, purpose="reflect", project=project,
+        prompt_chars=10, tools_used=[{"name": "brain_search", "ms": 5.0,
+                                      "ok": True}],
+        duration_ms=100.0, tokens=9, turns=1, ok=True, error="",
+    )
+
+
+def test_list_newest_first_with_limit_and_project(client):
+    a1 = _seed("alpha", "m-1")
+    b1 = _seed("beta", "m-2")
+    a2 = _seed("alpha", "m-3")
+
+    r = client.get("/api/pi-runs")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["count"] == 3
+    assert [x["run_id"] for x in body["runs"]] == [a2, b1, a1]
+
+    r = client.get("/api/pi-runs", params={"limit": 1})
+    assert [x["run_id"] for x in r.json()["runs"]] == [a2]
+
+    r = client.get("/api/pi-runs", params={"project": "alpha"})
+    assert [x["run_id"] for x in r.json()["runs"]] == [a2, a1]
+
+
+def test_row_shape_carries_audit_fields(client):
+    _seed("alpha", "qwen3:0.6b")
+    r = client.get("/api/pi-runs")
+    row = r.json()["runs"][0]
+    for field in ("run_id", "ts", "backend", "model", "purpose", "project",
+                  "prompt_chars", "tools_used", "duration_ms", "tokens",
+                  "ok", "error"):
+        assert field in row, f"missing audit field {field!r}"
+
+
+def test_get_single_run_and_404(client):
+    rid = _seed("alpha", "m-1")
+    r = client.get(f"/api/pi-runs/{rid}")
+    assert r.status_code == 200, r.text
+    assert r.json()["run_id"] == rid
+
+    r = client.get("/api/pi-runs/ffffffffffff")
+    assert r.status_code == 404

--- a/services/prism-service/tests/integration/test_api_pi_runs_pagination.py
+++ b/services/prism-service/tests/integration/test_api_pi_runs_pagination.py
@@ -1,0 +1,76 @@
+"""RED — GET /api/pi-runs must honor `offset` and expose a grand `total`
+(task 2bf0d49b).
+
+`limit` is honored but `offset` is silently ignored (offset=0 and
+offset=999 return the same first rows) and the response carries only
+`count` (page length) with no grand `total`, so a client cannot page
+through the ledger or know how many runs exist. The fix threads offset
+into the manifest slice and returns the full filtered count as `total`.
+
+Exercises the REAL FastAPI app via TestClient with the pi ledger
+repointed at tmp_path (module-level path patch, per the sibling
+test_api_pi_runs.py fixture).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+    return TestClient(app)
+
+
+def _seed(n: int, project: str = "alpha") -> list[str]:
+    """Append n runs; return their run_ids in creation (oldest-first)
+    order. list_recent reverses append order, so newest-first is the
+    reverse of this list — deterministic regardless of clock resolution."""
+    import prism_service.services.pi_run_log as prl
+    ids: list[str] = []
+    for i in range(n):
+        ids.append(prl.record_run(
+            backend="pi", model=f"m-{i}", purpose="reflect",
+            project=project, duration_ms=1.0, tokens=1, turns=1, ok=True))
+    return ids
+
+
+# AC-1 — offset skips the first N newest-first rows; past-the-end -> [].
+def test_offset_skips_rows(client):
+    ids = _seed(3)
+    newest_first = list(reversed(ids))
+    r = client.get("/api/pi-runs", params={"offset": 2})
+    assert r.status_code == 200, r.text
+    assert [x["run_id"] for x in r.json()["runs"]] == newest_first[2:]
+    r = client.get("/api/pi-runs", params={"offset": 999})
+    assert r.json()["runs"] == []
+
+
+# AC-2 — total is the full filtered count, independent of limit/offset.
+def test_total_is_full_count(client):
+    _seed(5)
+    body = client.get("/api/pi-runs", params={"limit": 2}).json()
+    assert body["total"] == 5
+    assert len(body["runs"]) == 2
+    body = client.get("/api/pi-runs", params={"offset": 3, "limit": 2}).json()
+    assert body["total"] == 5
+
+
+# AC-3 — limit+offset paginate: disjoint, in newest-first order, full cover.
+def test_limit_offset_paginate(client):
+    ids = _seed(5)
+    newest_first = list(reversed(ids))
+    pages: list[str] = []
+    for off in (0, 2, 4):
+        r = client.get("/api/pi-runs", params={"limit": 2, "offset": off})
+        pages.extend(x["run_id"] for x in r.json()["runs"])
+    assert pages == newest_first
+    assert len(pages) == len(set(pages)), "pages overlapped"

--- a/services/prism-service/tests/integration/test_brain_ask_backend.py
+++ b/services/prism-service/tests/integration/test_brain_ask_backend.py
@@ -6,8 +6,10 @@
 PRISM_BRAIN_ASK_BACKEND=local the SAME grounded prompt must run as one
 local_llm.complete completion, preserving the response contract —
 answer / sources / run_id / exit_code / duration_s / tokens{input,
-output} — with run_id + tokens filled from the run-ledger seam so the
-SPA ask panel keeps its receipts. Default (unset) stays claude_cli.
+output} — with run_id + tokens riding back off the completion's own
+pi_runs audit-ledger row (task d1d4fe00: pi_runs is THE ledger for
+pi|local runs; claude_runs stays claude-only) so the SPA ask panel
+keeps its receipts. Default (unset) stays claude_cli.
 
 Exercises the REAL FastAPI app via TestClient; Brain retrieval and both
 inference backends are stubbed — pytest never needs Ollama or claude.
@@ -33,10 +35,11 @@ _HITS = [
 
 @pytest.fixture
 def client(monkeypatch, tmp_path):
-    """TestClient over the real app with Brain retrieval stubbed and the
-    claude_runs ledger repointed at tmp_path."""
+    """TestClient over the real app with Brain retrieval stubbed and
+    BOTH run ledgers repointed at tmp_path."""
     import prism_service.api.brain as brain_api
     import prism_service.services.claude_run_log as crl
+    import prism_service.services.pi_run_log as prl
 
     class _FakeBrain:
         def search(self, q, domain=None, limit=8):
@@ -49,11 +52,15 @@ def client(monkeypatch, tmp_path):
     runs_dir = tmp_path / "claude_runs"
     monkeypatch.setattr(crl, "_RUNS_DIR", runs_dir)
     monkeypatch.setattr(crl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    pi_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", pi_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", pi_dir / "manifest.jsonl")
 
     from fastapi.testclient import TestClient
     from prism_service.main import app
     tc = TestClient(app, raise_server_exceptions=False)
     tc._runs_dir = runs_dir
+    tc._pi_dir = pi_dir
     return tc
 
 
@@ -135,8 +142,11 @@ def test_local_backend_same_contract(client, monkeypatch, forbid_claude):
 
     def fake_complete(prompt, **kw):
         calls.append({"prompt": prompt, **kw})
+        # Contract-accurate stub: the real complete() records its own
+        # pi_runs row and returns the row's run_id (task d1d4fe00).
         return {"text": "Grounded local answer [2].", "ms": 42.0,
-                "tokens": 17, "input_tokens": 88, "output_tokens": 17}
+                "tokens": 17, "input_tokens": 88, "output_tokens": 17,
+                "run_id": "pi-run-1"}
     monkeypatch.setattr(local_llm, "complete", fake_complete)
 
     r = client.post("/api/brain/ask", json={
@@ -150,7 +160,8 @@ def test_local_backend_same_contract(client, monkeypatch, forbid_claude):
         assert key in body, f"missing contract key {key!r}"
     assert body["answer"] == "Grounded local answer [2]."
     assert body["exit_code"] == 0
-    assert body["run_id"], "local path must fill run_id from the ledger seam"
+    assert body["run_id"] == "pi-run-1", \
+        "local path must surface the completion's pi ledger run_id"
     assert body["tokens"] == {"input": 88, "output": 17}
 
     # Sources keep the retrieval receipts.
@@ -168,32 +179,51 @@ def test_local_backend_same_contract(client, monkeypatch, forbid_claude):
 
 
 # ----------------------------------------------------------------------
-# AC-3 — the local run lands in the ledger; run_id matches the response.
+# AC-3 — the local run lands in the pi_runs audit ledger (task d1d4fe00:
+# pi_runs owns pi|local); run_id matches the response; claude_runs
+# stays claude-only.
 # ----------------------------------------------------------------------
 def test_local_run_lands_in_ledger(client, monkeypatch, forbid_claude):
+    import io
+
     from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
 
     monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
     monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
-    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
-        "text": "Ledger answer.", "ms": 7.0, "tokens": 5,
-        "input_tokens": 31, "output_tokens": 5})
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    payload = json.dumps({
+        "choices": [{"message": {"content": "Ledger answer."}}],
+        "usage": {"prompt_tokens": 31, "completion_tokens": 5},
+    }).encode()
+    monkeypatch.setattr(local_llm.urllib.request, "urlopen",
+                        lambda req, timeout=0: _Resp(payload))
 
     r = client.post("/api/brain/ask", json={
         "q": "ledger check?", "project": "proj-x"})
     assert r.status_code == 200, r.text
     body = r.json()
 
-    rows = _manifest_rows(client._runs_dir)
-    assert len(rows) == 1, "local ask must append exactly one manifest row"
+    rows = prl.list_recent(limit=10)
+    assert len(rows) == 1, "local ask must append exactly one pi_runs row"
     row = rows[0]
     assert row["run_id"] == body["run_id"]
     assert row["backend"] == "local"
     assert row["model"] == "stub-micro"
     assert row["purpose"].startswith("brain_ask@")
+    assert row["project"] == "proj-x"
     assert row["input_tokens"] == 31
     assert row["output_tokens"] == 5
-    assert row["final_text"] == "Ledger answer."
+    assert body["tokens"] == {"input": 31, "output": 5}
+    assert _manifest_rows(client._runs_dir) == [], \
+        "claude_runs must stay claude-only — no local seam rows"
 
 
 # ----------------------------------------------------------------------

--- a/services/prism-service/tests/integration/test_brain_ask_backend.py
+++ b/services/prism-service/tests/integration/test_brain_ask_backend.py
@@ -1,0 +1,215 @@
+"""Red suite — env-gated local backend for POST /api/brain/ask
+(task e1ebdd6e, claude-p-exit epic be898578).
+
+/ask grounds a question in Brain hybrid-search hits and shells
+`claude -p` single-shot (the prompt itself forbids tool calls). With
+PRISM_BRAIN_ASK_BACKEND=local the SAME grounded prompt must run as one
+local_llm.complete completion, preserving the response contract —
+answer / sources / run_id / exit_code / duration_s / tokens{input,
+output} — with run_id + tokens filled from the run-ledger seam so the
+SPA ask panel keeps its receipts. Default (unset) stays claude_cli.
+
+Exercises the REAL FastAPI app via TestClient; Brain retrieval and both
+inference backends are stubbed — pytest never needs Ollama or claude.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from types import SimpleNamespace
+
+import pytest
+
+
+_HITS = [
+    {"source_file": "prism_service/api/brain.py", "entity_name": "ask",
+     "entity_kind": "function", "rrf_score": 0.91, "content": "def ask(...)"},
+    {"source_file": "prism_service/inference/local_llm.py",
+     "entity_name": "complete", "entity_kind": "function",
+     "rrf_score": 0.55, "content": "def complete(...)"},
+]
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    """TestClient over the real app with Brain retrieval stubbed and the
+    claude_runs ledger repointed at tmp_path."""
+    import prism_service.api.brain as brain_api
+    import prism_service.services.claude_run_log as crl
+
+    class _FakeBrain:
+        def search(self, q, domain=None, limit=8):
+            return list(_HITS)
+
+    monkeypatch.setattr(
+        brain_api, "get_project",
+        lambda project: SimpleNamespace(brain_svc=_FakeBrain()))
+
+    runs_dir = tmp_path / "claude_runs"
+    monkeypatch.setattr(crl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(crl, "_MANIFEST", runs_dir / "manifest.jsonl")
+
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+    tc = TestClient(app, raise_server_exceptions=False)
+    tc._runs_dir = runs_dir
+    return tc
+
+
+def _manifest_rows(runs_dir):
+    mf = runs_dir / "manifest.jsonl"
+    if not mf.exists():
+        return []
+    return [json.loads(ln) for ln in
+            mf.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+@pytest.fixture
+def forbid_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+
+    def forbidden(*a, **k):
+        raise AssertionError(
+            "claude_cli.invoke must not run on the local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+
+
+# ----------------------------------------------------------------------
+# AC-1 — default (env unset) stays claude_cli with the current contract.
+# ----------------------------------------------------------------------
+def test_default_routes_claude_cli(client, monkeypatch):
+    from prism_service.inference import claude_cli, local_llm
+
+    monkeypatch.delenv("PRISM_BRAIN_ASK_BACKEND", raising=False)
+    monkeypatch.setattr(
+        local_llm, "complete",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("local_llm must not run on the default path")))
+
+    seen: list[dict] = []
+
+    class _FakeResult:
+        exit_code = 0
+        run_id = "claude-run-1"
+        duration_s = 1.25
+        usage = {"input_tokens": 100, "output_tokens": 40}
+
+        def final_text(self):
+            return "Grounded claude answer [1]."
+
+    def fake_invoke(prompt, **kw):
+        seen.append({"prompt": prompt, **kw})
+        return _FakeResult()
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    r = client.post("/api/brain/ask", json={
+        "q": "how does ask work?", "project": "proj-x", "max_turns": 2})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["answer"] == "Grounded claude answer [1]."
+    assert body["run_id"] == "claude-run-1"
+    assert body["exit_code"] == 0
+    assert body["tokens"] == {"input": 100, "output": 40}
+    assert len(body["sources"]) == len(_HITS)
+    assert seen, "claude_cli.invoke was not called on the default path"
+    kw = seen[0]
+    assert kw["max_turns"] == 2
+    assert kw["allowed_tools"] == ()
+    assert kw["purpose"].startswith("brain_ask@")
+    assert "how does ask work?" in seen[0]["prompt"]
+
+
+# ----------------------------------------------------------------------
+# AC-2 + AC-4 — local backend keeps the full response contract: same
+# grounded prompt, non-empty run_id, tokens from the local usage split,
+# sources preserved from the stubbed Brain hits.
+# ----------------------------------------------------------------------
+def test_local_backend_same_contract(client, monkeypatch, forbid_claude):
+    from prism_service.inference import local_llm
+
+    monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+
+    calls: list[dict] = []
+
+    def fake_complete(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"text": "Grounded local answer [2].", "ms": 42.0,
+                "tokens": 17, "input_tokens": 88, "output_tokens": 17}
+    monkeypatch.setattr(local_llm, "complete", fake_complete)
+
+    r = client.post("/api/brain/ask", json={
+        "q": "how does ask work?", "project": "proj-x"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    # Contract keys all present, same shape as the claude path.
+    for key in ("question", "project", "answer", "sources", "run_id",
+                "exit_code", "duration_s", "tokens"):
+        assert key in body, f"missing contract key {key!r}"
+    assert body["answer"] == "Grounded local answer [2]."
+    assert body["exit_code"] == 0
+    assert body["run_id"], "local path must fill run_id from the ledger seam"
+    assert body["tokens"] == {"input": 88, "output": 17}
+
+    # Sources keep the retrieval receipts.
+    assert [s["file"] for s in body["sources"]] == [
+        h["source_file"] for h in _HITS]
+    assert body["sources"][0]["index"] == 1
+    assert body["sources"][0]["entity_name"] == "ask"
+    assert body["sources"][0]["entity_kind"] == "function"
+
+    # Same grounded prompt, single completion.
+    assert len(calls) == 1
+    assert "how does ask work?" in calls[0]["prompt"]
+    assert "## Retrieved context" in calls[0]["prompt"]
+    assert calls[0].get("model") == "stub-micro"
+
+
+# ----------------------------------------------------------------------
+# AC-3 — the local run lands in the ledger; run_id matches the response.
+# ----------------------------------------------------------------------
+def test_local_run_lands_in_ledger(client, monkeypatch, forbid_claude):
+    from prism_service.inference import local_llm
+
+    monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
+        "text": "Ledger answer.", "ms": 7.0, "tokens": 5,
+        "input_tokens": 31, "output_tokens": 5})
+
+    r = client.post("/api/brain/ask", json={
+        "q": "ledger check?", "project": "proj-x"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    rows = _manifest_rows(client._runs_dir)
+    assert len(rows) == 1, "local ask must append exactly one manifest row"
+    row = rows[0]
+    assert row["run_id"] == body["run_id"]
+    assert row["backend"] == "local"
+    assert row["model"] == "stub-micro"
+    assert row["purpose"].startswith("brain_ask@")
+    assert row["input_tokens"] == 31
+    assert row["output_tokens"] == 5
+    assert row["final_text"] == "Ledger answer."
+
+
+# ----------------------------------------------------------------------
+# AC-5 — a local endpoint failure returns 502, never a fabricated answer.
+# ----------------------------------------------------------------------
+def test_local_failure_returns_502(client, monkeypatch, forbid_claude):
+    from prism_service.inference import local_llm
+
+    monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
+
+    def down(*a, **k):
+        raise urllib.error.URLError("connection refused")
+    monkeypatch.setattr(local_llm, "complete", down)
+
+    r = client.post("/api/brain/ask", json={
+        "q": "anyone home?", "project": "proj-x"})
+    assert r.status_code == 502, r.text
+    assert _manifest_rows(client._runs_dir) == [], \
+        "a failed local ask must not claim success in the ledger"

--- a/services/prism-service/tests/integration/test_brain_ask_project_query.py
+++ b/services/prism-service/tests/integration/test_brain_ask_project_query.py
@@ -1,0 +1,82 @@
+"""RED — POST /api/brain/ask must honor the ?project= query param
+(task 8dd3293d).
+
+`AskBody.project` is a BODY-only field with no `Query()` binding, unlike
+sibling `brain/search`, so a standard `?project=prism` call is silently
+ignored and the answer grounds in the empty `default` brain. The fix
+resolves the effective project as query-wins / body-fallback / 'default'
+(mirroring `api/conductor._effective_project`, the 48b965e0 precedent).
+
+Exercises the REAL FastAPI app via TestClient; Brain retrieval and the
+local inference backend are stubbed so pytest never needs Ollama or
+claude.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def client(monkeypatch, tmp_path):
+    import prism_service.api.brain as brain_api
+    import prism_service.services.pi_run_log as prl
+
+    class _FakeBrain:
+        def search(self, q, domain=None, limit=8):
+            return []
+
+    seen: dict = {}
+
+    def _fake_get_project(project):
+        seen["project"] = project
+        return SimpleNamespace(brain_svc=_FakeBrain())
+
+    monkeypatch.setattr(brain_api, "get_project", _fake_get_project)
+
+    pi_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", pi_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", pi_dir / "manifest.jsonl")
+
+    # Route through the local backend and stub the completion so no real
+    # model is invoked — we only care about which project the handler
+    # resolves and echoes.
+    monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
+    from prism_service.inference import local_llm
+    monkeypatch.setattr(
+        local_llm, "complete",
+        lambda prompt, **kw: {"text": "stub", "run_id": "pi-1",
+                              "input_tokens": 1, "output_tokens": 1,
+                              "tokens": 1})
+
+    from fastapi.testclient import TestClient
+    from prism_service.main import app
+    tc = TestClient(app, raise_server_exceptions=False)
+    tc._seen = seen
+    return tc
+
+
+# AC-1 — the query param grounds the answer in the named brain.
+def test_query_param_selects_project(client):
+    r = client.post("/api/brain/ask?project=prism", json={"q": "hi"})
+    assert r.status_code == 200, r.text
+    assert r.json()["project"] == "prism"
+    assert client._seen["project"] == "prism", \
+        "Brain was retrieved from the wrong project"
+
+
+# AC-2 — a body project with no query param is still honored (fallback).
+def test_body_project_still_fallback(client):
+    r = client.post("/api/brain/ask", json={"q": "hi", "project": "beta"})
+    assert r.status_code == 200, r.text
+    assert r.json()["project"] == "beta"
+
+
+# AC-3 — the query param wins when both are supplied.
+def test_query_wins_over_body(client):
+    r = client.post("/api/brain/ask?project=prism",
+                    json={"q": "hi", "project": "beta"})
+    assert r.status_code == 200, r.text
+    assert r.json()["project"] == "prism"

--- a/services/prism-service/tests/integration/test_brain_supernode_label_deconflict.py
+++ b/services/prism-service/tests/integration/test_brain_supernode_label_deconflict.py
@@ -1,0 +1,53 @@
+"""RED scaffold — Brain overview super-node labels must not overprint (task c8b4570e).
+
+The /brain overview (ExplorePage -> the server-rendered /graph/viewer Sigma
+canvas) force-renders the <=5 L0 super-node labels: labelDensity is bypassed
+for super-nodes (level < 3), so after FA2 settles they overprint each other in
+the packed centre ('PRISM Service Core' over 'Devtools Validation Suite',
+'Core Base Types' over 'Core Errors And Models'). The fix deconflicts
+super-node label placement per frame (offset each label off the ones already
+placed) — mirroring the /understand concept graph, whose labels sit clear.
+
+Scans the ACTUAL served Sigma viewer HTML (/graph/viewer) for the deconfliction
+seam. FAILS before the fix: the viewer never measures label width, never resets
+a per-frame label-rect accumulator, and the label drawer has no super-node
+collision-avoidance.
+"""
+
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent  # .../services/prism-service
+_GRAPH_STATIC = _SERVICE_ROOT / "prism_service" / "routes" / "graph_static.py"
+
+
+def _viewer_html() -> str:
+    from prism_service.main import app
+
+    c = TestClient(app)
+    r = c.get("/graph/viewer/prism")
+    assert r.status_code == 200, r.text
+    return r.text
+
+
+def test_viewer_measures_label_width_and_resets_per_frame():
+    html = _viewer_html()
+    # A bounding box needs the label's rendered width; overlap can't be tested
+    # without measuring it. Absent before the fix.
+    assert "measureText" in html, "super-node label width never measured"
+    # The per-frame accumulator of placed label rects must reset each render,
+    # else rects leak across frames and every label reads as colliding.
+    assert "beforeRender" in html, "no per-frame label-rect reset bound"
+
+
+def test_viewer_deconflicts_super_node_labels():
+    html = _viewer_html().lower()
+    # A collision-avoidance accumulator/routine keyed on the super-node labels
+    # (the only force-rendered ones). Absent before the fix.
+    assert any(tok in html for tok in
+               ("superlabelrect", "labelrect", "deconflict")), (
+        "no super-node label collision accumulator / deconflict routine in "
+        "the served viewer"
+    )

--- a/services/prism-service/tests/integration/test_conductor_lean_responses.py
+++ b/services/prism-service/tests/integration/test_conductor_lean_responses.py
@@ -34,6 +34,9 @@ def _isolated_project(tmp_path, monkeypatch, pid="test-lean-resp"):
     from prism_service import config as cfg
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     from prism_service import project_context as pc
     pc._contexts.clear()
     return pid

--- a/services/prism-service/tests/integration/test_conductor_project_body.py
+++ b/services/prism-service/tests/integration/test_conductor_project_body.py
@@ -1,0 +1,123 @@
+"""Conductor routes honor body.project (stress-loop finding 48b965e0).
+
+POST /api/conductor/advance read project ONLY from the query string
+(default 'default') and silently dropped a 'project' key in the JSON
+body, then reported a REAL task as bare 'unknown task'. Every MCP-shaped
+client that passes project in the body (the tasks-API convention) got a
+plausible-but-wrong failure against the wrong project. Contract under
+test: query param wins; body.project is the fallback when the query is
+absent; unknown-task refusals name WHICH project was searched. The
+sibling /api/conductor/gate route shares the same resolver.
+
+Exercises the real FastAPI router via TestClient against an isolated
+PRISM_DATA_DIR so no real project stores are touched.
+"""
+
+import pytest
+
+PROJ = "condbody"
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+def _mk(client, title="conductor body probe"):
+    r = client.post(
+        "/api/tasks", params={"project": PROJ}, json={"title": title},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["task"]["id"]
+
+
+def test_advance_honors_body_project(client):
+    """AC-1: the filed repro — body {project, task_id} with NO query param
+    must advance the real task instead of failing 'unknown task' against
+    the 'default' project."""
+    tid = _mk(client)
+    r = client.post(
+        "/api/conductor/advance",
+        json={"project": PROJ, "task_id": tid},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is True, body
+    assert body.get("to_step") == "review_previous_notes", body
+
+
+def test_query_param_wins_over_body(client):
+    """AC-2: when both are present the query param stays authoritative —
+    the body's project must not redirect the call."""
+    tid = _mk(client)
+    r = client.post(
+        "/api/conductor/advance",
+        params={"project": PROJ},
+        json={"project": "some-other-project", "task_id": tid},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json().get("ok") is True, r.text
+
+
+@pytest.mark.parametrize(
+    "params,body_project,expect_project",
+    [
+        ({"project": PROJ}, None, PROJ),        # query-carried
+        ({}, PROJ, PROJ),                        # body-carried
+        ({}, None, "default"),                   # neither -> default
+    ],
+    ids=["query", "body", "default"],
+)
+def test_unknown_task_reason_names_project(
+    client, params, body_project, expect_project,
+):
+    """AC-3: an unknown-task refusal must say WHICH project was searched,
+    not a bare 'unknown task' that misdirects debugging."""
+    _mk(client)  # ensure the project exists
+    payload = {"task_id": "no-such-task-id"}
+    if body_project:
+        payload["project"] = body_project
+    r = client.post("/api/conductor/advance", params=params, json=payload)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is False, body
+    reason = str(body.get("reason", ""))
+    assert reason != "unknown task", "bare reason must be enriched"
+    assert "no-such-task-id" in reason, reason
+    assert expect_project in reason, reason
+
+
+def test_gate_honors_body_project(client):
+    """AC-4: /api/conductor/gate shares the fallback — a body-project-only
+    call on a real task resolves THAT project (the refusal talks about the
+    gate step, never 'unknown task')."""
+    tid = _mk(client)
+    r = client.post(
+        "/api/conductor/gate",
+        json={"project": PROJ, "task_id": tid, "action": "approve",
+              "reason": "probe"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The task exists but is not on a gate step -> the in-project refusal.
+    assert body.get("ok") is False, body
+    assert "not currently on a gate step" in str(body.get("reason", "")), body
+
+
+def test_gate_unknown_task_reason_names_project(client):
+    """AC-4 (reason half): the gate's unknown-task refusal is enriched the
+    same way as advance's."""
+    _mk(client)
+    r = client.post(
+        "/api/conductor/gate",
+        json={"project": PROJ, "task_id": "ghost-task", "action": "approve",
+              "reason": "probe"},
+    )
+    assert r.status_code == 200, r.text
+    reason = str(r.json().get("reason", ""))
+    assert "ghost-task" in reason and PROJ in reason, reason

--- a/services/prism-service/tests/integration/test_conductor_project_body.py
+++ b/services/prism-service/tests/integration/test_conductor_project_body.py
@@ -25,7 +25,11 @@ def client(tmp_path, monkeypatch):
 
     from prism_service.main import app
 
-    return TestClient(app)
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "condbody"})
+    return c
 
 
 def _mk(client, title="conductor body probe"):

--- a/services/prism-service/tests/integration/test_consolidation_candidates_label.py
+++ b/services/prism-service/tests/integration/test_consolidation_candidates_label.py
@@ -1,0 +1,45 @@
+"""RED scaffold — Consolidation SESSIONS-SCANNED mislabel (task eca12a5f).
+
+STRESS-LOOP FINDING: the /consolidation signal strip renders
+"SESSIONS SCANNED 8", but rollup.sessions_scanned is len(rows) over
+consolidation_candidates (get_signal_rollup) — a COUNT OF REFLECTION
+CANDIDATES, not sessions. /sessions shows 2 imported session outcomes.
+A reader cross-checking the two pages sees 8 vs 2 for "sessions" and
+reads a contradiction, even though the scopes legitimately differ.
+
+Fix (label-only, front-end): the strip labels the count for what it
+actually is — reflection candidates — so no false cross-page
+session contradiction remains.
+
+Source-structure test — scans the real ConsolidationPage render path on
+disk. FAILS today: the rollup.sessions_scanned Kpi is labelled
+"Sessions scanned".
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_CONSOL = (_SERVICE_ROOT / "prism_service" / "web" / "src" / "pages"
+           / "ConsolidationPage.tsx")
+
+
+def test_rollup_count_labelled_candidates_not_sessions():
+    """The Kpi bound to rollup.sessions_scanned must label it as candidates
+    (its true scope), not 'Sessions scanned'."""
+    src = _CONSOL.read_text(encoding="utf-8")
+    # Find the Kpi whose value is rollup.sessions_scanned and read its label.
+    m = re.search(r'label="([^"]*)"\s+value=\{rollup\.sessions_scanned\}', src)
+    assert m, ("could not find the Kpi bound to rollup.sessions_scanned — "
+               "did the value expression change?")
+    label = m.group(1).lower()
+    assert "session" not in label, (
+        f"rollup.sessions_scanned counts consolidation_candidates, not "
+        f"sessions — label {m.group(1)!r} must not say 'session' or it "
+        f"contradicts the /sessions page count"
+    )
+    assert "candidate" in label, (
+        f"label {m.group(1)!r} should name what it counts (candidates)"
+    )

--- a/services/prism-service/tests/integration/test_dashboard_shipped_scope.py
+++ b/services/prism-service/tests/integration/test_dashboard_shipped_scope.py
@@ -1,0 +1,47 @@
+"""RED scaffold — Dashboard shipped-count scope label (task b5f2c78e).
+
+STRESS-LOOP FINDING: the Dashboard shows "TASKS SHIPPED 23" (and Delivery
+flow "23 SHIPPED"), counting EVERY task with a completed_at (roots AND
+children), while the /tasks board shows "COMPLETED → 17" (roots only, by
+the done-tasks-off-board product decision). The two surfaces disagree by
+the 6 completed child subtasks and read as a contradiction for the same
+"completed/shipped" concept.
+
+Fix: the dashboard's shipped metric keeps its all-done scope (roots +
+children) but LABELS that scope explicitly ("incl. subtasks"), so it no
+longer reads as the same number the roots-only board reports.
+
+Source-structure test — scans the real DashboardPage render path on disk.
+FAILS today: the shipped metrics are labelled bare "Tasks shipped" /
+"shipped" with no scope marker.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+_DASH = _SERVICE_ROOT / "prism_service" / "web" / "src" / "pages" / "DashboardPage.tsx"
+
+
+def test_shipped_kpi_declares_subtask_scope():
+    """The trend KPI over flow.completed carries an explicit scope marker."""
+    src = _DASH.read_text(encoding="utf-8")
+    assert "incl. subtasks" in src, (
+        "the dashboard shipped/completed metrics must declare their scope "
+        "(they count roots + children) so they don't contradict the "
+        "roots-only /tasks board 'Completed' count"
+    )
+
+
+def test_bare_tasks_shipped_label_is_scoped():
+    """The bare 'Tasks shipped' label (which read as == board Completed) is
+    replaced by a scoped label."""
+    src = _DASH.read_text(encoding="utf-8")
+    assert 'label="Tasks shipped"' not in src, (
+        "bare 'Tasks shipped' contradicts the roots-only board count — "
+        "scope it to 'Tasks shipped (incl. subtasks)'"
+    )
+    assert 'label="shipped"' not in src, (
+        "bare Delivery-flow 'shipped' stat must be scoped too"
+    )

--- a/services/prism-service/tests/integration/test_dashboard_trendkpi_delta.py
+++ b/services/prism-service/tests/integration/test_dashboard_trendkpi_delta.py
@@ -1,0 +1,57 @@
+"""RED scaffold — Dashboard TrendKpi delta/arrow semantics (task 855ef8aa).
+
+STRESS-LOOP FINDING: the Dashboard "DOCS INDEXED" trend KPI renders
+today's ABSOLUTE count next to a ▲/▼ arrow whose direction is the
+day-over-day rate (today vs prev). A day that ADDED docs (9 today after
+57 yesterday) renders "▼ 9 today", reading as a loss — the arrow encodes
+rate direction while the number encodes an absolute count (mismatched
+semantics).
+
+Fix (option b in the finding): render the SIGNED day-over-day delta
+(today - prev) next to the arrow so the arrow sign and the number share
+one semantic; relabel "today" -> "vs prev day". Then a KPI whose total
+rose never shows the bare absolute count behind a red down-arrow.
+
+Source-structure test — scans the real TrendKpi render path on disk.
+FAILS today: TrendKpi renders `{nf(today)}` behind the arrow with label
+"today" and never computes `today - prev`.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent  # .../services/prism-service
+_DASH = _SERVICE_ROOT / "prism_service" / "web" / "src" / "pages" / "DashboardPage.tsx"
+
+
+def _trendkpi_body() -> str:
+    src = _DASH.read_text(encoding="utf-8")
+    start = src.index("function TrendKpi")
+    end = src.index("function Stat", start)
+    return src[start:end]
+
+
+def test_trendkpi_computes_signed_delta():
+    """The arrow direction is derived from a signed day-over-day delta."""
+    body = _trendkpi_body()
+    assert "today - prev" in body, (
+        "TrendKpi must compute a signed delta (today - prev) so the arrow "
+        "and the shown number share one semantic"
+    )
+
+
+def test_trendkpi_does_not_show_bare_absolute_count_behind_arrow():
+    """The value beside the arrow is the signed delta, never the bare
+    absolute today count that reads as a loss under a red down-arrow."""
+    body = _trendkpi_body()
+    # The buggy render was: {up ? "▲" : "▼"} {nf(today)}</span> today
+    assert "nf(today)" not in body, (
+        "TrendKpi must not render the absolute today count (nf(today)) "
+        "behind the ▲/▼ arrow — show the signed delta instead"
+    )
+    assert not re.search(r">\s*today\s*<", body) and "} today" not in body, (
+        "the 'today' label must become an explicit day-over-day label "
+        "(e.g. 'vs prev day') so an absolute count is never implied"
+    )

--- a/services/prism-service/tests/integration/test_event_bus_emit_seams.py
+++ b/services/prism-service/tests/integration/test_event_bus_emit_seams.py
@@ -55,6 +55,9 @@ def _isolated_project(tmp_path, pid="test-emit-seams"):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     from prism_service import project_context as pc
 
     pc._contexts.clear()

--- a/services/prism-service/tests/integration/test_event_handlers_phase3.py
+++ b/services/prism-service/tests/integration/test_event_handlers_phase3.py
@@ -46,6 +46,9 @@ def project(tmp_path):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-phase3")
     pc._contexts.clear()
     yield "test-phase3"
     cfg.PROJECTS_DIR = original

--- a/services/prism-service/tests/integration/test_event_handlers_phase3.py
+++ b/services/prism-service/tests/integration/test_event_handlers_phase3.py
@@ -564,6 +564,7 @@ def test_session_imported_skips_noise_candidate(project, fresh_bus, monkeypatch)
 # Criterion 4 — a BURST of N imports coalesces into ONE claude -p
 # reflection pass (call count == 1 for the burst).
 # ======================================================================
+@pytest.mark.daemon_exclusive  # task 91ac81e8: event-pool coalescing races the live daemon's bus
 def test_session_imported_burst_coalesces_to_one_pass(
         project, fresh_bus, monkeypatch):
     from prism_service.project_context import get_project
@@ -591,6 +592,7 @@ def test_session_imported_burst_coalesces_to_one_pass(
 # memory is REINFORCED (no new duplicate row; matched memory's signal /
 # recall updated).
 # ======================================================================
+@pytest.mark.daemon_exclusive  # task 91ac81e8: event-pool coalescing races the live daemon's bus
 def test_session_imported_reinforces_instead_of_duplicating(
         project, fresh_bus, monkeypatch):
     from prism_service.project_context import get_project

--- a/services/prism-service/tests/integration/test_implement_source_of_truth_writeback.py
+++ b/services/prism-service/tests/integration/test_implement_source_of_truth_writeback.py
@@ -81,7 +81,10 @@ def _step_schema_block(src: str) -> str:
     """The STEP_SCHEMA object — the per-step structured-output contract that
     every non-locate step returns. AC7's source_tier field belongs here."""
     start = src.index("const STEP_SCHEMA = {")
-    end = src.index("// ── Phase: Pre-flight", start)
+    # 306c01f made implement.js ASCII-only: the box-drawing "── Phase" marker
+    # became plain hyphens, stranding this anchor (the AC7 source_tier
+    # feature itself landed in afd1e1c — these tests assert real substance).
+    end = src.index("// -- Phase: Pre-flight", start)
     return src[start:end]
 
 

--- a/services/prism-service/tests/integration/test_internal_agent_header_title_ui.py
+++ b/services/prism-service/tests/integration/test_internal_agent_header_title_ui.py
@@ -1,0 +1,73 @@
+"""UI acceptance test for: Internal agent page gets a proper header title
+(task 8f92751f-1235-43a4-b392-7d5d6026eabb).
+
+The web app ships no JS test runner, so — exactly as
+test_tasks_timeline_rich_markdown_ui.py and the other *_ui.py tests do —
+the acceptance criteria are pinned by asserting over the TSX SOURCE.
+
+/internal-agent (App.tsx Route -> InternalAgentPage) renders with the
+PageHeader fallback title "PRISM" because PageHeader.tsx's route-title map
+(TITLES) has no "/internal-agent" entry. The fix follows the existing
+longest-prefix-match pattern (resolveTitle): one entry in the TITLES map,
+no bespoke branch.
+
+FAILS at scaffold time because PageHeader.tsx's TITLES map carries no
+"/internal-agent" key (AC-1/AC-2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_WEB = (Path(__file__).resolve().parent.parent.parent
+        / "prism_service" / "web" / "src")
+_PAGE_HEADER = _WEB / "components" / "PageHeader.tsx"
+_APP = _WEB / "App.tsx"
+
+
+def _read(p: Path) -> str:
+    assert p.exists(), f"expected source file missing: {p}"
+    return p.read_text(encoding="utf-8")
+
+
+def _titles_block(src: str) -> str:
+    """The TITLES literal consumed by resolveTitle's longest-prefix lookup."""
+    m = re.search(r"const TITLES[^=]*=\s*\{(.*?)\};", src, re.DOTALL)
+    assert m, "PageHeader.tsx must keep the TITLES route-title map"
+    return m.group(1)
+
+
+# ---- AC-1: TITLES maps /internal-agent -> "Internal agent" -----------------
+
+def test_internal_agent_route_exists():
+    """Precondition seam: the route this title serves is real."""
+    app = _read(_APP)
+    assert '"/internal-agent"' in app, \
+        "App.tsx must route /internal-agent (InternalAgentPage)"
+
+
+def test_titles_map_carries_internal_agent_entry():
+    src = _read(_PAGE_HEADER)
+    block = _titles_block(src)
+    assert re.search(r'"/internal-agent"\s*:\s*"Internal agent"', block), (
+        'AC-1: TITLES in PageHeader.tsx must map "/internal-agent" to '
+        '"Internal agent" so the header does not fall back to "PRISM"'
+    )
+
+
+# ---- AC-2: the title flows through the longest-prefix map, no bespoke branch
+
+def test_mapping_lives_in_titles_map_only():
+    src = _read(_PAGE_HEADER)
+    block = _titles_block(src)
+    # resolveTitle stays the single consumer of TITLES.
+    assert "function resolveTitle" in src and "TITLES[" in src, \
+        "AC-2: resolveTitle's longest-prefix lookup over TITLES must remain"
+    # Every mention of internal-agent sits inside the TITLES literal —
+    # no new conditional special-casing the route outside the map.
+    outside = src.replace(block, "")
+    assert "internal-agent" not in outside, (
+        "AC-2: no bespoke internal-agent branch outside the TITLES map — "
+        "the entry must ride the existing longest-prefix-match pattern"
+    )

--- a/services/prism-service/tests/integration/test_learning_empty_state_crosslink_ui.py
+++ b/services/prism-service/tests/integration/test_learning_empty_state_crosslink_ui.py
@@ -1,0 +1,75 @@
+"""UI acceptance test for: Learning agent-runs empty-state must cross-link to
+the Internal agent page (task 262bc81a-2312-417c-93c3-6b5b295ab5e6).
+
+The /learning "Agent runs · timeline" empty-state reads /api/agent-runs (the
+implement-workflow ingest ledger, empty on this instance) and used to print a
+bare "No agent runs yet" — misleading now that real pi/local inference runs
+DO exist and are surfaced on /internal-agent (a separate /api/pi-runs ledger).
+
+The web app ships no JS test runner, so — exactly as
+test_internal_agent_header_title_ui.py and the other *_ui.py tests do — the
+acceptance criteria are pinned by asserting over the TSX SOURCE.
+
+FAILS at scaffold time because LearningPage.tsx's agentRuns empty-state carries
+no react-router Link to "/internal-agent" (AC-1/AC-2).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_WEB = (Path(__file__).resolve().parent.parent.parent
+        / "prism_service" / "web" / "src")
+_LEARNING = _WEB / "pages" / "LearningPage.tsx"
+_APP = _WEB / "App.tsx"
+
+
+def _read(p: Path) -> str:
+    assert p.exists(), f"expected source file missing: {p}"
+    return p.read_text(encoding="utf-8")
+
+
+def _empty_state_branch(src: str) -> str:
+    """The `agentRuns.length === 0 ? ( ... ) : (` empty-state region — the
+    branch rendered when the agent-runs ledger is empty."""
+    start = src.find("agentRuns.length === 0")
+    assert start != -1, (
+        "LearningPage.tsx must keep the agentRuns empty-state ternary")
+    # Up to the alternative branch marker that closes the empty-state.
+    end = src.find(") : (", start)
+    assert end != -1, "agentRuns empty-state ternary must have an alt branch"
+    return src[start:end]
+
+
+# ---- precondition seam: the route the cross-link targets is real -----------
+
+def test_internal_agent_route_exists():
+    app = _read(_APP)
+    assert '"/internal-agent"' in app, \
+        "App.tsx must route /internal-agent (InternalAgentPage)"
+
+
+# ---- AC-2: the cross-link is a real react-router Link, not a bare anchor ----
+
+def test_learning_imports_react_router_link():
+    src = _read(_LEARNING)
+    assert re.search(
+        r'import\s*\{[^}]*\bLink\b[^}]*\}\s*from\s*"react-router-dom"', src), (
+        'AC-2: LearningPage.tsx must import Link from "react-router-dom" so '
+        "the cross-link navigates in-app (no full page reload)"
+    )
+
+
+# ---- AC-1: the empty-state cross-links to /internal-agent ------------------
+
+def test_empty_state_crosslinks_internal_agent():
+    branch = _empty_state_branch(_read(_LEARNING))
+    assert '<Link' in branch and 'to="/internal-agent"' in branch, (
+        'AC-1: the agentRuns empty-state must render <Link to="/internal-agent"> '
+        "so a reader with zero workflow runs is pointed at the populated "
+        "internal-agent ledger instead of concluding nothing ran"
+    )
+    assert re.search(r"internal", branch, re.I), (
+        "AC-1: the empty-state copy must name the Internal agent surface"
+    )

--- a/services/prism-service/tests/integration/test_learning_loop_self_sustaining.py
+++ b/services/prism-service/tests/integration/test_learning_loop_self_sustaining.py
@@ -29,6 +29,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 _HERE = Path(__file__).resolve()
 _SERVICE_ROOT = _HERE.parent.parent.parent
 if str(_SERVICE_ROOT) not in sys.path:
@@ -256,6 +258,7 @@ def test_task_linked_session_candidate_carries_task_id(tmp_path):
 # =====================================================================
 
 
+@pytest.mark.daemon_exclusive  # task 91ac81e8: reflection worker races the live daemon's loop
 def test_completed_reflection_writes_rollup_and_feeds_outcome(
     tmp_path, monkeypatch
 ):

--- a/services/prism-service/tests/integration/test_local_llm_inference.py
+++ b/services/prism-service/tests/integration/test_local_llm_inference.py
@@ -1,0 +1,160 @@
+"""Red suite — micro-LLM internal inference for self-learning (task ecb90f7e).
+
+PRISM's self-learning loop (reflection -> memory) must be directable at a
+FREE local micro model instead of the claude CLI: a new OpenAI-compatible
+client `prism_service.inference.local_llm` (no API key — INV-1 intact) and
+an env-gated backend switch in reflection_runner
+(PRISM_REFLECTION_BACKEND=local + PRISM_LOCAL_LLM_MODEL/_URL).
+
+Tests run against a stdlib stub server — pytest must never require Ollama.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+_REPO_ROOT = _SERVICE_ROOT.parent.parent
+
+
+class _StubHandler(BaseHTTPRequestHandler):
+    """Minimal OpenAI-compatible /chat/completions endpoint."""
+
+    seen: list[dict] = []
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("content-length", 0))
+        body = json.loads(self.rfile.read(length) or b"{}")
+        type(self).seen.append({"path": self.path, "body": body})
+        payload = json.dumps({
+            "choices": [{"message": {"role": "assistant", "content": "hello world"}}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 7},
+        }).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_):  # silence
+        pass
+
+
+@pytest.fixture()
+def stub_server():
+    _StubHandler.seen = []
+    srv = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        yield f"http://127.0.0.1:{srv.server_port}/v1"
+    finally:
+        srv.shutdown()
+
+
+def test_complete_roundtrips_against_stub(stub_server):
+    """AC-3: local_llm.complete hits <base_url>/chat/completions and returns
+    {text, ms, tokens} — keyless, stdlib-only."""
+    from prism_service.inference import local_llm
+
+    out = local_llm.complete(
+        "say hi", model="stub-model", base_url=stub_server, max_tokens=32,
+    )
+    assert out["text"] == "hello world"
+    assert out["tokens"] == 7
+    assert out["ms"] >= 0
+    req = _StubHandler.seen[-1]
+    assert req["path"].endswith("/chat/completions")
+    assert req["body"]["model"] == "stub-model"
+    assert req["body"]["messages"][-1]["content"] == "say hi"
+
+
+def test_json_mode_and_system_prompt(stub_server):
+    from prism_service.inference import local_llm
+
+    local_llm.complete(
+        "verdict please", model="stub-model", base_url=stub_server,
+        system="You are the reflection engine.", json_mode=True,
+    )
+    body = _StubHandler.seen[-1]["body"]
+    assert body["response_format"] == {"type": "json_object"}
+    assert body["messages"][0]["role"] == "system"
+    assert "reflection engine" in body["messages"][0]["content"]
+
+
+def test_reflection_backend_env_routes_local(monkeypatch):
+    """AC-4: PRISM_REFLECTION_BACKEND=local routes reflection inference
+    through local_llm; claude_cli.invoke must NOT be touched."""
+    from prism_service.inference import claude_cli
+    from prism_service.services import reflection_runner as rr
+
+    monkeypatch.setenv("PRISM_REFLECTION_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+
+    calls: list[dict] = []
+
+    def fake_complete(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"text": '{"worth_learning": false, "new_memories": []}',
+                "ms": 5, "tokens": 12}
+
+    from prism_service.inference import local_llm
+    monkeypatch.setattr(local_llm, "complete", fake_complete)
+
+    def forbidden(*a, **k):
+        raise AssertionError("claude_cli.invoke must not run on the local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+
+    result = rr._invoke_backend(
+        prompt="reflect on this", work_dir=".", plugin_dir=".",
+        max_turns=3, allowed_tools=(), project="p", purpose="prism-reflect",
+    )
+    assert result.exit_code == 0
+    assert "worth_learning" in (result.final_text() or "")
+    assert calls and calls[0]["model"] == "stub-micro"
+
+
+def test_reflection_backend_default_stays_claude(monkeypatch):
+    """Without the env opt-in the seam still delegates to claude_cli."""
+    from prism_service.inference import claude_cli
+    from prism_service.services import reflection_runner as rr
+
+    monkeypatch.delenv("PRISM_REFLECTION_BACKEND", raising=False)
+    hit: list[dict] = []
+
+    class _FakeResult:
+        exit_code = 0
+        run_id = "fake"
+        def final_text(self):
+            return "{}"
+
+    def fake_invoke(**kw):
+        hit.append(kw)
+        return _FakeResult()
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    result = rr._invoke_backend(
+        prompt="reflect", work_dir=".", plugin_dir=".",
+        max_turns=3, allowed_tools=(), project="p", purpose="prism-reflect",
+    )
+    assert result.final_text() == "{}"
+    assert hit and hit[0]["purpose"] == "prism-reflect"
+
+
+def test_bench_harness_self_check():
+    """FR-1: the benchmark harness exists and validates its own task
+    definitions without needing Ollama (--check)."""
+    script = _REPO_ROOT / "benchmarks" / "micro_llm_selflearn" / "run.py"
+    assert script.exists(), f"harness missing: {script}"
+    proc = subprocess.run(
+        [sys.executable, str(script), "--check"],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout

--- a/services/prism-service/tests/integration/test_local_llm_inference.py
+++ b/services/prism-service/tests/integration/test_local_llm_inference.py
@@ -59,6 +59,7 @@ def stub_server():
         srv.shutdown()
 
 
+@pytest.mark.daemon_exclusive  # task 279ef52d: binds a real HTTP server + thread; flakes in-daemon
 def test_complete_roundtrips_against_stub(stub_server):
     """AC-3: local_llm.complete hits <base_url>/chat/completions and returns
     {text, ms, tokens} — keyless, stdlib-only."""
@@ -76,6 +77,7 @@ def test_complete_roundtrips_against_stub(stub_server):
     assert req["body"]["messages"][-1]["content"] == "say hi"
 
 
+@pytest.mark.daemon_exclusive  # task 279ef52d: binds a real HTTP server + thread; flakes in-daemon
 def test_json_mode_and_system_prompt(stub_server):
     from prism_service.inference import local_llm
 

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -19,7 +19,11 @@ def client():
 
     from prism_service.main import app
 
-    return TestClient(app)
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "prism"})
+    return c
 
 
 def test_okf_index_sections_are_memory_only(client):

--- a/services/prism-service/tests/integration/test_okf_api.py
+++ b/services/prism-service/tests/integration/test_okf_api.py
@@ -77,6 +77,24 @@ def test_okf_concept_includes_backlinks_list(client):
 
 
 def test_okf_concept_links_use_memory_id_and_understand_routes(client):
+    # Deterministic on ANY store (a young project has no [[wikilink]]-carrying
+    # memories): seed a linked pair through the PI agent tool passthrough —
+    # the same whitelisted memory_store the left-rail agent uses (711d5235).
+    for name, description in (
+        ("okf-link-target", "Link-target probe for OKF navigability."),
+        ("okf-link-source",
+         "Probes that OKF bodies produce navigable links to [[okf-link-target]]."),
+    ):
+        r = client.post(
+            "/api/agent/tool",
+            params={"project": "prism"},
+            json={"name": "memory_store", "args": {
+                "domain": "okf-test", "name": name, "description": description,
+                "type": "convention", "classification": "tactical",
+            }},
+        )
+        assert r.status_code == 200, r.text
+
     idx = client.get("/api/okf/index", params={"project": "prism"}).json()
     paths = [p for p in idx["paths"] if p.startswith("/memory/")]
     assert paths

--- a/services/prism-service/tests/integration/test_pi_agent_conductor.py
+++ b/services/prism-service/tests/integration/test_pi_agent_conductor.py
@@ -189,7 +189,11 @@ def client(tmp_path, monkeypatch):
 
     from prism_service.main import app
 
-    return TestClient(app)
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "pisdlc"})
+    return c
 
 
 # Task e70cdcda DELIBERATELY flips the old 403-without-internal contract:

--- a/services/prism-service/tests/integration/test_pi_agent_conductor.py
+++ b/services/prism-service/tests/integration/test_pi_agent_conductor.py
@@ -6,11 +6,13 @@ conductor_gate — so a local micro-model agent job can be DIRECTED at SDLC
 work: read a task (task_list by id), author/patch plan_doc sections,
 advance the per-task state machine, and propose gate evidence.
 
-SAFETY (FR-3): the three mutating conductor tools are whitelisted for
-INTERNAL AGENT CALLERS ONLY — POST /api/agent/tool refuses them with 403
-unless the body carries internal=true. The browser PI panel never sends
-the flag, so its reachable surface is unchanged. The subprocess runner
-(pi-runtime.mjs) sends internal=true on every bridged call (FR-4).
+SAFETY history: 9f20b605 gated the three mutating conductor tools to
+INTERNAL callers (403 without internal=true). Task e70cdcda DELIBERATELY
+retired that gate per owner directive — PI IS the orchestrator, so the
+panel drives the SDLC too; INTERNAL_ONLY_TOOLS is now an empty seam and
+the runner still sends internal=true harmlessly on every bridged call.
+Task e70cdcda also ships PI pre-loaded as the PRISM expert: ONE shared
+module (web/pi-expert.mjs) sources the system prompt + 18-tool catalog.
 
 Offline by construction: no Ollama, no live daemon — runner via --check,
 HTTP surface via TestClient against an isolated PRISM_DATA_DIR.
@@ -29,6 +31,20 @@ _SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
 _RUNNER = _SERVICE_ROOT / "prism_service" / "web" / "pi-runtime.mjs"
 
 _CONDUCTOR_TOOLS = ("task_update", "conductor_advance", "conductor_gate")
+
+# The full PRISM-expert catalog (task e70cdcda): PI ships pre-loaded as the
+# PRISM expert — one shared module (web/pi-expert.mjs) sources the system
+# prompt and this 18-tool surface for BOTH the runner and the rail panel.
+_EXPERT_CATALOG = (
+    "brain_search", "brain_understand", "brain_find_symbol", "brain_outline",
+    "brain_find_references", "brain_call_chain",
+    "memory_recall", "memory_store", "memory_invalidate",
+    "task_list", "task_next", "task_create", "task_update",
+    "conductor_advance", "conductor_gate",
+    "workflow_state", "context_bundle", "prism_status",
+)
+
+_EXPERT_MODULE = _SERVICE_ROOT / "prism_service" / "web" / "pi-expert.mjs"
 
 node = shutil.which("node")
 
@@ -51,6 +67,64 @@ def test_runner_check_lists_conductor_tools():
     tools = out.get("tools") or []
     for name in _CONDUCTOR_TOOLS:
         assert name in tools, f"{name} missing from runner tool set: {tools}"
+
+
+@pytest.mark.skipif(node is None, reason="node not installed")
+def test_runner_check_lists_full_expert_catalog():
+    """AC-1 (task e70cdcda): the runner ships pre-loaded as the PRISM
+    expert — --check constructs the FULL 18-tool catalog sourced from the
+    shared pi-expert.mjs module."""
+    proc = subprocess.run(
+        [node, str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(_RUNNER.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = json.loads(proc.stdout)
+    tools = set(out.get("tools") or [])
+    missing = set(_EXPERT_CATALOG) - tools
+    assert not missing, f"expert catalog tools missing from runner: {sorted(missing)}"
+    assert len(tools) == len(_EXPERT_CATALOG), (
+        f"runner tool set drifted from the expert catalog: {sorted(tools)}"
+    )
+
+
+@pytest.mark.skipif(node is None, reason="node not installed")
+def test_runner_check_reports_expert_prompt():
+    """AC-5 (task e70cdcda): the runner defaults an empty job.system to the
+    shared EXPERT_SYSTEM_PROMPT — --check surfaces its length as proof the
+    constant is wired."""
+    proc = subprocess.run(
+        [node, str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(_RUNNER.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = json.loads(proc.stdout)
+    assert out.get("expert_prompt_chars", 0) > 500, (
+        f"expert prompt missing/too small: {out.get('expert_prompt_chars')}"
+    )
+
+
+@pytest.mark.skipif(node is None, reason="node not installed")
+def test_pi_expert_module_parses():
+    """AC-4 (task e70cdcda): pi-expert.mjs is the ONE shared source — it
+    parses as an ES module and pi-runtime.mjs imports its catalog instead
+    of carrying a local TOOL_DEFS literal."""
+    assert _EXPERT_MODULE.exists(), f"shared expert module missing: {_EXPERT_MODULE}"
+    proc = subprocess.run(
+        [node, "--check", str(_EXPERT_MODULE)],
+        capture_output=True, text=True, timeout=60,
+        cwd=str(_EXPERT_MODULE.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    runtime_src = _RUNNER.read_text(encoding="utf-8")
+    assert "pi-expert.mjs" in runtime_src, (
+        "pi-runtime.mjs must import the shared pi-expert.mjs module"
+    )
+    assert "const TOOL_DEFS = {" not in runtime_src, (
+        "pi-runtime.mjs must not duplicate the tool catalog locally"
+    )
 
 
 @pytest.mark.skipif(node is None, reason="node not installed")
@@ -91,6 +165,20 @@ def test_pi_agent_exports_conductor_toolset():
     assert not set(_CONDUCTOR_TOOLS) & set(pi_agent.DEFAULT_TOOLS)
 
 
+def test_pi_agent_exports_expert_toolset():
+    """Task e70cdcda: the FULL expert catalog is a named toolset seam —
+    DEFAULT_TOOLS stays lean for reflection, EXPERT_TOOLS is the whole
+    pre-loaded PRISM surface."""
+    from prism_service.inference import pi_agent
+
+    assert hasattr(pi_agent, "EXPERT_TOOLS"), (
+        "pi_agent.EXPERT_TOOLS expert toolset seam missing"
+    )
+    assert set(pi_agent.EXPERT_TOOLS) == set(_EXPERT_CATALOG)
+    # Reflection default stays lean — the expert surface is opt-in.
+    assert set(pi_agent.DEFAULT_TOOLS) == {"brain_search", "memory_recall"}
+
+
 # ----------------------------------------------------------- HTTP surface
 
 
@@ -104,31 +192,45 @@ def client(tmp_path, monkeypatch):
     return TestClient(app)
 
 
+# Task e70cdcda DELIBERATELY flips the old 403-without-internal contract:
+# per owner directive PI IS the orchestrator, so task_update /
+# conductor_advance / conductor_gate are panel-reachable WITHOUT the
+# internal=true body flag (INTERNAL_ONLY_TOOLS is now an empty seam).
 @pytest.mark.parametrize("name", _CONDUCTOR_TOOLS)
-def test_conductor_tools_require_internal_flag(client, name):
-    """AC-2 (refusal half): the three conductor tools are whitelisted but
-    gated — without internal=true the passthrough must refuse with 403 so
-    the browser panel surface is unchanged."""
+def test_conductor_tools_allowed_without_internal_flag(client, name):
+    """AC-2 (task e70cdcda): the conductor tools dispatch for the panel —
+    no internal flag needed; the call reaches the real handle_tool (an
+    unknown-task refusal is IN-BAND ok=False, not HTTP 403)."""
     r = client.post(
         "/api/agent/tool",
         params={"project": "pisdlc"},
-        json={"name": name, "args": {"id": "whatever"}},
+        json={"name": name, "args": {"id": "no-such-task"}},
     )
-    assert r.status_code == 403, r.text
-    assert "internal" in r.json().get("detail", "").lower(), r.text
+    assert r.status_code == 200, r.text
+    result = r.json().get("result")
+    assert result is not None, r.text
 
 
-@pytest.mark.parametrize("name", _CONDUCTOR_TOOLS)
-def test_conductor_tools_reject_falsy_internal_flag(client, name):
-    """internal must be literally true — a truthy-looking string or false
-    does not open the gate."""
-    for flag in (False, "true", 1):
-        r = client.post(
-            "/api/agent/tool",
-            params={"project": "pisdlc"},
-            json={"name": name, "args": {"id": "whatever"}, "internal": flag},
-        )
-        assert r.status_code == 403, f"internal={flag!r}: {r.text}"
+@pytest.mark.parametrize("name", sorted(
+    {"brain_understand", "brain_find_symbol", "brain_outline",
+     "brain_find_references", "brain_call_chain", "memory_invalidate",
+     "task_next", "workflow_state", "context_bundle"}))
+def test_expert_surface_tools_whitelisted(client, name):
+    """Task e70cdcda: the widened expert surface dispatches through the
+    passthrough (200 + real handle_tool payload, never a 403)."""
+    args = {
+        "brain_find_symbol": {"name": "probe"},
+        "brain_outline": {"source_file": "nope.py"},
+        "brain_find_references": {"name": "probe"},
+        "brain_call_chain": {"entity": "probe"},
+        "memory_invalidate": {"memory_id": "mx-000000"},
+    }.get(name, {})
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={"name": name, "args": args},
+    )
+    assert r.status_code == 200, f"{name}: {r.text}"
 
 
 def _create_task(client, title):

--- a/services/prism-service/tests/integration/test_pi_agent_conductor.py
+++ b/services/prism-service/tests/integration/test_pi_agent_conductor.py
@@ -1,0 +1,218 @@
+"""Red suite — pi agent drives the conductor state machine (task 9f20b605).
+
+Phase 2 of the pi internal agent (phase 1: ac69ee28). The pi runtime tool
+bridge gains the conductor surface — task_update, conductor_advance,
+conductor_gate — so a local micro-model agent job can be DIRECTED at SDLC
+work: read a task (task_list by id), author/patch plan_doc sections,
+advance the per-task state machine, and propose gate evidence.
+
+SAFETY (FR-3): the three mutating conductor tools are whitelisted for
+INTERNAL AGENT CALLERS ONLY — POST /api/agent/tool refuses them with 403
+unless the body carries internal=true. The browser PI panel never sends
+the flag, so its reachable surface is unchanged. The subprocess runner
+(pi-runtime.mjs) sends internal=true on every bridged call (FR-4).
+
+Offline by construction: no Ollama, no live daemon — runner via --check,
+HTTP surface via TestClient against an isolated PRISM_DATA_DIR.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+_RUNNER = _SERVICE_ROOT / "prism_service" / "web" / "pi-runtime.mjs"
+
+_CONDUCTOR_TOOLS = ("task_update", "conductor_advance", "conductor_gate")
+
+node = shutil.which("node")
+
+
+# ---------------------------------------------------------------- runner
+
+
+@pytest.mark.skipif(node is None, reason="node not installed")
+def test_runner_check_lists_conductor_tools():
+    """AC-1: --check constructs the conductor tool defs alongside the
+    phase-1 set — the whitelist names are the REAL MCP tool names."""
+    proc = subprocess.run(
+        [node, str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(_RUNNER.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = json.loads(proc.stdout)
+    assert out.get("ok") is True
+    tools = out.get("tools") or []
+    for name in _CONDUCTOR_TOOLS:
+        assert name in tools, f"{name} missing from runner tool set: {tools}"
+
+
+@pytest.mark.skipif(node is None, reason="node not installed")
+def test_runner_bridge_body_carries_internal_flag():
+    """FR-4: the runner is an internal caller by construction — the body it
+    POSTs to /api/agent/tool carries internal=true (the same helper builds
+    the body for --check and for live execute)."""
+    proc = subprocess.run(
+        [node, str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(_RUNNER.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    out = json.loads(proc.stdout)
+    body = out.get("bridge_body") or {}
+    assert body.get("internal") is True, (
+        f"bridge body must carry internal=true for the internal-only "
+        f"conductor tools: {body}"
+    )
+    assert body.get("name"), body
+    assert isinstance(body.get("args"), dict), body
+
+
+# ------------------------------------------------------------ pi_agent seam
+
+
+def test_pi_agent_exports_conductor_toolset():
+    """The named toolset seam a directed SDLC job composes from."""
+    from prism_service.inference import pi_agent
+
+    assert hasattr(pi_agent, "CONDUCTOR_TOOLS"), (
+        "pi_agent.CONDUCTOR_TOOLS toolset seam missing"
+    )
+    assert set(_CONDUCTOR_TOOLS) <= set(pi_agent.CONDUCTOR_TOOLS)
+    # A directed job also needs to READ the task it is driving.
+    assert "task_list" in pi_agent.CONDUCTOR_TOOLS
+    # The default surface stays read-only — conductor tools are opt-in.
+    assert not set(_CONDUCTOR_TOOLS) & set(pi_agent.DEFAULT_TOOLS)
+
+
+# ----------------------------------------------------------- HTTP surface
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+@pytest.mark.parametrize("name", _CONDUCTOR_TOOLS)
+def test_conductor_tools_require_internal_flag(client, name):
+    """AC-2 (refusal half): the three conductor tools are whitelisted but
+    gated — without internal=true the passthrough must refuse with 403 so
+    the browser panel surface is unchanged."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={"name": name, "args": {"id": "whatever"}},
+    )
+    assert r.status_code == 403, r.text
+    assert "internal" in r.json().get("detail", "").lower(), r.text
+
+
+@pytest.mark.parametrize("name", _CONDUCTOR_TOOLS)
+def test_conductor_tools_reject_falsy_internal_flag(client, name):
+    """internal must be literally true — a truthy-looking string or false
+    does not open the gate."""
+    for flag in (False, "true", 1):
+        r = client.post(
+            "/api/agent/tool",
+            params={"project": "pisdlc"},
+            json={"name": name, "args": {"id": "whatever"}, "internal": flag},
+        )
+        assert r.status_code == 403, f"internal={flag!r}: {r.text}"
+
+
+def _create_task(client, title):
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={"name": "task_create", "args": {"title": title}},
+    )
+    assert r.status_code == 200, r.text
+    task = r.json()["result"]
+    assert task.get("id"), task
+    return task["id"]
+
+
+def test_task_update_with_internal_flag_dispatches(client):
+    """AC-2 (dispatch half): with internal=true, task_update reaches the
+    real handle_tool — a plan_doc round-trips onto an isolated task store."""
+    tid = _create_task(client, "pi conductor probe")
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={
+            "name": "task_update",
+            "args": {"id": tid, "plan_doc": "## Summary\n\npi-authored plan"},
+            "internal": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    r2 = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={"name": "task_list", "args": {"id": tid, "fields": ["id", "plan_doc"]}},
+    )
+    assert r2.status_code == 200, r2.text
+    rows = r2.json()["result"]
+    assert rows and rows[0]["plan_doc"].startswith("## Summary"), rows
+
+
+def test_conductor_advance_with_internal_flag_dispatches(client):
+    """conductor_advance enters the workflow at review_previous_notes —
+    proves the real ConductorService ran, not a mocked echo."""
+    tid = _create_task(client, "pi conductor advance probe")
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={
+            "name": "conductor_advance",
+            "args": {"id": tid, "session_id": "pi-agent-test"},
+            "internal": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    result = r.json()["result"]
+    assert result.get("ok") is True, result
+    assert result.get("to_step") == "review_previous_notes", result
+
+
+def test_conductor_gate_with_internal_flag_dispatches(client):
+    """conductor_gate dispatches for real: on a task NOT sitting on a gate
+    the service refuses in-band (ok=False, 'not currently on a gate') —
+    which proves the call went through the whitelist to the conductor."""
+    tid = _create_task(client, "pi conductor gate probe")
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={
+            "name": "conductor_gate",
+            "args": {"id": tid, "action": "approve",
+                     "reason": "probe evidence", "session_id": "pi-agent-test"},
+            "internal": True,
+        },
+    )
+    assert r.status_code == 200, r.text
+    result = r.json()["result"]
+    assert result.get("ok") is False, result
+    assert "gate" in str(result.get("reason", "")).lower(), result
+
+
+def test_read_tools_still_work_without_internal_flag(client):
+    """NFR-1 regression guard: the phase-1 read surface is unchanged —
+    no flag needed for the panel's whitelisted read tools."""
+    r = client.post(
+        "/api/agent/tool",
+        params={"project": "pisdlc"},
+        json={"name": "prism_status", "args": {}},
+    )
+    assert r.status_code == 200, r.text

--- a/services/prism-service/tests/integration/test_pi_agent_conductor.py
+++ b/services/prism-service/tests/integration/test_pi_agent_conductor.py
@@ -207,8 +207,14 @@ def test_conductor_tools_allowed_without_internal_flag(client, name):
         json={"name": name, "args": {"id": "no-such-task"}},
     )
     assert r.status_code == 200, r.text
-    result = r.json().get("result")
-    assert result is not None, r.text
+    body = r.json()
+    # Task 4f76beb9 refined the passthrough contract: a dispatch that
+    # produces an in-band error (e.g. conductor_gate KeyError on missing
+    # task_id) now surfaces as {ok: false, error} instead of stack noise
+    # under "result". Either shape proves the tool DISPATCHED (never 403).
+    assert body.get("result") is not None or (
+        body.get("ok") is False and body.get("error")
+    ), r.text
 
 
 @pytest.mark.parametrize("name", sorted(

--- a/services/prism-service/tests/integration/test_pi_agent_runtime.py
+++ b/services/prism-service/tests/integration/test_pi_agent_runtime.py
@@ -1,0 +1,118 @@
+"""Red suite — pi as PRISM's internal inference agent (task ac69ee28).
+
+The pi toolkit (Node, pi-agent-core) becomes the internal agent runtime:
+web/pi-runtime.mjs runs the agent loop on the local micro model with PRISM
+tools bridged through /api/agent/tool; inference/pi_agent.py wraps it like
+claude_cli.invoke; PRISM_REFLECTION_BACKEND=pi makes reflection agentic
+(brain_search/memory_recall grounding before the verdict).
+
+No Ollama, no live daemon: --check is offline, plumbing uses a fake runner.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+_RUNNER = _SERVICE_ROOT / "prism_service" / "web" / "pi-runtime.mjs"
+
+node = shutil.which("node")
+pytestmark = pytest.mark.skipif(node is None, reason="node not installed")
+
+
+def test_runner_check_offline():
+    """AC-1: the runner validates pi imports + tool construction offline."""
+    assert _RUNNER.exists(), f"runner missing: {_RUNNER}"
+    proc = subprocess.run(
+        [node, str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120,
+        cwd=str(_RUNNER.parent),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert "ok" in proc.stdout.lower()
+
+
+def test_pi_agent_invoke_plumbing(tmp_path, monkeypatch):
+    """AC-2: pi_agent.invoke spawns the runner, feeds the job on stdin,
+    parses the JSON result. Proven with a fake runner that echoes a canned
+    payload derived from the job."""
+    fake = tmp_path / "fake-runner.mjs"
+    fake.write_text(
+        """
+let raw = "";
+process.stdin.on("data", (c) => (raw += c));
+process.stdin.on("end", () => {
+  const job = JSON.parse(raw);
+  process.stdout.write(JSON.stringify({
+    ok: true,
+    text: `verdict for: ${job.prompt}`,
+    turns: 1,
+    tools_used: [{ name: "memory_recall", ms: 12, ok: true }],
+    ms: 34,
+    tokens: 5,
+    model: job.model,
+  }));
+});
+""",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PRISM_PI_RUNNER", str(fake))
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+
+    from prism_service.inference import pi_agent
+
+    out = pi_agent.invoke("ground this brief", system="expert", allowed_tools=("memory_recall",))
+    assert out["ok"] is True
+    assert out["text"] == "verdict for: ground this brief"
+    assert out["tools_used"][0]["name"] == "memory_recall"
+    assert out["model"] == "stub-micro"
+
+
+def test_pi_agent_invoke_raises_on_garbage_runner(tmp_path, monkeypatch):
+    fake = tmp_path / "broken-runner.mjs"
+    fake.write_text('process.stdout.write("not json"); ', encoding="utf-8")
+    monkeypatch.setenv("PRISM_PI_RUNNER", str(fake))
+
+    from prism_service.inference import pi_agent
+
+    with pytest.raises(pi_agent.PiRuntimeError):
+        pi_agent.invoke("x")
+
+
+def test_reflection_backend_pi_routes_through_pi_agent(monkeypatch):
+    """AC-3: PRISM_REFLECTION_BACKEND=pi routes reflection through
+    pi_agent.invoke; claude_cli must NOT run."""
+    from prism_service.inference import claude_cli, pi_agent
+    from prism_service.services import reflection_runner as rr
+
+    monkeypatch.setenv("PRISM_REFLECTION_BACKEND", "pi")
+    calls: list[dict] = []
+
+    def fake_invoke(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"ok": True, "text": '{"worth_learning": false, "new_memories": []}',
+                "turns": 2, "tools_used": [{"name": "memory_recall", "ms": 9, "ok": True}],
+                "ms": 40, "tokens": 20, "model": "stub-micro"}
+    monkeypatch.setattr(pi_agent, "invoke", fake_invoke)
+
+    def forbidden(*a, **k):
+        raise AssertionError("claude_cli.invoke must not run on the pi backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+
+    result = rr._invoke_backend(
+        prompt="reflect", work_dir=".", plugin_dir=".",
+        max_turns=5, allowed_tools=(), project="p", purpose="prism-reflect",
+    )
+    assert result.exit_code == 0
+    assert "worth_learning" in (result.final_text() or "")
+    assert result.duration_s >= 0
+    assert calls, "pi_agent.invoke was not called"
+    # The agentic backend passes the read tools so the model can ground.
+    assert "brain_search" in (calls[0].get("allowed_tools") or ())
+    assert "memory_recall" in (calls[0].get("allowed_tools") or ())

--- a/services/prism-service/tests/integration/test_pi_drive_telemetry_ui.py
+++ b/services/prism-service/tests/integration/test_pi_drive_telemetry_ui.py
@@ -1,0 +1,59 @@
+"""Source acceptance test — PI drive-loop know-how + telemetry POST (fc08da8d).
+
+The web app ships no JS test runner, so (as the other *_ui.py tests do) the
+acceptance criteria are pinned by asserting over the TS/MJS SOURCE:
+
+  HALF A — web/pi-expert.mjs's EXPERT_SYSTEM_PROMPT must teach an explicit
+    ordered DRIVE loop (not just gate names): the section header + the ordered
+    action verbs mirroring implement.js (author plan_doc -> advance to
+    story_gate -> approve with rubric evidence -> ... -> green_gate).
+
+  HALF B — web/src/lib/piAgent.ts must POST the exchange's usage to the new
+    /api/agent/run endpoint on agent_end, attributing it to the task detected
+    from the conductor/task tool calls.
+
+FAIL today: neither the DRIVE section nor the telemetry POST exists.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_WEB = (Path(__file__).resolve().parent.parent.parent
+        / "prism_service" / "web")
+_EXPERT = _WEB / "pi-expert.mjs"
+_PIAGENT = _WEB / "src" / "lib" / "piAgent.ts"
+
+
+def _read(p: Path) -> str:
+    assert p.exists(), f"expected source file missing: {p}"
+    return p.read_text(encoding="utf-8")
+
+
+def test_pi_expert_has_drive_loop_section():
+    src = _read(_EXPERT)
+    up = src.upper()
+    assert "DRIVING A TASK" in up, "pi-expert must add a DRIVE-loop section"
+    # It teaches the ORDERED action loop, not just step names.
+    assert "plan_doc" in src and "plan_diagram" in src
+    assert "story_gate" in src and "plan_gate" in src
+    assert "red_gate" in src and "green_gate" in src
+    # rubric-evidence discipline: approve carries the FR-n/AC-n oracle evidence.
+    assert "oracle:" in src
+    # Ordered verbs — the loop is actionable (author -> advance -> approve).
+    assert "conductor_advance" in src and "conductor_gate" in src
+
+
+def test_piagent_posts_task_attributed_telemetry_on_agent_end():
+    src = _read(_PIAGENT)
+    # Posts to the new endpoint.
+    assert "/api/agent/run" in src, "piAgent must POST exchange telemetry"
+    # Attribution is captured from conductor/task tool calls.
+    assert "captureTaskAttribution" in src
+    assert "conductor_advance" in src and "task_update" in src
+    # Fired from the terminal agent_end path (best-effort, never blocks).
+    assert "postTelemetry" in src
+    ae = src.index('case "agent_end"')
+    # postTelemetry is invoked within the agent_end handler.
+    assert "postTelemetry" in src[ae:ae + 2000], \
+        "postTelemetry must fire on agent_end"

--- a/services/prism-service/tests/integration/test_pi_multicall_interception.py
+++ b/services/prism-service/tests/integration/test_pi_multicall_interception.py
@@ -1,0 +1,74 @@
+"""RED suite — the interceptor must execute MULTI-call text tool blocks
+(task c4bb21f8; live-confirmed dup 4e5749bc).
+
+The owner-noticed PI panel bug: given a multi-step ask in ONE prompt
+("search the brain for X THEN create a task"), the local model emits the
+whole plan as a single plain-text JSON block — a top-level ARRAY of
+tool-call objects, or several {name,arguments} objects concatenated. The
+old single-object interceptor parsed only ONE object, so nothing executed
+and raw JSON was shown.
+
+The fix extracts a shared parser (web/pi-toolcall.mjs) used by BOTH
+interception surfaces — the Node runner (web/pi-runtime.mjs) and the
+browser panel (web/src/lib/piAgent.ts) — returning an ORDERED LIST of
+{name,args}. These tests pin: (1) the shared parser handles array +
+concatenated inputs, executed as a real node unit check; (2) the runner's
+offline --check reports the multi-call parse; (3) the panel wires the
+shared multi-call parser.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+_WEB = _SERVICE_ROOT / "prism_service" / "web"
+_RUNNER = _WEB / "pi-runtime.mjs"
+_PARSER_TEST = _WEB / "pi-toolcall.test.mjs"
+_PANEL = _WEB / "src" / "lib" / "piAgent.ts"
+
+node = shutil.which("node")
+pytestmark = pytest.mark.skipif(node is None, reason="node not installed")
+
+
+def test_shared_parser_unit_check() -> None:
+    """AC-1: the shared parser (pi-toolcall.mjs) parses single, fenced,
+    array, and concatenated tool-call blocks — proven by its node unit
+    check exiting 0. Covers BOTH surfaces (both import the module)."""
+    assert _PARSER_TEST.exists(), f"missing shared-parser unit check: {_PARSER_TEST}"
+    proc = subprocess.run(
+        [str(node), str(_PARSER_TEST)],
+        capture_output=True, text=True, timeout=120, cwd=str(_WEB),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+
+
+def test_runner_check_reports_multicall() -> None:
+    """AC-2: the Node runner's offline --check validates the multi-call
+    parse and surfaces the counts (array + concatenated each -> 2)."""
+    proc = subprocess.run(
+        [str(node), str(_RUNNER), "--check"],
+        capture_output=True, text=True, timeout=120, cwd=str(_WEB),
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    payload = json.loads(proc.stdout)
+    multicall = payload.get("multicall")
+    assert isinstance(multicall, dict), f"no multicall report in --check: {payload}"
+    assert multicall.get("array") == 2, multicall
+    assert multicall.get("concatenated") == 2, multicall
+
+
+def test_panel_wires_shared_multicall_parser() -> None:
+    """AC-3: the browser panel (piAgent.ts) imports the shared
+    parseTextToolCalls and drives interception from the ORDERED LIST, so
+    the array/concatenated shapes execute rather than render as raw JSON."""
+    src = _PANEL.read_text(encoding="utf-8")
+    assert "pi-toolcall.mjs" in src, "panel does not import the shared parser module"
+    assert "parseTextToolCalls" in src, "panel does not use the multi-call parser"
+    # The interceptor must iterate the list, not a single call.
+    assert src.count("parseTextToolCalls") >= 1

--- a/services/prism-service/tests/integration/test_sessions_tokens_per_file_kpi.py
+++ b/services/prism-service/tests/integration/test_sessions_tokens_per_file_kpi.py
@@ -1,0 +1,46 @@
+"""RED scaffold — Sessions 'TOKENS / FILE' KPI must divide by files READ (task 8c596af6).
+
+/sessions shows a 'Tokens / file' KPI card. With 2 sessions (161,897 tok / 7
+files read; 44,192 tok / 1 file), the card read 206,089 — EXACTLY the raw token
+SUM, not a per-file figure — because the denominator was built from
+`files_modified` (0 for both rows), so the `|| 1` fallback divided by one file.
+Expected ~25,761 = 206,089 / 8 files read (matching mainline 8888's plausible
+per-file value). The fix computes the KPI denominator from `files_read`.
+
+Scans web/src/pages/SessionsPage.tsx. FAILS before the fix: the 'Tokens / file'
+KPI denominator is derived from files_modified, not files_read.
+"""
+
+import re
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent  # .../services/prism-service
+_PAGES = _SERVICE_ROOT / "prism_service" / "web" / "src" / "pages"
+
+
+def _read(page: str) -> str:
+    return (_PAGES / page).read_text(encoding="utf-8")
+
+
+def test_tokens_per_file_kpi_denominator_is_files_read():
+    src = _read("SessionsPage.tsx")
+    m = re.search(r'label="Tokens / file"\s+value=\{([^}]*)\}', src)
+    assert m, "Tokens / file KPI card not found"
+    expr = m.group(1)
+    dm = re.search(r"totalTokens\s*/\s*([A-Za-z_$][\w$]*)", expr)
+    assert dm, "KPI must divide totalTokens by a named denominator: " + expr
+    denom = dm.group(1)
+    # Resolve the denominator variable's definition.
+    defm = re.search(r"\b" + re.escape(denom) + r"\b\s*=\s*([\s\S]*?);", src)
+    assert defm, f"denominator {denom!r} has no definition"
+    defn = defm.group(1)
+    # The per-file denominator must sum files READ, never files_modified.
+    assert "files_read" in defn, (
+        f"Tokens/file denominator {denom!r} is not derived from files_read: "
+        f"{defn.strip()}"
+    )
+    assert "files_modified" not in defn, (
+        f"Tokens/file denominator {denom!r} still uses files_modified: "
+        f"{defn.strip()}"
+    )

--- a/services/prism-service/tests/integration/test_task_dependency_validation.py
+++ b/services/prism-service/tests/integration/test_task_dependency_validation.py
@@ -29,6 +29,14 @@ import pytest
 @pytest.fixture()
 def client(tmp_path, monkeypatch):
     monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    # config.py resolves DATA_DIR/PROJECTS_DIR ONCE at import (config.py:14-17),
+    # so setenv alone never re-points them and every write leaked into the
+    # process's first data dir (finding 33a1397b). Re-point the frozen globals
+    # at this test's tmp dir; the source cache-key fix (keyed by resolved data
+    # dir) then guarantees a fresh, isolated ProjectContext per test.
+    import prism_service.config as _cfg
+    monkeypatch.setattr(_cfg, "DATA_DIR", tmp_path)
+    monkeypatch.setattr(_cfg, "PROJECTS_DIR", tmp_path / "projects")
     from fastapi.testclient import TestClient
 
     from prism_service.main import app

--- a/services/prism-service/tests/integration/test_task_dependency_validation.py
+++ b/services/prism-service/tests/integration/test_task_dependency_validation.py
@@ -1,0 +1,170 @@
+"""Dependency-link integrity (stress finding 47d0179a).
+
+POST /api/tasks (and MCP task_create) persisted `dependencies` with NO
+validation anywhere - phantom uuids, empty strings, and (via service
+callers) self/cyclic dependencies all landed silently, poisoning the
+conductor's dependency-aware scheduling. The earlier belief that deps got
+a 400 was update_task's generic "no fields to update" (REST PATCH does
+not carry the field).
+
+Contract pinned here, mirroring the landed status-enum (16234231,
+63d7aba) and parent-link (24ed8027, 123dea5) precedents - validation in
+TaskService.create/update so BOTH doors share one set of teeth, riding
+the SAME translators (api/tasks.py ValueError -> 422; MCP in-band error):
+
+  * AC-1 phantom dependency ids are 422 on POST, naming the id;
+  * AC-2 empty-string dependency ids are 422;
+  * AC-3 the MCP door surfaces the in-band error and persists nothing;
+  * AC-4 self-dependency is rejected on update;
+  * AC-5 dependency cycles (2-node and deeper) are rejected on update;
+  * AC-6 the epic-seeding shape (create with dependencies=[existing
+    sibling ids], commit ae8abc2's G0-G5 seed) keeps working.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "depval"})
+    return c
+
+
+def _mk(client, title="dep probe", **extra):
+    r = client.post(
+        "/api/tasks", params={"project": "depval"},
+        json={"title": title, **extra},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["task"]["id"]
+
+
+def _get(client, tid):
+    r = client.get(f"/api/tasks/{tid}", params={"project": "depval"})
+    assert r.status_code == 200, r.text
+    return r.json()["task"]
+
+
+def _svc(client):
+    from prism_service.project_context import get_project
+    return get_project("depval").task_svc
+
+
+# ----------------------------------------------------------------------
+# AC-1 / AC-2 - phantom + empty ids are 422 on the REST door
+# ----------------------------------------------------------------------
+
+
+def test_post_phantom_dependency_422(client):
+    """AC-1: the filed repro - a phantom uuid persisted silently."""
+    phantom = "11111111-2222-3333-4444-555555555555"
+    r = client.post(
+        "/api/tasks", params={"project": "depval"},
+        json={"title": "phantom dep probe", "dependencies": [phantom]},
+    )
+    assert r.status_code == 422, (
+        f"phantom dependency must be 422, got {r.status_code}: {r.text[:200]}"
+    )
+    assert phantom in str(r.json().get("detail", "")), r.text
+    # Nothing persisted.
+    listed = client.get("/api/tasks", params={"project": "depval"}).json()["tasks"]
+    assert all(t["title"] != "phantom dep probe" for t in listed)
+
+
+def test_post_empty_dependency_422(client):
+    """AC-2: an empty-string dependency id is meaningless - reject it."""
+    r = client.post(
+        "/api/tasks", params={"project": "depval"},
+        json={"title": "empty dep probe", "dependencies": [""]},
+    )
+    assert r.status_code == 422, (
+        f"empty dependency id must be 422, got {r.status_code}: {r.text[:200]}"
+    )
+
+
+# ----------------------------------------------------------------------
+# AC-3 - the MCP door shares the service-layer teeth
+# ----------------------------------------------------------------------
+
+
+def test_mcp_task_create_phantom_dep_rejected(client):
+    """AC-3: MCP task_create with a phantom dep surfaces the in-band
+    machine-legible error (4f76beb9 contract) and persists nothing."""
+    r = client.post(
+        "/api/agent/tool", params={"project": "depval"},
+        json={"name": "task_create", "args": {
+            "title": "mcp phantom dep probe",
+            "dependencies": ["not-a-real-task-id"],
+        }},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is False, body
+    assert "not-a-real-task-id" in str(body.get("error", "")), body
+    listed = client.get("/api/tasks", params={"project": "depval"}).json()["tasks"]
+    assert all(t["title"] != "mcp phantom dep probe" for t in listed)
+
+
+# ----------------------------------------------------------------------
+# AC-4 / AC-5 - self-dependency and cycles rejected at the service layer
+# (REST PATCH does not carry the field; the service is the shared seam)
+# ----------------------------------------------------------------------
+
+
+def test_update_rejects_self_dependency(client):
+    """AC-4: a task cannot depend on itself."""
+    tid = _mk(client, title="self dep probe")
+    svc = _svc(client)
+    with pytest.raises(ValueError, match="itself"):
+        svc.update(tid, dependencies=[tid])
+    assert _get(client, tid)["dependencies"] == []
+
+
+def test_update_rejects_dependency_cycles(client):
+    """AC-5: the filed repro (A->B then B->A) plus a deeper
+    A->B->C->A chain - any update that closes a cycle is rejected and
+    nothing persists."""
+    a = _mk(client, title="cycle A")
+    b = _mk(client, title="cycle B")
+    c = _mk(client, title="cycle C")
+    svc = _svc(client)
+    # Legit chain: A depends on B, B depends on C.
+    svc.update(a, dependencies=[b])
+    svc.update(b, dependencies=[c])
+    # Two-node cycle: B -> A (A already -> B).
+    with pytest.raises(ValueError, match="[Cc]ycle"):
+        svc.update(b, dependencies=[a])
+    # Deeper cycle: C -> A (A -> B -> C).
+    with pytest.raises(ValueError, match="[Cc]ycle"):
+        svc.update(c, dependencies=[a])
+    assert _get(client, b)["dependencies"] == [c]
+    assert _get(client, c)["dependencies"] == []
+
+
+# ----------------------------------------------------------------------
+# AC-6 - the epic-seeding shape keeps working
+# ----------------------------------------------------------------------
+
+
+def test_epic_seed_shape_still_works(client):
+    """AC-6: create with dependencies=[existing sibling ids] - the
+    G0-G5 epic seed shape (ae8abc2) - still lands and round-trips."""
+    g0 = _mk(client, title="G0 foundations")
+    g1 = _mk(client, title="G1 rails", dependencies=[g0])
+    g2 = _mk(client, title="G2 engine", dependencies=[g0, g1])
+    assert _get(client, g1)["dependencies"] == [g0]
+    assert _get(client, g2)["dependencies"] == [g0, g1]
+    # And a valid dependency update through the service persists.
+    svc = _svc(client)
+    svc.update(g2, dependencies=[g1])
+    assert _get(client, g2)["dependencies"] == [g1]

--- a/services/prism-service/tests/integration/test_task_plan_doc.py
+++ b/services/prism-service/tests/integration/test_task_plan_doc.py
@@ -123,6 +123,9 @@ def _isolated_project(tmp_path, monkeypatch, pid="test-plan-doc"):
     from prism_service import config as cfg
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     from prism_service import project_context as pc
     pc._contexts.clear()
     return pid

--- a/services/prism-service/tests/integration/test_task_session_association.py
+++ b/services/prism-service/tests/integration/test_task_session_association.py
@@ -46,6 +46,9 @@ def _isolated_project(tmp_path, pid="test-task-sessions"):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     from prism_service import project_context as pc
     pc._contexts.clear()
     yield pid

--- a/services/prism-service/tests/integration/test_task_validation_api.py
+++ b/services/prism-service/tests/integration/test_task_validation_api.py
@@ -22,7 +22,11 @@ def client(tmp_path, monkeypatch):
 
     from prism_service.main import app
 
-    return TestClient(app)
+    c = TestClient(app)
+    # get_project no longer creates on miss (d37193da): create the
+    # test project explicitly through the documented affordance.
+    c.post("/api/projects", json={"name": "valtest"})
+    return c
 
 
 def _mk(client, title="probe task", **extra):

--- a/services/prism-service/tests/integration/test_task_validation_api.py
+++ b/services/prism-service/tests/integration/test_task_validation_api.py
@@ -1,0 +1,136 @@
+"""Task-boundary validation (stress-loop findings 16234231 + 24ed8027).
+
+16234231: PATCH /api/tasks/{id} accepted ANY string as status ('bananas'
+persisted, making the task invisible to every status-keyed surface) and
+an unbounded title (10,240 chars accepted, breaking board rendering).
+Validation lives in the SERVICE layer (TaskService.create/update) so the
+REST API and the MCP task_update path are covered by the same teeth:
+api/tasks.py translates the service ValueError into HTTP 422; the MCP
+door surfaces it as its in-band machine-legible error.
+
+Exercises the real FastAPI router via TestClient against an isolated
+PRISM_DATA_DIR so no real project stores are touched.
+"""
+
+import pytest
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PRISM_DATA_DIR", str(tmp_path))
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+def _mk(client, title="probe task", **extra):
+    r = client.post(
+        "/api/tasks", params={"project": "valtest"},
+        json={"title": title, **extra},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()["task"]["id"]
+
+
+def _get(client, tid):
+    r = client.get(f"/api/tasks/{tid}", params={"project": "valtest"})
+    assert r.status_code == 200, r.text
+    return r.json()["task"]
+
+
+# ----------------------------------------------------------------------
+# Status enum (AC-1 / AC-2)
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["bananas", "zzz_fake", "DONE", "pending "])
+def test_patch_invalid_status_422_and_not_persisted(client, bad):
+    """AC-1: the filed repro. An off-enum status is a 422 whose detail
+    names the allowed values, and nothing persists."""
+    tid = _mk(client)
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"status": bad},
+    )
+    assert r.status_code == 422, f"{bad!r}: {r.text}"
+    detail = str(r.json().get("detail", ""))
+    for allowed in ("pending", "in_progress", "done", "blocked"):
+        assert allowed in detail, detail
+    assert _get(client, tid)["status"] == "pending"
+
+
+@pytest.mark.parametrize(
+    "good", ["in_progress", "blocked", "done", "cancelled", "deleted", "pending"],
+)
+def test_patch_valid_statuses_still_work(client, good):
+    """AC-2: every canonical lifecycle + terminal soft state still lands,
+    and done still auto-stamps completed_at."""
+    tid = _mk(client)
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"status": good},
+    )
+    assert r.status_code == 200, f"{good!r}: {r.text}"
+    t = _get(client, tid)
+    assert t["status"] == good
+    if good == "done":
+        assert t["completed_at"], "done must stamp completed_at"
+
+
+# ----------------------------------------------------------------------
+# Title cap (AC-3 / AC-5)
+# ----------------------------------------------------------------------
+
+
+def test_title_cap_enforced_on_create_and_patch(client):
+    """AC-3: >500-char titles are 422 on POST and PATCH, naming the cap.
+    AC-5: exactly 500 chars is accepted on both paths."""
+    huge = "T" * 10_240
+    r = client.post(
+        "/api/tasks", params={"project": "valtest"}, json={"title": huge},
+    )
+    assert r.status_code == 422, r.text
+    assert "500" in str(r.json().get("detail", "")), r.text
+
+    at_cap = "T" * 500
+    tid = _mk(client, title=at_cap)
+    assert _get(client, tid)["title"] == at_cap
+
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"title": "x" * 501},
+    )
+    assert r.status_code == 422, r.text
+    assert "500" in str(r.json().get("detail", "")), r.text
+    assert _get(client, tid)["title"] == at_cap
+
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"title": "renamed within cap"},
+    )
+    assert r.status_code == 200, r.text
+    assert _get(client, tid)["title"] == "renamed within cap"
+
+
+# ----------------------------------------------------------------------
+# The MCP door shares the service-layer teeth (AC-4)
+# ----------------------------------------------------------------------
+
+
+def test_mcp_task_update_invalid_status_rejected(client):
+    """AC-4: probed live on the fork — MCP task_update persisted
+    status='bananas-mcp-probe'. With service-layer validation the same
+    call must surface an in-band error and leave the status untouched."""
+    tid = _mk(client)
+    r = client.post(
+        "/api/agent/tool", params={"project": "valtest"},
+        json={"name": "task_update", "args": {"id": tid, "status": "bananas"}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The 4f76beb9 contract: in-band dispatch errors ride ok:false+error.
+    assert body.get("ok") is False, body
+    assert "status" in str(body.get("error", "")), body
+    assert _get(client, tid)["status"] == "pending"

--- a/services/prism-service/tests/integration/test_task_validation_api.py
+++ b/services/prism-service/tests/integration/test_task_validation_api.py
@@ -134,3 +134,107 @@ def test_mcp_task_update_invalid_status_rejected(client):
     assert body.get("ok") is False, body
     assert "status" in str(body.get("error", "")), body
     assert _get(client, tid)["status"] == "pending"
+# ----------------------------------------------------------------------
+# parent_id integrity (task 24ed8027 — self/cycle/phantom parents)
+# ----------------------------------------------------------------------
+
+
+def test_patch_self_parent_422(client):
+    """AC-1: a task cannot be its own parent."""
+    tid = _mk(client)
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"parent_id": tid},
+    )
+    assert r.status_code == 422, r.text
+    assert "own parent" in str(r.json().get("detail", "")), r.text
+    assert _get(client, tid)["parent_id"] == ""
+
+
+def test_phantom_parent_422_on_patch_and_create(client):
+    """AC-2: a parent id that does not exist is rejected on PATCH and POST,
+    naming the missing id."""
+    tid = _mk(client)
+    r = client.patch(
+        f"/api/tasks/{tid}", params={"project": "valtest"},
+        json={"parent_id": "not-a-real-task-id"},
+    )
+    assert r.status_code == 422, r.text
+    assert "not-a-real-task-id" in str(r.json().get("detail", "")), r.text
+    assert _get(client, tid)["parent_id"] == ""
+
+    r = client.post(
+        "/api/tasks", params={"project": "valtest"},
+        json={"title": "orphan probe", "parent_id": "also-not-real"},
+    )
+    assert r.status_code == 422, r.text
+    assert "also-not-real" in str(r.json().get("detail", "")), r.text
+
+
+def test_ancestor_cycle_422(client):
+    """AC-3: the filed repro (A<->B) plus a deeper A->B->C chain — any
+    re-parent that closes a cycle through the task is rejected and nothing
+    persists."""
+    a = _mk(client, title="cycle A")
+    b = _mk(client, title="cycle B")
+    c = _mk(client, title="cycle C")
+    # Legit chain: B under A, C under B.
+    assert client.patch(
+        f"/api/tasks/{b}", params={"project": "valtest"},
+        json={"parent_id": a},
+    ).status_code == 200
+    assert client.patch(
+        f"/api/tasks/{c}", params={"project": "valtest"},
+        json={"parent_id": b},
+    ).status_code == 200
+    # Two-node cycle: A under B.
+    r = client.patch(
+        f"/api/tasks/{a}", params={"project": "valtest"},
+        json={"parent_id": b},
+    )
+    assert r.status_code == 422, r.text
+    assert "cycle" in str(r.json().get("detail", "")).lower(), r.text
+    # Deeper cycle: A under C (A -> C -> B -> A).
+    r = client.patch(
+        f"/api/tasks/{a}", params={"project": "valtest"},
+        json={"parent_id": c},
+    )
+    assert r.status_code == 422, r.text
+    assert "cycle" in str(r.json().get("detail", "")).lower(), r.text
+    assert _get(client, a)["parent_id"] == ""
+    assert _get(client, b)["parent_id"] == a
+
+
+def test_valid_reparent_still_works(client):
+    """AC-4: legit re-parenting (under a root, then back to root) is
+    unaffected."""
+    root = _mk(client, title="epic root")
+    child = _mk(client, title="child")
+    r = client.patch(
+        f"/api/tasks/{child}", params={"project": "valtest"},
+        json={"parent_id": root},
+    )
+    assert r.status_code == 200, r.text
+    assert _get(client, child)["parent_id"] == root
+    r = client.patch(
+        f"/api/tasks/{child}", params={"project": "valtest"},
+        json={"parent_id": ""},
+    )
+    assert r.status_code == 200, r.text
+    assert _get(client, child)["parent_id"] == ""
+
+
+def test_mcp_task_update_self_parent_rejected(client):
+    """AC-5: the MCP door shares the teeth — parent_id=self surfaces the
+    in-band machine-legible error (4f76beb9 contract) and persists
+    nothing."""
+    tid = _mk(client)
+    r = client.post(
+        "/api/agent/tool", params={"project": "valtest"},
+        json={"name": "task_update", "args": {"id": tid, "parent_id": tid}},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("ok") is False, body
+    assert "parent" in str(body.get("error", "")), body
+    assert _get(client, tid)["parent_id"] == ""

--- a/services/prism-service/tests/integration/test_tasks_timeline_rich_markdown_ui.py
+++ b/services/prism-service/tests/integration/test_tasks_timeline_rich_markdown_ui.py
@@ -74,8 +74,13 @@ def test_markdown_parses_structured_blocks():
     # Unordered lists as real <ul>/<li>, not a run-on paragraph.
     assert "<ul" in md and "<li" in md, "FR-2: lists must render as <ul>/<li>"
     assert "<p" in md, "FR-2: paragraphs must render as <p> blocks"
-    # Inline `code` and **bold**.
-    assert "<code" in md, "FR-2: inline `code` spans must render as <code>"
+    # Inline `code` and **bold**. Backtick spans render through XrefLink
+    # (cb3295a xref cross-linking) — the <code> element itself moved into
+    # XrefLink.tsx, so follow the seam: Markdown must emit XrefLink for
+    # code chips, and XrefLink must still render a real <code>.
+    assert "XrefLink" in md, "FR-2: inline `code` spans must render via XrefLink"
+    xref = _read(_MARKDOWN.parent / "XrefLink.tsx")
+    assert "<code" in xref, "FR-2: XrefLink must render code chips as <code>"
     assert "<strong" in md, "FR-2: **bold** must render as <strong>"
     # The heading/list/bold detection regexes carried over from the block parser.
     assert "^#" in md or r"#\s" in md, "FR-2: heading regex must be present"

--- a/services/prism-service/tests/integration/test_unknown_project_404.py
+++ b/services/prism-service/tests/integration/test_unknown_project_404.py
@@ -1,0 +1,196 @@
+"""Unknown ?project= must not mint phantom projects (stress finding d37193da).
+
+Any /api/* request naming an unknown project silently created a ~1.1MB
+project dir - including plain GETs - because project_context.get_project()
+creates on miss and understand_engine routes even READS of
+understand_state.json through the creating config.project_data_dir().
+The same read path is how the pytest suite leaked test_*0 project dirs
+into the shared data dir (ConductorService._project_source_path derives a
+"project id" from a tmp scores.db path and reads state for it).
+
+Contract pinned here:
+  * reads/writes against an unknown project -> HTTP 404 "unknown project
+    '<p>'" and NOTHING persists (AC-1, AC-2, AC-3);
+  * the missing-param -> 'default' fallback keeps auto-creating (AC-4);
+  * creation stays explicit and working: POST /api/projects (AC-5) and
+    MCP project_onboard (AC-7);
+  * conductor read probes for a non-project id mint nothing (AC-6, the
+    pytest-leak repro).
+
+Assertions run against the EFFECTIVE prism_service.config.PROJECTS_DIR
+(module-level, frozen at first import) - not a monkeypatched env var -
+so the no-dir-minted checks observe the same store the routes write to.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+
+def _projects_dir():
+    from prism_service.config import PROJECTS_DIR
+    return PROJECTS_DIR
+
+
+def _fresh_name(prefix: str = "phantom-probe") -> str:
+    return f"{prefix}-{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture()
+def client():
+    from fastapi.testclient import TestClient
+
+    from prism_service.main import app
+
+    return TestClient(app)
+
+
+def _cleanup_project(client, name: str) -> None:
+    """Best-effort removal of a project a test deliberately created."""
+    try:
+        client.delete(f"/api/projects/{name}")
+    except Exception:
+        pass
+
+
+# ----------------------------------------------------------------------
+# AC-1 / AC-2 / AC-3 - unknown project -> 404, nothing persists
+# ----------------------------------------------------------------------
+
+
+def test_get_tasks_unknown_project_404_no_dir(client):
+    """AC-1: the filed repro - a mere GET minted a project dir + 200."""
+    name = _fresh_name()
+    r = client.get("/api/tasks", params={"project": name})
+    assert r.status_code == 404, (
+        f"GET /api/tasks?project={name} must 404, got {r.status_code}: "
+        f"{r.text[:200]}"
+    )
+    detail = str(r.json().get("detail", ""))
+    assert "unknown project" in detail, detail
+    assert name in detail, detail
+    assert not (_projects_dir() / name).exists(), (
+        "a mere GET minted a project dir on disk"
+    )
+    listed = client.get("/api/projects").json()["projects"]
+    assert name not in listed, "phantom project appeared in /api/projects"
+
+
+def test_post_tasks_unknown_project_404_no_dir(client):
+    """AC-2: a write to an unknown project is a loud 404, not a silent
+    task-into-phantom-board loss."""
+    name = _fresh_name()
+    r = client.post(
+        "/api/tasks", params={"project": name}, json={"title": "x"},
+    )
+    assert r.status_code == 404, (
+        f"POST /api/tasks?project={name} must 404, got {r.status_code}: "
+        f"{r.text[:200]}"
+    )
+    detail = str(r.json().get("detail", ""))
+    assert "unknown project" in detail and name in detail, detail
+    assert not (_projects_dir() / name).exists(), (
+        "a rejected write still minted a project dir"
+    )
+
+
+def test_get_conductor_state_unknown_project_404_no_dir(client):
+    """AC-3: another project-scoped read route shares the contract."""
+    name = _fresh_name()
+    r = client.get("/api/conductor/state", params={"project": name})
+    assert r.status_code == 404, (
+        f"GET /api/conductor/state?project={name} must 404, got "
+        f"{r.status_code}: {r.text[:200]}"
+    )
+    assert "unknown project" in str(r.json().get("detail", ""))
+    assert not (_projects_dir() / name).exists(), (
+        "a conductor read minted a project dir"
+    )
+
+
+# ----------------------------------------------------------------------
+# AC-4 - the long-standing missing-param -> 'default' fallback stays
+# ----------------------------------------------------------------------
+
+
+def test_default_fallback_still_creates(client):
+    """AC-4: no project param -> the task lands in 'default' (which is
+    allowed to auto-create; it is the documented implicit fallback)."""
+    r = client.post("/api/tasks", json={"title": "default-fallback probe"})
+    assert r.status_code == 200, r.text
+    tid = r.json()["task"]["id"]
+    r = client.get(f"/api/tasks/{tid}", params={"project": "default"})
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["title"] == "default-fallback probe"
+
+
+# ----------------------------------------------------------------------
+# AC-5 / AC-7 - creation stays explicit AND working
+# ----------------------------------------------------------------------
+
+
+def test_explicit_create_then_read(client):
+    """AC-5: POST /api/projects is the explicit creation affordance; the
+    project is usable immediately afterwards."""
+    name = _fresh_name("explicit-create")
+    try:
+        r = client.post("/api/projects", json={"name": name})
+        assert r.status_code == 200, r.text
+        assert r.json()["created"] is True
+        r = client.get("/api/tasks", params={"project": name})
+        assert r.status_code == 200, (
+            f"explicitly created project must be readable: {r.text[:200]}"
+        )
+        assert r.json()["tasks"] == []
+    finally:
+        _cleanup_project(client, name)
+
+
+def test_mcp_project_onboard_still_creates(client):
+    """AC-7: MCP project_onboard against a fresh project id is a
+    legitimate creation path and must keep working."""
+    from prism_service.mcp import tools as mcp_tools
+
+    name = _fresh_name("onboard-probe")
+    try:
+        out = mcp_tools._dispatch_tool(
+            "project_onboard",
+            {"project_name": name},
+            project_id=name,
+        )
+        text = "".join(getattr(c, "text", "") or "" for c in out)
+        assert "error" not in text.lower() or "onboard" in text.lower(), text
+        assert (_projects_dir() / name).is_dir(), (
+            "project_onboard must create the project dir"
+        )
+    finally:
+        _cleanup_project(client, name)
+
+
+# ----------------------------------------------------------------------
+# AC-6 - the pytest-leak repro: conductor read probes mint nothing
+# ----------------------------------------------------------------------
+
+
+def test_conductor_probe_mints_no_project_dir(tmp_path):
+    """AC-6: ConductorService resolves a 'project id' from its scores.db
+    parent dir name and reads understand_state.json for it. That READ
+    must not mkdir under the real PROJECTS_DIR - this exact chain leaked
+    8 test_*0 phantom project dirs from the pytest suite."""
+    from prism_service.services.conductor_service import ConductorService
+    from prism_service.services.task_service import TaskService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"),
+        enable_engine=False,
+        task_svc=task_svc,
+    )
+    cond._project_source_path()
+    cond._project_override_dir()
+    leaked = _projects_dir() / tmp_path.name
+    assert not leaked.exists(), (
+        f"read probe minted {leaked} - reads must never create project dirs"
+    )

--- a/services/prism-service/tests/integration/test_unknown_project_404.py
+++ b/services/prism-service/tests/integration/test_unknown_project_404.py
@@ -182,15 +182,20 @@ def test_conductor_probe_mints_no_project_dir(tmp_path):
     from prism_service.services.conductor_service import ConductorService
     from prism_service.services.task_service import TaskService
 
-    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    # Unique dir name -> the derived "project id" is unique per run, so a
+    # phantom leaked by an EARLIER (pre-fix) run can never mask a pass or
+    # fail this assertion spuriously.
+    probe = tmp_path / _fresh_name("leakprobe")
+    probe.mkdir()
+    task_svc = TaskService(str(probe / "tasks.db"))
     cond = ConductorService(
-        str(tmp_path / "scores.db"),
+        str(probe / "scores.db"),
         enable_engine=False,
         task_svc=task_svc,
     )
     cond._project_source_path()
     cond._project_override_dir()
-    leaked = _projects_dir() / tmp_path.name
+    leaked = _projects_dir() / probe.name
     assert not leaked.exists(), (
         f"read probe minted {leaked} - reads must never create project dirs"
     )

--- a/services/prism-service/tests/unit/test_analyzer_runner_backend.py
+++ b/services/prism-service/tests/unit/test_analyzer_runner_backend.py
@@ -1,0 +1,229 @@
+"""Red scaffold — env-gated pi-agent backend for the Understand analyzer runner.
+
+Task 96341ef8 (claude-p-exit epic be898578): `inference.analyzer_runner.
+run_analyzer` shells `claude_cli.invoke` for a ~35-turn Read/Glob/Grep
+file-walk. This adds a PRISM_ANALYZER_BACKEND=pi seam that routes the SAME
+analyzer through the pi-agent runtime (local micro model, keyless) with an
+IDENTICAL return contract, while the default env stays byte-for-byte on
+claude_cli. The pi runtime bridges Brain tools, NOT the Read/Glob/Grep file
+tools an analyzer needs, so a skip-guard falls back to claude when those fs
+tools are absent (a follow-up adds them to the pi catalog — web/** is out of
+this task's scope).
+
+Acceptance criteria pinned here:
+
+  * AC-1 default env (unset) -> claude_cli.invoke, pi_agent.invoke never
+         called; the {payload, tokens_used, wall_clock_s, status, error}
+         contract is unchanged.
+  * AC-2 PRISM_ANALYZER_BACKEND=pi WITH fs tools available routes through
+         pi_agent.invoke (allowed_tools=ANALYZER_FS_TOOLS, project + max_turns
+         + purpose passthrough); claude_cli.invoke never called.
+  * AC-3 the pi path maps the runner result to the IDENTICAL contract:
+         payload parsed the same way, status via the shared classifier,
+         tokens_used from the pi result, wall_clock_s from ms.
+  * AC-4 skip-guard: PRISM_ANALYZER_BACKEND=pi but the pi runtime advertises
+         no Read/Glob/Grep tools -> fall back to claude_cli.invoke (pi never
+         called); documents the follow-up need. Today the real pi catalog
+         has no fs tools, so _pi_has_fs_tools() is False.
+  * AC-5 the pi path routes through pi_agent.invoke, which is the single
+         pi_run_log recording point (backend='pi') — no separate/duplicate
+         claude ledger write on the pi path.
+
+Every test FAILS today: analyzer_runner has no backend seam.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.inference import analyzer_runner as ar  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / stubs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeCliResult:
+    """Stand-in for ClaudeCliResult carrying a single JSON text block."""
+    exit_code: int = 0
+    parsed_events: list = field(default_factory=list)
+    usage: dict = field(default_factory=dict)
+    run_id: str = "claude-run-1"
+    duration_s: float = 0.1
+
+    def final_text(self) -> str:  # parity with the real result
+        return ""
+
+
+def _events_with_text(text: str) -> list:
+    return [{"message": {"content": [{"type": "text", "text": text}]}}]
+
+
+_ARCH_JSON = '{"schema": "architecture_analyzer_v1", "layers": [{"id": "svc"}]}'
+
+
+@pytest.fixture(autouse=True)
+def _stub_source_dir(monkeypatch, tmp_path):
+    """analyzer_runner reads a real prompt file then resolves the source dir;
+    keep the prompt (architecture_analyzer.md ships) but stub the source dir."""
+    monkeypatch.setattr(
+        "prism_service.services.source_service.source_dir_for",
+        lambda project: tmp_path, raising=False,
+    )
+
+
+def _stub_claude(monkeypatch, capture: dict, text: str = _ARCH_JSON):
+    def _invoke(prompt, source_dir=None, **kw):
+        capture["called"] = True
+        capture["kwargs"] = {"prompt": prompt, "source_dir": source_dir, **kw}
+        return _FakeCliResult(
+            exit_code=0, parsed_events=_events_with_text(text),
+            usage={"input_tokens": 10, "output_tokens": 7},
+        )
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _invoke)
+
+
+def _stub_pi(monkeypatch, capture: dict, result: dict):
+    def _invoke(prompt, **kw):
+        capture["called"] = True
+        capture["kwargs"] = {"prompt": prompt, **kw}
+        return result
+    monkeypatch.setattr("prism_service.inference.pi_agent.invoke", _invoke)
+
+
+# ---------------------------------------------------------------------------
+# AC-1: default env -> claude_cli, pi never touched, contract intact
+# ---------------------------------------------------------------------------
+
+def test_default_env_routes_claude_cli(monkeypatch):
+    monkeypatch.delenv("PRISM_ANALYZER_BACKEND", raising=False)
+    claude: dict = {}
+    _stub_claude(monkeypatch, claude)
+
+    def _boom(*a, **k):
+        raise AssertionError("pi_agent.invoke must not run on the default path")
+    monkeypatch.setattr("prism_service.inference.pi_agent.invoke", _boom)
+
+    out = ar.run_analyzer("prism", "architecture_analyzer", "deadbeef")
+    assert claude.get("called") is True
+    assert set(out) == {"payload", "tokens_used", "wall_clock_s",
+                        "status", "error"}
+    assert out["status"] == "complete"
+    assert out["tokens_used"] == 17
+
+
+# ---------------------------------------------------------------------------
+# AC-2 / AC-3: backend=pi with fs tools -> pi path, identical contract
+# ---------------------------------------------------------------------------
+
+def test_pi_backend_routes_pi_agent_with_fs_tools(monkeypatch):
+    monkeypatch.setenv("PRISM_ANALYZER_BACKEND", "pi")
+    monkeypatch.setattr(ar, "_pi_has_fs_tools", lambda: True)
+
+    def _boom(*a, **k):
+        raise AssertionError("claude_cli.invoke must not run on the pi path")
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _boom)
+
+    pi: dict = {}
+    _stub_pi(monkeypatch, pi, {
+        "ok": True, "text": _ARCH_JSON, "tokens": 42, "ms": 1500.0,
+        "turns": 4, "model": "qwen3:1.7b",
+    })
+
+    out = ar.run_analyzer("prism", "architecture_analyzer", "deadbeef",
+                          max_turns=35)
+    assert pi.get("called") is True
+    kw = pi["kwargs"]
+    assert kw.get("allowed_tools") == ar.ANALYZER_FS_TOOLS
+    assert kw.get("project") == "prism"
+    assert kw.get("max_turns") == 35
+    assert "pi" in str(kw.get("purpose", "")).lower()
+    # Identical contract shape + values mapped from the pi result.
+    assert set(out) == {"payload", "tokens_used", "wall_clock_s",
+                        "status", "error"}
+    assert out["status"] == "complete"
+    assert out["tokens_used"] == 42
+    assert out["wall_clock_s"] == pytest.approx(1.5)
+    assert out["payload"]["schema"] == "architecture_analyzer_v1"
+
+
+def test_pi_backend_partial_on_not_ok(monkeypatch):
+    """Parseable payload but ok=False (e.g. max-turns) -> partial, like the
+    claude exit!=0 path."""
+    monkeypatch.setenv("PRISM_ANALYZER_BACKEND", "pi")
+    monkeypatch.setattr(ar, "_pi_has_fs_tools", lambda: True)
+    _stub_pi(monkeypatch, {}, {
+        "ok": False, "text": _ARCH_JSON, "tokens": 5, "ms": 900.0,
+    })
+    out = ar.run_analyzer("prism", "architecture_analyzer", "deadbeef")
+    assert out["status"] == "partial"
+
+
+def test_pi_backend_failed_on_junk_payload(monkeypatch):
+    monkeypatch.setenv("PRISM_ANALYZER_BACKEND", "pi")
+    monkeypatch.setattr(ar, "_pi_has_fs_tools", lambda: True)
+    _stub_pi(monkeypatch, {}, {"ok": True, "text": "sorry, no idea",
+                               "tokens": 3, "ms": 100.0})
+    out = ar.run_analyzer("prism", "architecture_analyzer", "deadbeef")
+    assert out["status"] == "failed"
+    assert out["error"]
+
+
+# ---------------------------------------------------------------------------
+# AC-4: skip-guard — pi requested but fs tools absent -> fall back to claude
+# ---------------------------------------------------------------------------
+
+def test_pi_backend_without_fs_tools_falls_back_to_claude(monkeypatch):
+    monkeypatch.setenv("PRISM_ANALYZER_BACKEND", "pi")
+    # Do NOT patch _pi_has_fs_tools: the real pi catalog has no fs tools.
+    assert ar._pi_has_fs_tools() is False, (
+        "the real pi runtime advertises no Read/Glob/Grep tools yet — "
+        "the skip-guard's premise"
+    )
+    claude: dict = {}
+    _stub_claude(monkeypatch, claude)
+
+    def _boom(*a, **k):
+        raise AssertionError("pi must not run when fs tools are absent")
+    monkeypatch.setattr("prism_service.inference.pi_agent.invoke", _boom)
+
+    out = ar.run_analyzer("prism", "architecture_analyzer", "deadbeef")
+    assert claude.get("called") is True, "must fall back to claude_cli"
+    assert out["status"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# AC-5: the pi path routes through pi_agent.invoke (the pi_run_log recorder)
+# ---------------------------------------------------------------------------
+
+def test_pi_path_uses_pi_agent_recording_point(monkeypatch):
+    """No separate claude ledger write on the pi path — routing exclusively
+    through pi_agent.invoke (which records the backend='pi' pi_run_log row)."""
+    monkeypatch.setenv("PRISM_ANALYZER_BACKEND", "pi")
+    monkeypatch.setattr(ar, "_pi_has_fs_tools", lambda: True)
+
+    calls = {"pi": 0, "claude": 0}
+
+    def _pi(prompt, **kw):
+        calls["pi"] += 1
+        return {"ok": True, "text": _ARCH_JSON, "tokens": 1, "ms": 1.0}
+
+    def _claude(*a, **k):
+        calls["claude"] += 1
+        return _FakeCliResult()
+
+    monkeypatch.setattr("prism_service.inference.pi_agent.invoke", _pi)
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _claude)
+
+    ar.run_analyzer("prism", "architecture_analyzer", "deadbeef")
+    assert calls == {"pi": 1, "claude": 0}

--- a/services/prism-service/tests/unit/test_api_projects_delete.py
+++ b/services/prism-service/tests/unit/test_api_projects_delete.py
@@ -84,11 +84,13 @@ def test_delete_releases_project_context(isolated_projects_root):
     _seed_project("cached-proj")
     # Force a context cache entry.
     project_context.get_project("cached-proj")
-    assert "cached-proj" in project_context._contexts
+    # _contexts is keyed by (resolved_data_dir, project_id) (33a1397b), so
+    # membership is checked on the project-id half of the composite key.
+    assert any(k[1] == "cached-proj" for k in project_context._contexts)
 
     projects_api.delete_project("cached-proj")
 
-    assert "cached-proj" not in project_context._contexts
+    assert not any(k[1] == "cached-proj" for k in project_context._contexts)
 
 
 def test_delete_then_recreate_is_clean_slate(isolated_projects_root):

--- a/services/prism-service/tests/unit/test_brain_call_chain_name_alias.py
+++ b/services/prism-service/tests/unit/test_brain_call_chain_name_alias.py
@@ -1,0 +1,100 @@
+"""brain_call_chain must accept ``name`` as an alias for ``entity`` so an
+agent that standardizes on ``name`` across brain_find_symbol /
+brain_find_references / brain_call_chain never hits a validation error
+(task 0d2d5aeb).
+
+RED before the fix: the dispatch reads ``arguments["entity"]`` (KeyError on a
+name-only call, so call_chain is never reached) and the inputSchema hard-
+requires ``entity`` with no ``name`` property.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_PID = "test-callchain-alias"
+
+
+@pytest.fixture
+def project(tmp_path):
+    from prism_service import config as cfg
+    original = cfg.PROJECTS_DIR
+    cfg.PROJECTS_DIR = tmp_path / "projects"
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da) — seed explicitly.
+    cfg.project_data_dir(_PID)
+    from prism_service import project_context as pc
+    pc._contexts.clear()
+    yield _PID
+    cfg.PROJECTS_DIR = original
+    pc._contexts.clear()
+
+
+def _call(tool, args, project_id):
+    from prism_service.mcp.tools import handle_tool
+    return asyncio.run(handle_tool(tool, args, project_id=project_id))
+
+
+def _capture_call_chain(project_id, monkeypatch):
+    """Stub brain_svc.call_chain to capture the kwargs the dispatch passes."""
+    from prism_service.project_context import get_project
+    ctx = get_project(project_id)
+    captured: dict = {}
+
+    def fake_call_chain(**kwargs):
+        captured.update(kwargs)
+        return []
+
+    monkeypatch.setattr(ctx.brain_svc, "call_chain", fake_call_chain)
+    return captured
+
+
+def test_name_alias_reaches_call_chain(project, monkeypatch):  # AC-1
+    captured = _capture_call_chain(project, monkeypatch)
+    _call("brain_call_chain", {"name": "foo"}, project)
+    assert captured.get("entity") == "foo", (
+        "name alias must supply the entity identifier when entity is absent"
+    )
+
+
+def test_entity_still_works(project, monkeypatch):  # AC-2 (back-compat)
+    captured = _capture_call_chain(project, monkeypatch)
+    _call("brain_call_chain", {"entity": "bar"}, project)
+    assert captured.get("entity") == "bar"
+
+
+def test_entity_wins_when_both_supplied(project, monkeypatch):  # FR-2
+    captured = _capture_call_chain(project, monkeypatch)
+    _call("brain_call_chain", {"entity": "keep", "name": "drop"}, project)
+    assert captured.get("entity") == "keep"
+
+
+def test_missing_both_returns_validation_error(project, monkeypatch):  # FR-3
+    captured = _capture_call_chain(project, monkeypatch)
+    result = _call("brain_call_chain", {}, project)
+    # Neither param → call_chain must NOT be invoked, and the caller gets a
+    # clear textual error rather than an opaque KeyError.
+    assert captured == {}
+    text = result[0].text.lower()
+    assert "entity" in text or "name" in text
+    assert "keyerror" not in text
+
+
+def test_schema_exposes_name_and_not_entity_only():  # AC-3
+    from prism_service.mcp.tools import TOOLS
+    tool = next(t for t in TOOLS if t.name == "brain_call_chain")
+    props = tool.inputSchema["properties"]
+    assert "name" in props, "inputSchema must advertise the canonical `name`"
+    assert "entity" in props, "the `entity` alias must remain for back-compat"
+    assert "entity" not in tool.inputSchema.get("required", []), (
+        "entity must no longer be hard-required on its own"
+    )

--- a/services/prism-service/tests/unit/test_conductor_re_verify_failed_gate.py
+++ b/services/prism-service/tests/unit/test_conductor_re_verify_failed_gate.py
@@ -100,9 +100,13 @@ def _walk_to_gate(cond, task_id: str, gate_id: str) -> None:
         cond.advance_task(task_id)
 
 
-def _manual_override_rows(task_svc, task_id: str) -> list:
+def _manual_override_rows(task_svc, task_id: str, gate: str = "green_gate") -> list:
+    """manual-override gate_decide rows for a SPECIFIC gate. The _walk_to_gate
+    helper clears earlier gates (story/plan/red) with override, so scope the
+    honesty assertion to the gate under test."""
     return [r for r in task_svc.history(task_id)
-            if r.action == "gate_decide" and r.actor == "manual-override"]
+            if r.action == "gate_decide" and r.actor == "manual-override"
+            and f"gate={gate}" in (r.details or "")]
 
 
 # ----------------------------------------------------------------------

--- a/services/prism-service/tests/unit/test_conductor_re_verify_failed_gate.py
+++ b/services/prism-service/tests/unit/test_conductor_re_verify_failed_gate.py
@@ -1,0 +1,236 @@
+"""Honest re-verify path for a latched-failed gate (task 19e31e88).
+
+A green_gate/red_gate that latched ``gate_state='failed'`` (often from a
+transient/env artifact during the verifier run) could previously ONLY be
+cleared with ``approve + override=True`` — override bookkeeping for what
+should be a clean re-verify. These tests pin the new ``re_verify`` flag:
+``approve`` on a FAILED gate with ``re_verify=True`` (NOT override) resets
+the gate to pending, re-runs the VerifierService fresh, and releases ONLY
+if the verifier now passes — a normal verifier-passed release with NO
+override actor and NO manual-override audit row. A genuinely red slice
+still cannot re-arm green via re_verify (the verifier still fails it).
+
+Backend-only tests with a scripted FakeVerifier (no shelling out).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Optional
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+class FakeVerifier:
+    """Returns scripted results in order (``.script``) so a first FAIL then
+    a later PASS can simulate a transient artifact clearing on re-verify."""
+
+    def __init__(self, result: Optional[dict] = None) -> None:
+        self.calls: list[dict] = []
+        self.next_result: Optional[dict] = result
+        self.script: list[dict] = []
+
+    def run(self, **kwargs: object) -> dict:
+        self.calls.append(dict(kwargs))
+        if self.script:
+            return self.script.pop(0)
+        assert self.next_result is not None, "FakeVerifier has no result queued"
+        return self.next_result
+
+
+_FAIL = {"status": "fail", "tier0": "fail", "tier1": "not-run",
+         "tier2": "skipped", "summary": "2 tests failing (transient)"}
+_PASS = {"status": "pass", "tier0": "pass", "tier1": "pass",
+         "tier2": "skipped", "summary": "all green"}
+
+# green_gate artifact tooth (proof_type unset -> test shape) wants a runner
+# + a pass signal in the decision reason.
+_GREEN_REASON = "re-verify: pytest -q -> 320 passed, 0 failed (tree now green)"
+
+
+def _services(tmp_path, verifier: Optional[FakeVerifier] = None):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"),
+        enable_engine=False,
+        task_svc=task_svc,
+        verifier_svc=verifier,
+    )
+    return task_svc, cond
+
+
+def _workflow():
+    from prism_service.models.workflow import WORKFLOW_STEPS
+
+    return WORKFLOW_STEPS
+
+
+def _green_gate_id() -> str:
+    return "green_gate"
+
+
+def _walk_to_gate(cond, task_id: str, gate_id: str) -> None:
+    """Advance to gate_id, clearing earlier pending gates with a distinct-actor
+    override approve carrying a real failing-test trace (artifact tooth)."""
+    steps = _workflow()
+    target_idx = next(i for i, s in enumerate(steps) if s["id"] == gate_id)
+    guard = (target_idx + 1) * 3
+    cleared = 0
+    while guard > 0:
+        guard -= 1
+        snap = cond._task_svc.get(task_id)
+        if snap.workflow_step == gate_id and snap.gate_state == "pending":
+            return
+        if snap.gate_state == "pending":
+            cleared += 1
+            cond.gate_decide(
+                task_id, action="approve",
+                reason=("walk_to_gate intermediate; independent re-run: "
+                        "pytest -q -> 1 failed"),
+                override=True, actor=f"walk-bot-{cleared}",
+                session_id=f"walk-bot-{cleared}")
+            continue
+        cond.advance_task(task_id)
+
+
+def _manual_override_rows(task_svc, task_id: str) -> list:
+    return [r for r in task_svc.history(task_id)
+            if r.action == "gate_decide" and r.actor == "manual-override"]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — re_verify releases a failed gate whose tree is now green, on merit
+# ----------------------------------------------------------------------
+
+
+def test_re_verify_releases_failed_gate_when_tree_now_green(tmp_path):
+    verifier = FakeVerifier()
+    verifier.script = [dict(_FAIL), dict(_PASS)]
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(title="re-verify clears transient failure")
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    # First, a fresh verifier FAIL latches gate_state='failed' (the transient).
+    first = cond.gate_decide(t.id, action="approve", reason=_GREEN_REASON)
+    assert first["ok"] is False
+    assert task_svc.get(t.id).gate_state == "failed"
+
+    # Now the tree is green — re_verify (NOT override) re-runs the verifier and
+    # releases on merit.
+    result = cond.gate_decide(
+        t.id, action="approve", reason=_GREEN_REASON, re_verify=True)
+
+    assert result["ok"] is True
+    assert result["gate_state"] == "passed"
+    assert result["verifier"]["status"] == "pass"
+    # Honest release: NOT an override.
+    assert result.get("override") is not True
+    # The verifier was re-consulted fresh (once for the fail, once for re_verify).
+    assert len(verifier.calls) == 2
+    # NO manual-override audit row was written by the re_verify release.
+    assert _manual_override_rows(task_svc, t.id) == []
+    # A gate_decide row records the verifier pass under actor='conductor'.
+    passed_rows = [r for r in task_svc.history(t.id)
+                   if r.action == "gate_decide" and "verifier=pass" in r.details]
+    assert passed_rows and passed_rows[-1].actor == "conductor"
+
+
+# ----------------------------------------------------------------------
+# AC-2 — a still-red slice cannot re-arm green via re_verify
+# ----------------------------------------------------------------------
+
+
+def test_re_verify_stays_failed_when_verifier_still_fails(tmp_path):
+    verifier = FakeVerifier()
+    verifier.script = [dict(_FAIL), dict(_FAIL)]
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(title="re-verify on a genuinely red slice")
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    first = cond.gate_decide(t.id, action="approve", reason=_GREEN_REASON)
+    assert first["ok"] is False
+
+    result = cond.gate_decide(
+        t.id, action="approve", reason=_GREEN_REASON, re_verify=True)
+
+    assert result["ok"] is False
+    assert result["gate_state"] == "failed"
+    refreshed = task_svc.get(t.id)
+    assert refreshed.gate_state == "failed"
+    assert refreshed.gate_reason  # a fresh reason is recorded
+    # No dishonest release: no manual-override row either.
+    assert _manual_override_rows(task_svc, t.id) == []
+
+
+# ----------------------------------------------------------------------
+# AC-3 — re_verify needs a verifier to re-run
+# ----------------------------------------------------------------------
+
+
+def test_re_verify_requires_attached_verifier(tmp_path):
+    task_svc, cond = _services(tmp_path, verifier=None)
+    t = task_svc.create(title="re-verify with no verifier")
+    _walk_to_gate(cond, t.id, _green_gate_id())
+    # Latch failed via reject (no verifier available to fail it).
+    cond.gate_decide(t.id, action="reject", reason="latched failed for test")
+    assert task_svc.get(t.id).gate_state == "failed"
+
+    result = cond.gate_decide(
+        t.id, action="approve", reason=_GREEN_REASON, re_verify=True)
+
+    assert result["ok"] is False
+    assert "verifier" in result["reason"].lower()
+    assert task_svc.get(t.id).gate_state == "failed"
+
+
+# ----------------------------------------------------------------------
+# AC-4 — override path unchanged; plain approve on a failed gate still refused
+# ----------------------------------------------------------------------
+
+
+def test_override_path_unchanged_on_failed_gate(tmp_path):
+    verifier = FakeVerifier()
+    verifier.script = [dict(_FAIL)]
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(title="override still recovers a failed gate")
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    first = cond.gate_decide(t.id, action="approve", reason=_GREEN_REASON)
+    assert first["ok"] is False
+    calls_before = len(verifier.calls)
+
+    # Distinct-actor override recovers the failed gate, tags manual-override,
+    # and does NOT consult the verifier.
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason=("qa judgment: env blip; independent re-run: "
+                "pytest -q -> 320 passed, 0 failed"),
+        override=True, actor="independent-verifier", session_id="iv-1")
+    assert result["ok"] is True
+    assert result["gate_state"] == "passed"
+    assert result["override"] is True
+    assert len(verifier.calls) == calls_before  # verifier NOT re-consulted
+    assert _manual_override_rows(task_svc, t.id)  # audit row present
+
+
+def test_failed_gate_plain_approve_still_refused(tmp_path):
+    verifier = FakeVerifier()
+    verifier.script = [dict(_FAIL)]
+    task_svc, cond = _services(tmp_path, verifier)
+    t = task_svc.create(title="plain approve cannot clear a failed gate")
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    first = cond.gate_decide(t.id, action="approve", reason=_GREEN_REASON)
+    assert first["ok"] is False
+
+    # No override, no re_verify -> still refused, gate stays failed.
+    result = cond.gate_decide(t.id, action="approve", reason=_GREEN_REASON)
+    assert result["ok"] is False
+    assert task_svc.get(t.id).gate_state == "failed"

--- a/services/prism-service/tests/unit/test_context_builder.py
+++ b/services/prism-service/tests/unit/test_context_builder.py
@@ -22,6 +22,9 @@ def project(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("context-pack-test")
     pc._contexts.clear()
     yield "context-pack-test"
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_event_handlers_backend_seam.py
+++ b/services/prism-service/tests/unit/test_event_handlers_backend_seam.py
@@ -5,7 +5,9 @@ event_handlers has the bus's two direct `claude -p` sites:
   * _summarize_haiku (:191) — novel memory.written summary, haiku-pinned,
     tool-less. Must route through memory_summary_worker._invoke_backend so
     PRISM_MEMORY_SUMMARY_BACKEND=local serves it from the local micro model
-    (with a claude_runs ledger row), while the default keeps the haiku pin.
+    (with a pi_runs audit-ledger row — task d1d4fe00: pi_runs is THE
+    ledger for pi|local runs; claude_runs stays claude-only), while the
+    default keeps the haiku pin.
   * _reflect_once (:319) — session.imported coalesced reflect. Must
     delegate to reflection_runner._invoke_backend so PRISM_REFLECTION_
     BACKEND=local|pi applies; default stays claude with the same args.
@@ -124,33 +126,50 @@ def test_novelty_summary_default_stays_haiku_claude(tmp_path, monkeypatch):
 
 
 # ----------------------------------------------------------------------
-# AC-2 — novelty summary local backend: no claude, ledger row recorded.
+# AC-2 — novelty summary local backend: no claude, pi_runs row recorded
+# (task d1d4fe00: pi_runs owns pi|local; claude_runs stays claude-only).
 # ----------------------------------------------------------------------
 def test_novelty_summary_local_backend_routes_and_records(
         tmp_path, monkeypatch, isolated_runs_dir, forbid_claude):
+    import io
+
     from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
     from prism_service.services import event_handlers as eh
+
+    pi_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", pi_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", pi_dir / "manifest.jsonl")
 
     monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
     monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
-    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
-        "text": "Local tile sentence.", "ms": 4.0, "tokens": 6,
-        "input_tokens": 17, "output_tokens": 6,
-    })
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    payload = json.dumps({
+        "choices": [{"message": {"content": "Local tile sentence."}}],
+        "usage": {"prompt_tokens": 17, "completion_tokens": 6},
+    }).encode()
+    monkeypatch.setattr(local_llm.urllib.request, "urlopen",
+                        lambda req, timeout=0: _Resp(payload))
 
     mem = _FakeMem()
     eh._summarize_haiku(_fake_ctx(tmp_path), mem, _entry())
 
     assert mem.updates == [("m1", "Local tile sentence.")]
-    manifest = isolated_runs_dir / "manifest.jsonl"
-    assert manifest.exists(), "local run must land in the claude_runs ledger"
-    rows = [json.loads(ln) for ln in
-            manifest.read_text(encoding="utf-8").splitlines() if ln.strip()]
-    assert len(rows) == 1
+    rows = prl.list_recent(limit=10)
+    assert len(rows) == 1, "local run must land in the pi_runs ledger"
     assert rows[0]["backend"] == "local"
     assert rows[0]["purpose"] == "memory_summary"
     assert rows[0]["input_tokens"] == 17
     assert rows[0]["output_tokens"] == 6
+    assert not (isolated_runs_dir / "manifest.jsonl").exists(), \
+        "claude_runs must stay claude-only — no local seam rows"
 
 
 # ----------------------------------------------------------------------

--- a/services/prism-service/tests/unit/test_event_handlers_backend_seam.py
+++ b/services/prism-service/tests/unit/test_event_handlers_backend_seam.py
@@ -1,0 +1,214 @@
+"""Red suite — event-bus inference routes through env-gated backend seams
+(task cba42d6b, claude-p-exit epic be898578).
+
+event_handlers has the bus's two direct `claude -p` sites:
+  * _summarize_haiku (:191) — novel memory.written summary, haiku-pinned,
+    tool-less. Must route through memory_summary_worker._invoke_backend so
+    PRISM_MEMORY_SUMMARY_BACKEND=local serves it from the local micro model
+    (with a claude_runs ledger row), while the default keeps the haiku pin.
+  * _reflect_once (:319) — session.imported coalesced reflect. Must
+    delegate to reflection_runner._invoke_backend so PRISM_REFLECTION_
+    BACKEND=local|pi applies; default stays claude with the same args.
+
+All stubs — pytest never needs Ollama or the claude CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+
+# ----------------------------------------------------------------------
+# Fakes
+# ----------------------------------------------------------------------
+class _FakeMem:
+    def __init__(self):
+        self.updates: list[tuple[str, str]] = []
+
+    def update_entry(self, entry_id, **kw):
+        self.updates.append((entry_id, kw.get("summary", "")))
+
+
+def _fake_ctx(tmp_path):
+    return SimpleNamespace(_data_dir=tmp_path)
+
+
+def _entry():
+    return SimpleNamespace(id="m1", name="mem-name", description="mem-desc")
+
+
+class _FakeCliResult:
+    def __init__(self, text):
+        self._text = text
+        self.exit_code = 0
+        self.run_id = "fake-claude"
+        self.duration_s = 0.1
+
+    def final_text(self):
+        return self._text
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    import prism_service.services.claude_run_log as crl
+    runs_dir = tmp_path / "claude_runs"
+    monkeypatch.setattr(crl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(crl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+@pytest.fixture
+def forbid_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+
+    def forbidden(*a, **k):
+        raise AssertionError(
+            "claude_cli.invoke must not run on a local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+
+
+def _scores_db(tmp_path):
+    db = str(tmp_path / "scores.db")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE consolidation_candidates ("
+        " id TEXT PRIMARY KEY, task_id TEXT, session_id TEXT,"
+        " scope_json TEXT, trigger TEXT, status TEXT, queued_at TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO consolidation_candidates "
+        "(id, task_id, session_id, scope_json, trigger, status, queued_at) "
+        "VALUES ('cand1', 't1', 's1', '{}', 'test', 'pending', '2026-01-01')"
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+# ----------------------------------------------------------------------
+# AC-1 — novelty summary default path keeps the haiku pin via claude.
+# ----------------------------------------------------------------------
+def test_novelty_summary_default_stays_haiku_claude(tmp_path, monkeypatch):
+    from prism_service.inference import claude_cli, local_llm
+    from prism_service.services import event_handlers as eh
+
+    monkeypatch.delenv("PRISM_MEMORY_SUMMARY_BACKEND", raising=False)
+    monkeypatch.setattr(
+        local_llm, "complete",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("local_llm must not run on the default path")))
+
+    seen: list[dict] = []
+
+    def fake_invoke(**kw):
+        seen.append(kw)
+        return _FakeCliResult("One clean sentence.")
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    mem = _FakeMem()
+    eh._summarize_haiku(_fake_ctx(tmp_path), mem, _entry())
+
+    assert mem.updates == [("m1", "One clean sentence.")]
+    assert seen, "claude_cli.invoke was not called on the default path"
+    kw = seen[0]
+    assert kw["model"] == "haiku"          # criterion 7 pin preserved
+    assert kw["max_turns"] == 1
+    assert kw["allowed_tools"] == ()
+    assert kw["purpose"] == "memory_summary"
+    from prism_service.services.memory_summary_worker import render_prompt
+    assert kw["prompt"] == render_prompt("mem-name", "mem-desc")
+
+
+# ----------------------------------------------------------------------
+# AC-2 — novelty summary local backend: no claude, ledger row recorded.
+# ----------------------------------------------------------------------
+def test_novelty_summary_local_backend_routes_and_records(
+        tmp_path, monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import event_handlers as eh
+
+    monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
+        "text": "Local tile sentence.", "ms": 4.0, "tokens": 6,
+        "input_tokens": 17, "output_tokens": 6,
+    })
+
+    mem = _FakeMem()
+    eh._summarize_haiku(_fake_ctx(tmp_path), mem, _entry())
+
+    assert mem.updates == [("m1", "Local tile sentence.")]
+    manifest = isolated_runs_dir / "manifest.jsonl"
+    assert manifest.exists(), "local run must land in the claude_runs ledger"
+    rows = [json.loads(ln) for ln in
+            manifest.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(rows) == 1
+    assert rows[0]["backend"] == "local"
+    assert rows[0]["purpose"] == "memory_summary"
+    assert rows[0]["input_tokens"] == 17
+    assert rows[0]["output_tokens"] == 6
+
+
+# ----------------------------------------------------------------------
+# AC-3 — coalesced reflect default path stays claude with the same args.
+# ----------------------------------------------------------------------
+def test_reflect_once_default_stays_claude(tmp_path, monkeypatch):
+    from prism_service.inference import claude_cli, local_llm
+    from prism_service.services import event_handlers as eh
+    from prism_service.services import reflection_runner as rr
+
+    monkeypatch.delenv("PRISM_REFLECTION_BACKEND", raising=False)
+    monkeypatch.setattr(
+        local_llm, "complete",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("local_llm must not run on the default path")))
+
+    seen: list[dict] = []
+    verdict_json = '{"worth_learning": false, "new_memories": []}'
+
+    def fake_invoke(**kw):
+        seen.append(kw)
+        return _FakeCliResult(verdict_json)
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    db = _scores_db(tmp_path)
+    verdict = eh._reflect_once(
+        "no-such-project", _fake_ctx(tmp_path), db, "cand1")
+
+    assert verdict == {"worth_learning": False, "new_memories": []}
+    assert seen, "claude_cli.invoke was not called on the default path"
+    kw = seen[0]
+    assert kw["max_turns"] == 15
+    assert tuple(kw["allowed_tools"]) == tuple(rr.DEFAULT_REFLECT_TOOLS)
+    assert kw["purpose"] == "prism-reflect"
+
+
+# ----------------------------------------------------------------------
+# AC-4 — coalesced reflect honors PRISM_REFLECTION_BACKEND=local.
+# ----------------------------------------------------------------------
+def test_reflect_once_local_backend(tmp_path, monkeypatch, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import event_handlers as eh
+
+    monkeypatch.setenv("PRISM_REFLECTION_BACKEND", "local")
+    calls: list[dict] = []
+
+    def fake_complete(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"text": '{"worth_learning": true, "new_memories": []}',
+                "ms": 8.0, "tokens": 15,
+                "input_tokens": 40, "output_tokens": 15}
+    monkeypatch.setattr(local_llm, "complete", fake_complete)
+
+    db = _scores_db(tmp_path)
+    verdict = eh._reflect_once(
+        "no-such-project", _fake_ctx(tmp_path), db, "cand1")
+
+    assert verdict == {"worth_learning": True, "new_memories": []}
+    assert calls, "local_llm.complete was not reached via the reflection seam"
+    # The reflect brief itself must be the prompt (contract unchanged).
+    assert "reflection sub-agent" in calls[0]["prompt"]

--- a/services/prism-service/tests/unit/test_full_outcome_complete.py
+++ b/services/prism-service/tests/unit/test_full_outcome_complete.py
@@ -58,6 +58,9 @@ def project(tmp_path, monkeypatch):
     from prism_service import project_context as pc
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-outcome")
     pc._contexts.clear()
     yield "test-outcome"
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_graph_enrich_backend.py
+++ b/services/prism-service/tests/unit/test_graph_enrich_backend.py
@@ -5,11 +5,12 @@ graph_enrich.enrich_one must route through an env-gated backend seam
 mirroring memory_summary_worker._invoke_backend: PRISM_GRAPH_ENRICH_
 BACKEND=local -> inference/local_llm.complete (json_mode) with the
 unchanged render_prompt(scope) contract; default (unset) stays
-claude_cli.invoke byte-for-byte. The local path records an equivalent
-claude_runs manifest row (backend='local' + input/output token counts)
-via claude_run_log.record_local_run, the _parse truncation contract
-(name<=60, purpose<=160, ("","") on failure) is unchanged, and the
-graph_annotations provenance string reflects the active backend.
+claude_cli.invoke byte-for-byte. The local run is recorded by
+local_llm.complete ITSELF into the pi_runs audit ledger (backend='local'
++ input/output token split; task d1d4fe00 — pi_runs is THE ledger for
+pi|local runs, claude_runs stays claude-only), the _parse truncation
+contract (name<=60, purpose<=160, ("","") on failure) is unchanged, and
+the graph_annotations provenance string reflects the active backend.
 
 All stubs — pytest never needs Ollama or the claude CLI.
 """
@@ -136,39 +137,55 @@ def test_local_backend_routes_local_llm(
 
 
 # ----------------------------------------------------------------------
-# AC-3 — the local run lands in the claude_runs ledger with tokens.
+# AC-3 — the local run lands in the pi_runs audit ledger with the token
+# split; claude_runs stays claude-only (task d1d4fe00 reconciliation).
 # ----------------------------------------------------------------------
 def test_local_run_lands_in_ledger(
-        monkeypatch, isolated_runs_dir, forbid_claude):
+        monkeypatch, tmp_path, isolated_runs_dir, forbid_claude):
+    import io
+
     from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
     from prism_service.services import graph_enrich as ge
+
+    pi_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", pi_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", pi_dir / "manifest.jsonl")
 
     monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
     monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
-    payload = '{"name": "Ledger Cluster", "purpose": "Keeps receipts."}'
-    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
-        "text": payload, "ms": 9.0, "tokens": 6,
-        "input_tokens": 27, "output_tokens": 6,
-    })
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    text = '{"name": "Ledger Cluster", "purpose": "Keeps receipts."}'
+    payload = json.dumps({
+        "choices": [{"message": {"content": text}}],
+        "usage": {"prompt_tokens": 27, "completion_tokens": 6},
+    }).encode()
+    monkeypatch.setattr(local_llm.urllib.request, "urlopen",
+                        lambda req, timeout=0: _Resp(payload))
 
     name, purpose = ge.enrich_one(_scope(), "no-such-project")
     assert (name, purpose) == ("Ledger Cluster", "Keeps receipts.")
 
-    rows = _manifest_rows(isolated_runs_dir)
-    assert len(rows) == 1, "local run must append exactly one manifest row"
+    rows = prl.list_recent(limit=10)
+    assert len(rows) == 1, "local run must append exactly one pi_runs row"
     row = rows[0]
     assert row["backend"] == "local"
     assert row["model"] == "stub-micro"
     assert row["purpose"] == "graph_enrich"
-    assert row["exit_code"] == 0
+    assert row["project"] == "no-such-project"
+    assert row["ok"] is True
     assert row["input_tokens"] == 27
     assert row["output_tokens"] == 6
-    assert row["tokens_used"] == 33
-    # The synthetic stream file must exist so /api/claude-runs/{id}/stream
-    # (and final_text extraction) keep working for local runs.
-    assert row["final_text"] == payload
-    import prism_service.services.claude_run_log as crl
-    assert crl.stream_path_for(row["run_id"]) is not None
+    assert row["tokens"] == 6  # completion side, unchanged meaning
+    assert _manifest_rows(isolated_runs_dir) == [], \
+        "claude_runs must stay claude-only — no local seam rows"
 
 
 # ----------------------------------------------------------------------

--- a/services/prism-service/tests/unit/test_graph_enrich_backend.py
+++ b/services/prism-service/tests/unit/test_graph_enrich_backend.py
@@ -1,0 +1,257 @@
+"""Red suite — env-gated local backend for the graph-enrich seam
+(task f669c5ce, claude-p-exit epic be898578).
+
+graph_enrich.enrich_one must route through an env-gated backend seam
+mirroring memory_summary_worker._invoke_backend: PRISM_GRAPH_ENRICH_
+BACKEND=local -> inference/local_llm.complete (json_mode) with the
+unchanged render_prompt(scope) contract; default (unset) stays
+claude_cli.invoke byte-for-byte. The local path records an equivalent
+claude_runs manifest row (backend='local' + input/output token counts)
+via claude_run_log.record_local_run, the _parse truncation contract
+(name<=60, purpose<=160, ("","") on failure) is unchanged, and the
+graph_annotations provenance string reflects the active backend.
+
+All stubs — pytest never needs Ollama or the claude CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+
+def _scope():
+    return {
+        "scope_id": "prism/services",
+        "level": 1,
+        "files": ["a.py", "b.py"],
+        "symbols": ["AlphaService", "beta_helper"],
+        "input_hash": "cafebabe1234",
+    }
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    """Repoint claude_run_log at tmp_path (module captures _RUNS_DIR /
+    _MANIFEST from DATA_DIR at import)."""
+    import prism_service.services.claude_run_log as crl
+    runs_dir = tmp_path / "claude_runs"
+    monkeypatch.setattr(crl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(crl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+@pytest.fixture
+def forbid_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+
+    def forbidden(*a, **k):
+        raise AssertionError(
+            "claude_cli.invoke must not run on the local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+    return claude_cli
+
+
+def _manifest_rows(runs_dir):
+    mf = runs_dir / "manifest.jsonl"
+    if not mf.exists():
+        return []
+    return [json.loads(ln) for ln in
+            mf.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — default (env unset) stays claude_cli with the current contract.
+# ----------------------------------------------------------------------
+def test_default_routes_claude_cli(monkeypatch):
+    from prism_service.inference import claude_cli, local_llm
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.delenv("PRISM_GRAPH_ENRICH_BACKEND", raising=False)
+
+    def no_local(*a, **k):
+        raise AssertionError("local_llm must not run on the default backend")
+    monkeypatch.setattr(local_llm, "complete", no_local)
+
+    seen: list[dict] = []
+
+    class _FakeResult:
+        exit_code = 0
+        run_id = "fake-claude"
+
+        def final_text(self):
+            return '{"name": "Alpha Services", "purpose": "Serves alpha."}'
+
+    def fake_invoke(**kw):
+        seen.append(kw)
+        return _FakeResult()
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    scope = _scope()
+    name, purpose = ge.enrich_one(scope, "no-such-project")
+    assert (name, purpose) == ("Alpha Services", "Serves alpha.")
+    assert seen, "claude_cli.invoke was not called on the default path"
+    kw = seen[0]
+    assert kw["prompt"] == ge.render_prompt(scope)
+    assert kw["max_turns"] == 1
+    assert kw["allowed_tools"] == ()
+    assert kw["purpose"] == "graph_enrich"
+
+
+# ----------------------------------------------------------------------
+# AC-2 — PRISM_GRAPH_ENRICH_BACKEND=local routes local_llm.complete with
+#         json_mode and honors the _parse truncation contract.
+# ----------------------------------------------------------------------
+def test_local_backend_routes_local_llm(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+
+    calls: list[dict] = []
+    long_name = "N" * 90
+    long_purpose = "P" * 200
+
+    def fake_complete(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"text": json.dumps({"name": long_name,
+                                    "purpose": long_purpose}),
+                "ms": 5.0, "tokens": 9,
+                "input_tokens": 33, "output_tokens": 9}
+    monkeypatch.setattr(local_llm, "complete", fake_complete)
+
+    scope = _scope()
+    name, purpose = ge.enrich_one(scope, "no-such-project")
+    # _parse truncation contract unchanged: name<=60, purpose<=160.
+    assert name == long_name[:60]
+    assert purpose == long_purpose[:160]
+    assert calls, "local_llm.complete was not called on the local backend"
+    assert calls[0]["prompt"] == ge.render_prompt(scope)
+    assert calls[0].get("model") == "stub-micro"
+    assert calls[0].get("json_mode") is True
+
+
+# ----------------------------------------------------------------------
+# AC-3 — the local run lands in the claude_runs ledger with tokens.
+# ----------------------------------------------------------------------
+def test_local_run_lands_in_ledger(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    payload = '{"name": "Ledger Cluster", "purpose": "Keeps receipts."}'
+    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
+        "text": payload, "ms": 9.0, "tokens": 6,
+        "input_tokens": 27, "output_tokens": 6,
+    })
+
+    name, purpose = ge.enrich_one(_scope(), "no-such-project")
+    assert (name, purpose) == ("Ledger Cluster", "Keeps receipts.")
+
+    rows = _manifest_rows(isolated_runs_dir)
+    assert len(rows) == 1, "local run must append exactly one manifest row"
+    row = rows[0]
+    assert row["backend"] == "local"
+    assert row["model"] == "stub-micro"
+    assert row["purpose"] == "graph_enrich"
+    assert row["exit_code"] == 0
+    assert row["input_tokens"] == 27
+    assert row["output_tokens"] == 6
+    assert row["tokens_used"] == 33
+    # The synthetic stream file must exist so /api/claude-runs/{id}/stream
+    # (and final_text extraction) keep working for local runs.
+    assert row["final_text"] == payload
+    import prism_service.services.claude_run_log as crl
+    assert crl.stream_path_for(row["run_id"]) is not None
+
+
+# ----------------------------------------------------------------------
+# AC-4 — a local failure returns ("", "") — cycle moves on, no success row.
+# ----------------------------------------------------------------------
+def test_local_failure_returns_empty(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
+    attempts: list[int] = []
+
+    def down(*a, **k):
+        attempts.append(1)
+        raise urllib.error.URLError("endpoint down")
+    monkeypatch.setattr(local_llm, "complete", down)
+
+    assert ge.enrich_one(_scope(), "no-such-project") == ("", "")
+    assert attempts, "local backend was never attempted"
+    assert _manifest_rows(isolated_runs_dir) == [], \
+        "a failed local run must not claim success in the ledger"
+
+
+# ----------------------------------------------------------------------
+# AC-5 — annotation provenance reflects the active backend.
+# ----------------------------------------------------------------------
+class _StubGraph:
+    def __init__(self):
+        self.upserts: list[tuple] = []
+
+    def get_annotation(self, scope_kind, scope_id, kind):
+        return None  # everything reads as changed
+
+    def upsert_annotation(self, scope_kind, scope_id, kind,
+                          name, purpose, input_hash, provenance):
+        self.upserts.append(
+            (scope_kind, scope_id, name, purpose, provenance))
+        return True
+
+
+def test_provenance_reflects_backend(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
+    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
+        "text": '{"name": "Local Name", "purpose": "Local purpose."}',
+        "ms": 3.0, "tokens": 5, "input_tokens": 12, "output_tokens": 5,
+    })
+
+    graph = _StubGraph()
+    out = {"enriched": 0, "skipped": 0, "errors": 0, "pending": 0}
+    ge._enrich_kind(graph, "no-such-project", "community",
+                    [_scope()], 1, out)
+    assert out["enriched"] == 1
+    assert graph.upserts, "annotation was not upserted"
+    prov = graph.upserts[0][-1]
+    assert prov.startswith("local @ "), \
+        f"provenance must reflect the local backend, got {prov!r}"
+
+
+def test_provenance_default_stays_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.delenv("PRISM_GRAPH_ENRICH_BACKEND", raising=False)
+
+    class _FakeResult:
+        exit_code = 0
+        run_id = "fake-claude"
+
+        def final_text(self):
+            return '{"name": "Claude Name", "purpose": "Claude purpose."}'
+
+    monkeypatch.setattr(claude_cli, "invoke", lambda **kw: _FakeResult())
+
+    graph = _StubGraph()
+    out = {"enriched": 0, "skipped": 0, "errors": 0, "pending": 0}
+    ge._enrich_kind(graph, "no-such-project", "hierarchy",
+                    [_scope()], 1, out)
+    assert out["enriched"] == 1
+    prov = graph.upserts[0][-1]
+    assert prov.startswith("claude @ "), \
+        f"default provenance must stay claude-shaped, got {prov!r}"

--- a/services/prism-service/tests/unit/test_local_llm_run_recording.py
+++ b/services/prism-service/tests/unit/test_local_llm_run_recording.py
@@ -40,7 +40,7 @@ class _FakeResponse(io.BytesIO):
 def _fake_urlopen_payload():
     return json.dumps({
         "choices": [{"message": {"content": "verdict text"}}],
-        "usage": {"completion_tokens": 21},
+        "usage": {"prompt_tokens": 13, "completion_tokens": 21},
     }).encode()
 
 
@@ -64,6 +64,11 @@ def test_complete_records_one_local_row(isolated_runs_dir, monkeypatch):
     assert r["model"] == "qwen3:1.7b"
     assert r["project"] == "proj-z"
     assert r["tokens"] == 21
+    # Additive split + run_id receipt (task d1d4fe00): pi_runs is THE
+    # ledger for pi|local; callers read the row id off the output.
+    assert r["input_tokens"] == 13
+    assert r["output_tokens"] == 21
+    assert out["run_id"] == r["run_id"]
     assert r["prompt_chars"] == len("brief text")
     assert r["tools_used"] == []  # tool-less by design
     assert r["ok"] is True
@@ -120,3 +125,4 @@ def test_broken_ledger_never_breaks_complete(isolated_runs_dir, monkeypatch):
 
     out = local_llm.complete("brief")
     assert out["text"] == "verdict text"
+    assert out["run_id"] == ""  # no receipt when the ledger is down

--- a/services/prism-service/tests/unit/test_local_llm_run_recording.py
+++ b/services/prism-service/tests/unit/test_local_llm_run_recording.py
@@ -1,0 +1,122 @@
+"""RED scaffold — local_llm.complete() records every run into pi_run_log.
+
+Plain completions against the keyless local endpoint are internal
+inference too: each complete() appends one backend=local manifest row;
+an unreachable endpoint appends an ok=False row and re-raises the
+original error unchanged; the new purpose/project kwargs are additive
+(defaults keep every existing caller untouched).
+
+ALL FAIL today: pi_run_log does not exist and complete() records nothing.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+class _FakeResponse(io.BytesIO):
+    """Context-manager response like urlopen's."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _fake_urlopen_payload():
+    return json.dumps({
+        "choices": [{"message": {"content": "verdict text"}}],
+        "usage": {"completion_tokens": 21},
+    }).encode()
+
+
+def test_complete_records_one_local_row(isolated_runs_dir, monkeypatch):
+    from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(
+        local_llm.urllib.request, "urlopen",
+        lambda req, timeout=0: _FakeResponse(_fake_urlopen_payload()))
+
+    out = local_llm.complete("brief text", model="qwen3:1.7b",
+                             project="proj-z")
+    assert out["text"] == "verdict text"
+    assert out["tokens"] == 21
+
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1
+    r = runs[0]
+    assert r["backend"] == "local"
+    assert r["model"] == "qwen3:1.7b"
+    assert r["project"] == "proj-z"
+    assert r["tokens"] == 21
+    assert r["prompt_chars"] == len("brief text")
+    assert r["tools_used"] == []  # tool-less by design
+    assert r["ok"] is True
+    assert r["duration_ms"] >= 0
+
+
+def test_complete_purpose_inferred_for_reflection(
+        isolated_runs_dir, monkeypatch):
+    from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(
+        local_llm.urllib.request, "urlopen",
+        lambda req, timeout=0: _FakeResponse(_fake_urlopen_payload()))
+
+    local_llm.complete("b1", system="You are PRISM's reflection engine.")
+    local_llm.complete("b2")
+    local_llm.complete("b3", purpose="panel-bridge")
+
+    purposes = [r["purpose"] for r in prl.list_recent(limit=10)]
+    assert purposes == ["panel-bridge", "adhoc", "reflect"]  # newest first
+
+
+def test_complete_unreachable_records_error_and_reraises(
+        isolated_runs_dir, monkeypatch):
+    from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
+
+    def _refused(req, timeout=0):
+        raise urllib.error.URLError("connection refused")
+    monkeypatch.setattr(local_llm.urllib.request, "urlopen", _refused)
+
+    with pytest.raises(urllib.error.URLError):
+        local_llm.complete("brief")
+
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1
+    assert runs[0]["backend"] == "local"
+    assert runs[0]["ok"] is False
+    assert "connection refused" in runs[0]["error"]
+
+
+def test_broken_ledger_never_breaks_complete(isolated_runs_dir, monkeypatch):
+    from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(
+        local_llm.urllib.request, "urlopen",
+        lambda req, timeout=0: _FakeResponse(_fake_urlopen_payload()))
+
+    def _explode(**kwargs):
+        raise RuntimeError("ledger on fire")
+    monkeypatch.setattr(prl, "record_run", _explode)
+
+    out = local_llm.complete("brief")
+    assert out["text"] == "verdict text"

--- a/services/prism-service/tests/unit/test_mcp_augmentation.py
+++ b/services/prism-service/tests/unit/test_mcp_augmentation.py
@@ -30,6 +30,9 @@ def project(tmp_path, monkeypatch):
     from prism_service import project_context as pc
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-ll-09")
     pc._contexts.clear()
     monkeypatch.delenv("PRISM_MCP_AUGMENT_NUDGES", raising=False)
     yield "test-ll-09"

--- a/services/prism-service/tests/unit/test_mcp_graph_annotate.py
+++ b/services/prism-service/tests/unit/test_mcp_graph_annotate.py
@@ -46,6 +46,9 @@ def _isolated_project(tmp_path, pid=_PID):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     from prism_service import project_context as pc
     pc._contexts.clear()
     yield pid

--- a/services/prism-service/tests/unit/test_mcp_janitor.py
+++ b/services/prism-service/tests/unit/test_mcp_janitor.py
@@ -27,6 +27,9 @@ def _isolated_project(tmp_path, pid="test-ll-08"):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir(pid)
     # Reset the cached context registry so each test is isolated.
     from prism_service import project_context as pc
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_mcp_janitor_reflect_profile.py
+++ b/services/prism-service/tests/unit/test_mcp_janitor_reflect_profile.py
@@ -39,6 +39,9 @@ def project(tmp_path):
     original = cfg.PROJECTS_DIR
     cfg.PROJECTS_DIR = tmp_path / "projects"
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-issue-173")
     pc._contexts.clear()
     yield "test-issue-173"
     cfg.PROJECTS_DIR = original

--- a/services/prism-service/tests/unit/test_memory_ops_backend.py
+++ b/services/prism-service/tests/unit/test_memory_ops_backend.py
@@ -1,0 +1,383 @@
+"""Red scaffold — env-gated local backend for the memory-ops runner.
+
+Task 9f61d484 (claude-p-exit epic be898578): `memory_ops.runner.run_one`
+routes every op (merge / forget / verify_staleness / distill_procedural)
+through `claude_cli.invoke` with per-op model routing, including a
+HARDCODED `claude-opus-4-20250514` in `distill_procedural.py`. These
+tests pin the acceptance criteria for the backend seam:
+
+  * AC-1  PRISM_MEMORY_OPS_BACKEND=local (local_llm stubbed) drives
+          run_one end-to-end to a janitor submit with the SAME verdict
+          JSON contract for each op family — durable consolidation_runs
+          row (op_type populated, read through a separate connection),
+          zero claude_cli calls;
+  * AC-2  default env -> claude_cli with op.model routing intact, distill
+          resolving to the opus id from the runner's per-op map;
+  * AC-3  no hardcoded opus id remains in distill_procedural.py — the id
+          lives ONLY in runner.CLAUDE_MODEL_MAP;
+  * AC-4  local runs carry telemetry through the pi_runs single recording
+          point in local_llm.complete: purpose="memory-ops:<op_type>" +
+          project passthrough, run_id surfaced on OperationResult;
+  * AC-5  per-op local model resolution (op.local_model, then
+          LOCAL_MODEL_MAP, then local_llm.configured_model()) with
+          json_mode=True on every op (all four op contracts are
+          JSON-only verdicts).
+
+Every test here FAILS today: the runner has no backend seam, no model
+maps, and distill_procedural.py still carries the opus hardcode.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (mirrors test_memory_ops_framework.py)
+# ---------------------------------------------------------------------------
+
+def _make_scores_db(tmp_path: Path) -> str:
+    from prism_service.engines.brain_engine import Brain
+
+    scores = tmp_path / "scores.db"
+    Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=str(scores),
+    )
+    return str(scores)
+
+
+def _insert_candidate(scores_db: str, cid: str) -> None:
+    c = sqlite3.connect(scores_db)
+    try:
+        c.execute(
+            "INSERT INTO consolidation_candidates "
+            "(id, task_id, session_id, trigger, status, queued_at, scope_json) "
+            "VALUES (?, NULL, ?, ?, 'pending', ?, '{}')",
+            (cid, "sess-1", "test", "2026-07-02T10:00:00+00:00"),
+        )
+        c.commit()
+    finally:
+        c.close()
+
+
+def _patch_project(monkeypatch, scores_db: str, tmp_path: Path):
+    class _Ctx:
+        _data_dir = Path(scores_db).parent
+
+        class memory_svc:  # noqa: N801 — attribute namespace
+            @staticmethod
+            def store(**kw):
+                class _E:
+                    id = "mem-1"
+                return _E()
+
+    monkeypatch.setattr(
+        "prism_service.project_context.get_project", lambda p: _Ctx()
+    )
+    monkeypatch.setattr(
+        "prism_service.services.source_service.source_dir_for",
+        lambda p: tmp_path, raising=False,
+    )
+    return _Ctx
+
+
+def _stub_op_cls(op_type: str, model: str = "", local_model: str = ""):
+    """A minimal concrete MemoryOperation for a given op family."""
+    from prism_service.services.memory_ops.base import MemoryOperation
+
+    _op_type, _model, _local_model = op_type, model, local_model
+
+    class _StubOp(MemoryOperation):
+        op_type = _op_type
+        schema: dict = {}
+        model = _model
+        provenance = {"source": "stub"}
+
+        def __init__(self, items=None):
+            self._items = items if items is not None else ["item-1"]
+            self.applied = []
+
+        def select(self, project):
+            return list(self._items)
+
+        def build_prompt(self, item, project):
+            return f"{self.op_type}? item={item} project={project}"
+
+        def apply_verdict(self, item, verdict, project):
+            self.applied.append((item, verdict))
+
+    if _local_model:
+        _StubOp.local_model = _local_model
+    return _StubOp
+
+
+class _FakeCliResult:
+    def __init__(self, text: str, run_id: str = "claude-run-1"):
+        self._text = text
+        self.exit_code = 0
+        self.run_id = run_id
+        self.duration_s = 0.1
+
+    def final_text(self) -> str:
+        return self._text
+
+
+def _local_stub(captured: list, text: str, run_id: str = "pi-run-1"):
+    """Stub for inference.local_llm.complete: captures kwargs, returns the
+    dict contract local_llm.complete promises (text/ms/tokens/run_id)."""
+
+    def _complete(prompt, **kw):
+        captured.append({"prompt": prompt, **kw})
+        return {
+            "text": text, "ms": 5.0, "tokens": 12,
+            "input_tokens": 34, "output_tokens": 12, "run_id": run_id,
+        }
+
+    return _complete
+
+
+# The five-field JanitorService.submit envelope every op's prompt demands,
+# plus the op-specific verdict fields — the per-op JSON contract.
+_ENVELOPE = (
+    '"qualitative_score": 0.6, "narrative": "n", "new_memories": [], '
+    '"invalidate_memory_ids": [], "confidence": 0.7'
+)
+_OP_VERDICTS = {
+    "merge": '{"same_fact": false, ' + _ENVELOPE + "}",
+    "forget": '{"decision": "keep", "reason": "still load-bearing", '
+              + _ENVELOPE + "}",
+    "verify_staleness": '{"decision": "keep", "correction": "", '
+                        + _ENVELOPE + "}",
+    "distill_procedural": "{" + _ENVELOPE + "}",
+}
+
+
+# ---------------------------------------------------------------------------
+# AC-1: local backend drives every op family end-to-end to a janitor submit
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("op_type", sorted(_OP_VERDICTS))
+def test_local_backend_end_to_end_submits_verdict(
+        monkeypatch, tmp_path, op_type):
+    from prism_service.services.memory_ops import runner
+
+    scores_db = _make_scores_db(tmp_path)
+    _insert_candidate(scores_db, "item-1")
+    _patch_project(monkeypatch, scores_db, tmp_path)
+    monkeypatch.setenv("PRISM_MEMORY_OPS_BACKEND", "local")
+
+    claude_calls = {"n": 0}
+
+    def _no_claude(**kw):
+        claude_calls["n"] += 1
+        return _FakeCliResult(_OP_VERDICTS[op_type])
+
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _no_claude)
+    captured: list = []
+    monkeypatch.setattr(
+        "prism_service.inference.local_llm.complete",
+        _local_stub(captured, _OP_VERDICTS[op_type]),
+    )
+
+    op = _stub_op_cls(op_type)(items=["item-1"])
+    result = runner.run_one(op, "item-1", "p")
+
+    assert result.ok, getattr(result, "error", result)
+    assert claude_calls["n"] == 0, (
+        "PRISM_MEMORY_OPS_BACKEND=local must not touch claude_cli"
+    )
+    assert len(captured) == 1, "local_llm.complete must carry the inference"
+    assert op.applied and op.applied[0][0] == "item-1", (
+        "apply_verdict must receive the parsed verdict on the local path"
+    )
+
+    # Durable audit row — separate connection, op_type populated (AC-1).
+    conn = sqlite3.connect(scores_db)
+    try:
+        row = conn.execute(
+            "SELECT op_type, output_json FROM consolidation_runs "
+            "WHERE candidate_id = ?", ("item-1",),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None, "no consolidation_runs row was written"
+    assert row[0] == op_type, f"op_type column not populated: {row[0]!r}"
+
+
+# ---------------------------------------------------------------------------
+# AC-2: default env -> claude_cli, distill model resolved from the map
+# ---------------------------------------------------------------------------
+
+def test_default_env_routes_claude_with_distill_opus_from_map(
+        monkeypatch, tmp_path):
+    from prism_service.services.memory_ops import runner
+
+    scores_db = _make_scores_db(tmp_path)
+    _insert_candidate(scores_db, "item-1")
+    _patch_project(monkeypatch, scores_db, tmp_path)
+    monkeypatch.delenv("PRISM_MEMORY_OPS_BACKEND", raising=False)
+
+    seen = {}
+
+    def _capture(**kw):
+        seen.update(kw)
+        return _FakeCliResult(_OP_VERDICTS["distill_procedural"])
+
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _capture)
+    local_calls = {"n": 0}
+    monkeypatch.setattr(
+        "prism_service.inference.local_llm.complete",
+        lambda *a, **kw: local_calls.__setitem__("n", local_calls["n"] + 1),
+    )
+
+    # op.model is EMPTY: the opus pin must come from the runner's map now.
+    op = _stub_op_cls("distill_procedural", model="")(items=["item-1"])
+    result = runner.run_one(op, "item-1", "p")
+
+    assert result.ok, getattr(result, "error", result)
+    assert local_calls["n"] == 0, "default env must not touch local_llm"
+    assert seen.get("model") == "claude-opus-4-20250514", (
+        "distill_procedural's claude model must resolve to the opus id "
+        f"from runner.CLAUDE_MODEL_MAP, got {seen.get('model')!r}"
+    )
+    assert seen.get("purpose") == "prism-distill_procedural", (
+        "default claude path must stay byte-identical (purpose arg)"
+    )
+
+
+def test_default_env_op_model_attribute_still_wins(monkeypatch, tmp_path):
+    """A non-empty op.model must keep winning over the map (routing intact)."""
+    from prism_service.services.memory_ops import runner
+
+    scores_db = _make_scores_db(tmp_path)
+    _insert_candidate(scores_db, "item-1")
+    _patch_project(monkeypatch, scores_db, tmp_path)
+    monkeypatch.delenv("PRISM_MEMORY_OPS_BACKEND", raising=False)
+
+    seen = {}
+
+    def _capture(**kw):
+        seen.update(kw)
+        return _FakeCliResult(_OP_VERDICTS["forget"])
+
+    monkeypatch.setattr("prism_service.inference.claude_cli.invoke", _capture)
+
+    op = _stub_op_cls("forget", model="claude-haiku-test")(items=["item-1"])
+    runner.run_one(op, "item-1", "p")
+    assert seen.get("model") == "claude-haiku-test"
+
+
+# ---------------------------------------------------------------------------
+# AC-3: no hardcoded opus id in distill_procedural.py; map owns the pin
+# ---------------------------------------------------------------------------
+
+def test_no_hardcoded_opus_in_distill_module():
+    from prism_service.services.memory_ops import distill_procedural, runner
+
+    src = Path(distill_procedural.__file__).read_text(encoding="utf-8")
+    assert "claude-opus" not in src, (
+        "distill_procedural.py still hardcodes an opus model id — the pin "
+        "must live in runner.CLAUDE_MODEL_MAP"
+    )
+    assert getattr(runner, "CLAUDE_MODEL_MAP", {}).get(
+        "distill_procedural") == "claude-opus-4-20250514", (
+        "runner.CLAUDE_MODEL_MAP must carry distill_procedural's opus pin"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: local telemetry — purpose/project passthrough + run_id receipt
+# ---------------------------------------------------------------------------
+
+def test_local_run_telemetry_purpose_project_run_id(monkeypatch, tmp_path):
+    from prism_service.services.memory_ops import runner
+
+    scores_db = _make_scores_db(tmp_path)
+    _insert_candidate(scores_db, "item-1")
+    _patch_project(monkeypatch, scores_db, tmp_path)
+    monkeypatch.setenv("PRISM_MEMORY_OPS_BACKEND", "local")
+
+    captured: list = []
+    monkeypatch.setattr(
+        "prism_service.inference.local_llm.complete",
+        _local_stub(captured, _OP_VERDICTS["forget"], run_id="pi-run-42"),
+    )
+
+    op = _stub_op_cls("forget")(items=["item-1"])
+    result = runner.run_one(op, "item-1", "proj-x")
+
+    assert result.ok, getattr(result, "error", result)
+    kw = captured[0]
+    assert kw.get("purpose") == "memory-ops:forget", (
+        f"local runs must record purpose='memory-ops:<op>': {kw.get('purpose')!r}"
+    )
+    assert kw.get("project") == "proj-x", "project must pass through to the ledger"
+    assert result.run_id == "pi-run-42", (
+        "the pi_runs run_id receipt must surface on OperationResult.run_id"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-5: per-op local model resolution + json_mode on every op
+# ---------------------------------------------------------------------------
+
+def test_local_model_resolution_and_json_mode(monkeypatch, tmp_path):
+    from prism_service.services.memory_ops import runner
+
+    scores_db = _make_scores_db(tmp_path)
+    _patch_project(monkeypatch, scores_db, tmp_path)
+    monkeypatch.setenv("PRISM_MEMORY_OPS_BACKEND", "local")
+    monkeypatch.setattr(
+        "prism_service.inference.local_llm.configured_model",
+        lambda: "default-micro",
+    )
+
+    captured: list = []
+    monkeypatch.setattr(
+        "prism_service.inference.local_llm.complete",
+        _local_stub(captured, _OP_VERDICTS["merge"]),
+    )
+    # Hermetic: a mis-routed claude path must fail fast, not pay real
+    # inference (pre-implementation the runner ignores the env gate).
+    monkeypatch.setattr(
+        "prism_service.inference.claude_cli.invoke",
+        lambda **kw: _FakeCliResult("not-the-local-path"),
+    )
+
+    # (a) op.local_model override wins.
+    _insert_candidate(scores_db, "item-a")
+    op = _stub_op_cls("merge", local_model="qwen3:4b")(items=["item-a"])
+    assert runner.run_one(op, "item-a", "p").ok
+    assert captured[-1].get("model") == "qwen3:4b", (
+        f"op.local_model must win: {captured[-1].get('model')!r}"
+    )
+
+    # (b) LOCAL_MODEL_MAP is consulted when the op carries no override.
+    monkeypatch.setitem(runner.LOCAL_MODEL_MAP, "merge", "mapped-model")
+    _insert_candidate(scores_db, "item-b")
+    op = _stub_op_cls("merge")(items=["item-b"])
+    assert runner.run_one(op, "item-b", "p").ok
+    assert captured[-1].get("model") == "mapped-model"
+
+    # (c) fallback: local_llm.configured_model().
+    monkeypatch.delitem(runner.LOCAL_MODEL_MAP, "merge", raising=False)
+    _insert_candidate(scores_db, "item-c")
+    op = _stub_op_cls("merge")(items=["item-c"])
+    assert runner.run_one(op, "item-c", "p").ok
+    assert captured[-1].get("model") == "default-micro"
+
+    # json_mode=True on EVERY local call (all op contracts are JSON-only).
+    assert captured and all(kw.get("json_mode") is True for kw in captured), (
+        "every op verdict is a JSON contract — json_mode must be True"
+    )

--- a/services/prism-service/tests/unit/test_memory_summary_backend.py
+++ b/services/prism-service/tests/unit/test_memory_summary_backend.py
@@ -1,0 +1,215 @@
+"""Red suite — env-gated local backend for the memory-summary seam
+(task 5fc1683e, claude-p-exit epic be898578).
+
+memory_summary_worker.summarize_one must route through a
+`_invoke_backend` seam mirroring reflection_runner._invoke_backend:
+PRISM_MEMORY_SUMMARY_BACKEND=local -> inference/local_llm.complete with
+the unchanged render_prompt distillation prompt; default (unset) stays
+claude_cli.invoke byte-for-byte. The local path records an equivalent
+claude_runs manifest row (backend='local' + token counts) via the
+additive claude_run_log seam; local_llm.complete additively reports
+input_tokens/output_tokens.
+
+All stubs — pytest never needs Ollama or the claude CLI.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    """Repoint claude_run_log at tmp_path (module captures _RUNS_DIR /
+    _MANIFEST from DATA_DIR at import)."""
+    import prism_service.services.claude_run_log as crl
+    runs_dir = tmp_path / "claude_runs"
+    monkeypatch.setattr(crl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(crl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+@pytest.fixture
+def forbid_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+
+    def forbidden(*a, **k):
+        raise AssertionError(
+            "claude_cli.invoke must not run on the local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+    return claude_cli
+
+
+def _manifest_rows(runs_dir):
+    mf = runs_dir / "manifest.jsonl"
+    if not mf.exists():
+        return []
+    return [json.loads(ln) for ln in
+            mf.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — default (env unset) stays claude_cli with the current contract.
+# ----------------------------------------------------------------------
+def test_default_routes_claude_cli(monkeypatch):
+    from prism_service.inference import claude_cli, local_llm
+    from prism_service.services import memory_summary_worker as msw
+
+    monkeypatch.delenv("PRISM_MEMORY_SUMMARY_BACKEND", raising=False)
+
+    def no_local(*a, **k):
+        raise AssertionError("local_llm must not run on the default backend")
+    monkeypatch.setattr(local_llm, "complete", no_local)
+
+    seen: list[dict] = []
+
+    class _FakeResult:
+        exit_code = 0
+        run_id = "fake-claude"
+
+        def final_text(self):
+            return '"A clean sentence."'
+
+    def fake_invoke(**kw):
+        seen.append(kw)
+        return _FakeResult()
+    monkeypatch.setattr(claude_cli, "invoke", fake_invoke)
+
+    out = msw.summarize_one("mem-name", "mem-desc", "no-such-project")
+    assert out == "A clean sentence."
+    assert seen, "claude_cli.invoke was not called on the default path"
+    kw = seen[0]
+    assert kw["prompt"] == msw.render_prompt("mem-name", "mem-desc")
+    assert kw["max_turns"] == 1
+    assert kw["allowed_tools"] == ()
+    assert kw["purpose"] == "memory_summary"
+
+
+# ----------------------------------------------------------------------
+# AC-2 — PRISM_MEMORY_SUMMARY_BACKEND=local routes local_llm.complete.
+# ----------------------------------------------------------------------
+def test_local_backend_routes_local_llm(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import memory_summary_worker as msw
+
+    monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+
+    calls: list[dict] = []
+
+    def fake_complete(prompt, **kw):
+        calls.append({"prompt": prompt, **kw})
+        return {"text": '"Concise tile sentence."', "ms": 5.0, "tokens": 7,
+                "input_tokens": 11, "output_tokens": 7}
+    monkeypatch.setattr(local_llm, "complete", fake_complete)
+
+    out = msw.summarize_one("mem-name", "mem-desc", "no-such-project")
+    assert out == "Concise tile sentence."   # _strip removed the quotes
+    assert calls, "local_llm.complete was not called on the local backend"
+    assert calls[0]["prompt"] == msw.render_prompt("mem-name", "mem-desc")
+    assert calls[0].get("model") == "stub-micro"
+
+
+# ----------------------------------------------------------------------
+# AC-3 — the local run lands in the claude_runs ledger with tokens.
+# ----------------------------------------------------------------------
+def test_local_run_lands_in_ledger(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import memory_summary_worker as msw
+
+    monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
+        "text": "Ledger sentence.", "ms": 9.0, "tokens": 4,
+        "input_tokens": 21, "output_tokens": 4,
+    })
+
+    out = msw.summarize_one("mem-name", "mem-desc", "no-such-project")
+    assert out == "Ledger sentence."
+
+    rows = _manifest_rows(isolated_runs_dir)
+    assert len(rows) == 1, "local run must append exactly one manifest row"
+    row = rows[0]
+    assert row["backend"] == "local"
+    assert row["model"] == "stub-micro"
+    assert row["purpose"] == "memory_summary"
+    assert row["exit_code"] == 0
+    assert row["input_tokens"] == 21
+    assert row["output_tokens"] == 4
+    assert row["tokens_used"] == 25
+    # The synthetic stream file must exist so /api/claude-runs/{id}/stream
+    # (and final_text extraction) keep working for local runs.
+    assert row["final_text"] == "Ledger sentence."
+    import prism_service.services.claude_run_log as crl
+    assert crl.stream_path_for(row["run_id"]) is not None
+
+
+# ----------------------------------------------------------------------
+# AC-4 — local_llm.complete additively reports input/output tokens.
+# ----------------------------------------------------------------------
+class _StubHandler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        payload = json.dumps({
+            "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+            "usage": {"prompt_tokens": 13, "completion_tokens": 5},
+        }).encode()
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, *_):
+        pass
+
+
+def test_complete_reports_prompt_and_completion_tokens():
+    from prism_service.inference import local_llm
+
+    srv = HTTPServer(("127.0.0.1", 0), _StubHandler)
+    t = threading.Thread(target=srv.serve_forever, daemon=True)
+    t.start()
+    try:
+        out = local_llm.complete(
+            "hello", model="stub-model",
+            base_url=f"http://127.0.0.1:{srv.server_port}/v1",
+        )
+    finally:
+        srv.shutdown()
+    # Existing keys keep their meaning (additive change only).
+    assert out["text"] == "hi"
+    assert out["tokens"] == 5
+    # New keys: real usage from the endpoint.
+    assert out["input_tokens"] == 13
+    assert out["output_tokens"] == 5
+
+
+# ----------------------------------------------------------------------
+# AC-5 — a local failure returns "" (retry next cycle), no success row.
+# ----------------------------------------------------------------------
+def test_local_failure_returns_empty(
+        monkeypatch, isolated_runs_dir, forbid_claude):
+    from prism_service.inference import local_llm
+    from prism_service.services import memory_summary_worker as msw
+
+    monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
+    attempts: list[int] = []
+
+    def down(*a, **k):
+        attempts.append(1)
+        raise urllib.error.URLError("endpoint down")
+    monkeypatch.setattr(local_llm, "complete", down)
+
+    out = msw.summarize_one("mem-name", "mem-desc", "no-such-project")
+    assert out == ""
+    assert attempts, "local backend was never attempted"
+    assert all(r.get("exit_code") == 0 for r in
+               _manifest_rows(isolated_runs_dir)) or not _manifest_rows(
+        isolated_runs_dir), "a failed local run must not claim success"

--- a/services/prism-service/tests/unit/test_memory_summary_backend.py
+++ b/services/prism-service/tests/unit/test_memory_summary_backend.py
@@ -190,6 +190,7 @@ class _StubHandler(BaseHTTPRequestHandler):
         pass
 
 
+@pytest.mark.daemon_exclusive  # task 279ef52d: binds a real HTTP server + thread; flakes in-daemon
 def test_complete_reports_prompt_and_completion_tokens():
     from prism_service.inference import local_llm
 

--- a/services/prism-service/tests/unit/test_memory_summary_backend.py
+++ b/services/prism-service/tests/unit/test_memory_summary_backend.py
@@ -5,10 +5,12 @@ memory_summary_worker.summarize_one must route through a
 `_invoke_backend` seam mirroring reflection_runner._invoke_backend:
 PRISM_MEMORY_SUMMARY_BACKEND=local -> inference/local_llm.complete with
 the unchanged render_prompt distillation prompt; default (unset) stays
-claude_cli.invoke byte-for-byte. The local path records an equivalent
-claude_runs manifest row (backend='local' + token counts) via the
-additive claude_run_log seam; local_llm.complete additively reports
-input_tokens/output_tokens.
+claude_cli.invoke byte-for-byte. The local run is recorded by
+local_llm.complete ITSELF into the pi_runs audit ledger (backend='local'
++ input/output token split, purpose/project passthrough) — pi_runs is
+THE ledger for pi|local runs (task d1d4fe00); claude_runs stays
+claude-only. local_llm.complete additively reports input_tokens/
+output_tokens and the pi row's run_id.
 
 All stubs — pytest never needs Ollama or the claude CLI.
 """
@@ -117,38 +119,56 @@ def test_local_backend_routes_local_llm(
 
 
 # ----------------------------------------------------------------------
-# AC-3 — the local run lands in the claude_runs ledger with tokens.
+# AC-3 — the local run lands in the pi_runs audit ledger with the token
+# split; claude_runs stays claude-only (task d1d4fe00 reconciliation).
 # ----------------------------------------------------------------------
 def test_local_run_lands_in_ledger(
-        monkeypatch, isolated_runs_dir, forbid_claude):
+        monkeypatch, tmp_path, isolated_runs_dir, forbid_claude):
     from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
     from prism_service.services import memory_summary_worker as msw
+
+    pi_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", pi_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", pi_dir / "manifest.jsonl")
 
     monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
     monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
-    monkeypatch.setattr(local_llm, "complete", lambda prompt, **kw: {
-        "text": "Ledger sentence.", "ms": 9.0, "tokens": 4,
-        "input_tokens": 21, "output_tokens": 4,
-    })
+
+    # Real local_llm.complete (the single recording point) — only the
+    # HTTP endpoint is stubbed.
+    import io
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+    payload = json.dumps({
+        "choices": [{"message": {"content": "Ledger sentence."}}],
+        "usage": {"prompt_tokens": 21, "completion_tokens": 4},
+    }).encode()
+    monkeypatch.setattr(local_llm.urllib.request, "urlopen",
+                        lambda req, timeout=0: _Resp(payload))
 
     out = msw.summarize_one("mem-name", "mem-desc", "no-such-project")
     assert out == "Ledger sentence."
 
-    rows = _manifest_rows(isolated_runs_dir)
-    assert len(rows) == 1, "local run must append exactly one manifest row"
+    rows = prl.list_recent(limit=10)
+    assert len(rows) == 1, "local run must append exactly one pi_runs row"
     row = rows[0]
     assert row["backend"] == "local"
     assert row["model"] == "stub-micro"
     assert row["purpose"] == "memory_summary"
-    assert row["exit_code"] == 0
+    assert row["project"] == "no-such-project"
+    assert row["ok"] is True
     assert row["input_tokens"] == 21
     assert row["output_tokens"] == 4
-    assert row["tokens_used"] == 25
-    # The synthetic stream file must exist so /api/claude-runs/{id}/stream
-    # (and final_text extraction) keep working for local runs.
-    assert row["final_text"] == "Ledger sentence."
-    import prism_service.services.claude_run_log as crl
-    assert crl.stream_path_for(row["run_id"]) is not None
+    assert row["tokens"] == 4  # completion side, unchanged meaning
+    assert _manifest_rows(isolated_runs_dir) == [], \
+        "claude_runs must stay claude-only — no local seam rows"
 
 
 # ----------------------------------------------------------------------

--- a/services/prism-service/tests/unit/test_meta_conductor.py
+++ b/services/prism-service/tests/unit/test_meta_conductor.py
@@ -170,6 +170,9 @@ def project(tmp_path, monkeypatch):
 
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("meta-conductor-mcp")
     pc._contexts.clear()
     yield "meta-conductor-mcp"
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_okf_dedupe_file_concepts.py
+++ b/services/prism-service/tests/unit/test_okf_dedupe_file_concepts.py
@@ -1,0 +1,59 @@
+"""RED scaffold — Understand Code domain must not list one file twice (task 61aafcc6).
+
+/understand's Code domain listed the SAME file as two concepts — a bare
+'prism_cli.py' and the qualified 'prism_service/cli/prism_cli.py' — inflating
+the domain's concept count. The OKF graph projection must dedup file concepts by
+resolved path: when one file concept's title is a segment-aligned path-suffix of
+another's, they denote the same file; keep the most-qualified (longest) title.
+
+Unit-tests the pure dedup helper the /api/okf/graph projection uses. FAILS
+before the fix: prism_service.services.okf_host.dedupe_file_concepts does not
+exist.
+"""
+
+
+def test_bare_and_qualified_same_file_collapse_to_one():
+    from prism_service.services.okf_host import dedupe_file_concepts
+
+    nodes = [
+        {"id": "a", "type": "file", "title": "prism_cli.py", "domain": "code"},
+        {"id": "b", "type": "file",
+         "title": "prism_service/cli/prism_cli.py", "domain": "code"},
+        {"id": "c", "type": "file", "title": "main.py", "domain": "code"},
+    ]
+    out = dedupe_file_concepts(nodes)
+    titles = [n["title"] for n in out]
+    # The qualified path survives; the bare-basename duplicate is dropped.
+    assert "prism_service/cli/prism_cli.py" in titles
+    assert "prism_cli.py" not in titles
+    # Exactly one prism_cli file concept remains (count no longer inflated).
+    assert sum(1 for n in out
+               if n["type"] == "file" and n["title"].endswith("prism_cli.py")) == 1
+    # An unrelated file is untouched.
+    assert "main.py" in titles
+
+
+def test_distinct_files_sharing_a_basename_are_not_merged():
+    from prism_service.services.okf_host import dedupe_file_concepts
+
+    nodes = [
+        {"id": "a", "type": "file", "title": "pkg_a/utils.py", "domain": "code"},
+        {"id": "b", "type": "file", "title": "pkg_b/utils.py", "domain": "code"},
+    ]
+    out = dedupe_file_concepts(nodes)
+    assert len(out) == 2, "distinct qualified paths must not be merged"
+
+
+def test_non_file_concepts_pass_through_untouched():
+    from prism_service.services.okf_host import dedupe_file_concepts
+
+    nodes = [
+        {"id": "a", "type": "file", "title": "prism_cli.py", "domain": "code"},
+        {"id": "b", "type": "file",
+         "title": "prism_service/cli/prism_cli.py", "domain": "code"},
+        # A non-file concept that happens to share the basename must survive.
+        {"id": "d", "type": "decision", "title": "prism_cli.py",
+         "domain": "architecture"},
+    ]
+    out = dedupe_file_concepts(nodes)
+    assert any(n["id"] == "d" for n in out), "non-file concept wrongly deduped"

--- a/services/prism-service/tests/unit/test_phase_metrics.py
+++ b/services/prism-service/tests/unit/test_phase_metrics.py
@@ -1,0 +1,182 @@
+"""RED — per-phase metrics rollup for every SDLC step (task bd1c2289).
+
+The SDLC is only partly observable: history rows carry a timestamp per
+advance_task/gate_decide (per-step DURATION) and the fc08da8d telemetry
+attributes per-exchange tokens to a task_id (per-step TOKENS), but nothing
+ROLLS THEM UP per phase. `compute_phase_metrics` (a pure module-level helper in
+conductor_service, ON TOP of the fc08da8d plumbing — it does not touch
+phase_progress/burn) folds the history segments + task-attributed pi_runs into
+one entry per VISITED workflow step plus a task total.
+
+Pins, RED-first (these FAIL before compute_phase_metrics lands):
+
+  * AC-1 — per-step DURATION = next transition ts − this step's entry ts; the
+    current/last step is measured to `now`; steps come back in WORKFLOW_STEPS
+    order with their entered_at.
+  * AC-2 — tokens bucket into the step the task was on at each pi_runs row's ts
+    (or the row's explicit `step` when present); out-of-window rows are ignored;
+    tokens_in/out + turns + model aggregate per step.
+  * AC-3 — gate steps carry gate_outcome (passed on approve, failed on reject);
+    sparse history returns empty steps + a total without raising.
+  * AC-4 — the task total reports wall_duration_s, total_tokens and tok/s.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_T0 = datetime(2026, 7, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(sec: float) -> str:
+    return (_T0 + timedelta(seconds=sec)).isoformat()
+
+
+def _epoch(sec: float) -> float:
+    return (_T0 + timedelta(seconds=sec)).timestamp()
+
+
+def _adv(to: str, at: float, extra: str = "") -> dict:
+    det = f"from=x; to={to}" + (f"; {extra}" if extra else "")
+    return {"action": "advance_task", "details": det, "timestamp": _iso(at),
+            "actor": "conductor"}
+
+
+def _gate(step: str, action: str, at: float) -> dict:
+    return {"action": "gate_decide",
+            "details": f"gate={step}; action={action}; reason=r",
+            "timestamp": _iso(at), "actor": "conductor"}
+
+
+def _walk_history() -> list[dict]:
+    # created -> review(0) -> draft(10) -> story_gate(30, pending) ->
+    # approve(35) -> verify_plan(40); "now" is 100s in.
+    return [
+        {"action": "created", "details": "title='x'", "timestamp": _iso(0)},
+        _adv("review_previous_notes", 0),
+        _adv("draft_story", 10),
+        _adv("story_gate", 30, "gate=pending"),
+        _gate("story_gate", "approve", 35),
+        _adv("verify_plan", 40),
+    ]
+
+
+# ── AC-1: per-step durations + order + entered_at ──────────────────────
+
+def test_per_step_durations_and_order():
+    from prism_service.services.conductor_service import compute_phase_metrics
+
+    res = compute_phase_metrics(
+        _walk_history(), [], now=_epoch(100), task_status="in_progress")
+    steps = res["steps"]
+    by = {s["step"]: s for s in steps}
+
+    # Canonical WORKFLOW_STEPS order (review < draft < story_gate < verify_plan).
+    assert [s["step"] for s in steps] == [
+        "review_previous_notes", "draft_story", "story_gate", "verify_plan"]
+
+    assert by["review_previous_notes"]["duration_s"] == 10.0
+    assert by["draft_story"]["duration_s"] == 20.0
+    assert by["story_gate"]["duration_s"] == 10.0
+    # The current/last step is measured to `now` (40 -> 100 == 60).
+    assert by["verify_plan"]["duration_s"] == 60.0
+
+    # Each entry records when it was entered.
+    assert by["draft_story"]["entered_at"] == _iso(10)
+
+
+# ── AC-2: token bucketing by step window + explicit step ───────────────
+
+def test_tokens_bucket_by_step_window_and_explicit_step():
+    from prism_service.services.conductor_service import compute_phase_metrics
+
+    pi_rows = [
+        # In the draft_story window [10, 30) -> draft_story.
+        {"ts": _epoch(15), "input_tokens": 40, "output_tokens": 100},
+        # In the verify_plan window [40, now) -> verify_plan; carries a model.
+        {"ts": _epoch(45), "input_tokens": 10, "output_tokens": 20,
+         "model": "qwen3:0.6b"},
+        # Explicit step wins over the ts (ts would fall in draft_story).
+        {"ts": _epoch(15), "step": "story_gate", "input_tokens": 5,
+         "output_tokens": 7},
+        # Out of window (before the first advance) -> ignored entirely.
+        {"ts": _epoch(-50), "input_tokens": 999, "output_tokens": 999},
+    ]
+    res = compute_phase_metrics(
+        _walk_history(), pi_rows, now=_epoch(100), task_status="in_progress")
+    by = {s["step"]: s for s in res["steps"]}
+
+    assert by["draft_story"]["tokens_in"] == 40
+    assert by["draft_story"]["tokens_out"] == 100
+    assert by["draft_story"]["turns"] == 1
+    assert by["verify_plan"]["tokens_in"] == 10
+    assert by["verify_plan"]["tokens_out"] == 20
+    assert by["verify_plan"]["model"] == "qwen3:0.6b"
+    assert by["story_gate"]["tokens_out"] == 7
+
+    # The out-of-window 999/999 row folded nowhere.
+    total = res["total"]
+    assert total["total_tokens"] == 40 + 100 + 10 + 20 + 5 + 7 == 182
+
+
+# ── AC-4: task total (wall duration + tok/s) ───────────────────────────
+
+def test_task_total_wall_and_tok_s():
+    from prism_service.services.conductor_service import compute_phase_metrics
+
+    pi_rows = [{"ts": _epoch(15), "input_tokens": 0, "output_tokens": 100}]
+    res = compute_phase_metrics(
+        _walk_history(), pi_rows, now=_epoch(100), task_status="in_progress")
+    total = res["total"]
+    assert total["wall_duration_s"] == 100.0
+    assert total["total_tokens"] == 100
+    # tok/s = total_tokens / wall_duration_s.
+    assert abs(total["tok_s"] - 1.0) < 1e-6
+
+
+# ── AC-3: gate outcome (approve/reject) + non-gate has none ────────────
+
+def test_gate_outcome_passed_and_failed():
+    from prism_service.services.conductor_service import compute_phase_metrics
+
+    hist = [
+        _adv("write_failing_tests", 0),
+        _adv("red_gate", 10, "gate=pending"),
+        _gate("red_gate", "reject", 12),
+    ]
+    res = compute_phase_metrics(
+        hist, [], now=_epoch(20), task_status="in_progress")
+    by = {s["step"]: s for s in res["steps"]}
+    assert by["red_gate"]["gate_outcome"] == "failed"
+    # A non-gate agent step never carries a gate outcome.
+    assert by["write_failing_tests"]["gate_outcome"] in (None, "none")
+
+    # story_gate approve -> passed (from the standard walk).
+    res2 = compute_phase_metrics(
+        _walk_history(), [], now=_epoch(100), task_status="in_progress")
+    by2 = {s["step"]: s for s in res2["steps"]}
+    assert by2["story_gate"]["gate_outcome"] == "passed"
+
+
+# ── AC-3: robustness — sparse / empty history never raises ─────────────
+
+def test_sparse_history_returns_empty_steps_without_raising():
+    from prism_service.services.conductor_service import compute_phase_metrics
+
+    only_created = [{"action": "created", "details": "title='x'",
+                     "timestamp": _iso(0)}]
+    res = compute_phase_metrics(
+        only_created, [], now=_epoch(50), task_status="in_progress")
+    assert res["steps"] == []
+    assert "wall_duration_s" in res["total"]
+
+    # Wholly empty history is still safe.
+    res2 = compute_phase_metrics([], [], now=_epoch(0))
+    assert res2["steps"] == []
+    assert res2["total"]["total_tokens"] == 0

--- a/services/prism-service/tests/unit/test_phase_metrics_ui.py
+++ b/services/prism-service/tests/unit/test_phase_metrics_ui.py
@@ -1,0 +1,67 @@
+"""UI contract — the Phase-metrics card on the task detail page (task bd1c2289).
+
+The PRISM SPA has no JS test runner, so the UI-FIRST acceptance criterion is
+pinned by asserting the ACTUAL web source (TSX) — the same pattern as
+tests/unit/test_task_tree_ui.py and the sibling *_ui.py contracts.
+
+These assert the real seams and ALL FAIL today (TaskDetailPage renders no
+Phase-metrics card; it reads phase_progress, never phase_metrics):
+
+  * AC-5 — TaskDetailPage merges the API's phase_metrics block onto the task and
+    renders a PhaseMetricsCard: one row per visited step with a duration bar,
+    duration, tokens (in/out), tok/s, and a gate-outcome pill for gate steps,
+    plus a header total (wall duration, total tokens, tok/s). It reuses the
+    shared stepLabel + gate chip helpers and Hermes accent tokens (no invented
+    palette).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SRC = _HERE.parent.parent.parent / "prism_service" / "web" / "src"
+_DETAIL = _SRC / "pages" / "TaskDetailPage.tsx"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def test_detail_page_reads_phase_metrics_from_api():
+    src = _read(_DETAIL)
+    # The detail page must consume the new top-level phase_metrics block
+    # (merged onto the task, like phase_progress) and read it back.
+    assert "phase_metrics" in src, \
+        "TaskDetailPage must read the API's phase_metrics block"
+    assert "task.phase_metrics" in src, \
+        "the card must read task.phase_metrics"
+
+
+def test_detail_page_renders_phase_metrics_card():
+    src = _read(_DETAIL)
+    assert "PhaseMetricsCard" in src, \
+        "a PhaseMetricsCard component must render the per-phase breakdown"
+    assert "Phase metrics" in src, "the card needs a 'Phase metrics' heading"
+    # One row per step, labelled with the shared workflow-step label helper.
+    assert "stepLabel" in src, "reuse the shared stepLabel helper"
+
+
+def test_phase_metrics_card_shows_per_step_effort_fields():
+    src = _read(_DETAIL)
+    # Per-step: duration + tokens (in/out) + tok/s + a gate-outcome pill.
+    assert "duration_s" in src, "each row shows its duration"
+    assert "tokens_out" in src and "tokens_in" in src, \
+        "each row shows tokens in/out"
+    assert "tok/s" in src, "each row shows a per-step tok/s rate"
+    assert "gate_outcome" in src, \
+        "gate steps render a passed/failed outcome pill"
+
+
+def test_phase_metrics_card_shows_task_total_and_is_hermes_themed():
+    src = _read(_DETAIL)
+    # Header total pulled from the API total block.
+    assert "wall_duration_s" in src, "the header shows the task wall duration"
+    assert "total_tokens" in src, "the header shows the task total tokens"
+    # Hermes accent tokens only — no invented palette.
+    assert "var(--accent-" in src, "status/gate tones must use Hermes tokens"

--- a/services/prism-service/tests/unit/test_phase_progress_pi_fold.py
+++ b/services/prism-service/tests/unit/test_phase_progress_pi_fold.py
@@ -1,0 +1,107 @@
+"""RED — conductor phase_progress folds task-attributed pi_runs into the burn
+(task fc08da8d).
+
+The browser PI agent runs inference LOCALLY; its exchanges never land in a
+Claude transcript, so a task the PI agent drove reads 0 turns / no tok/s on the
+/conductor tile. phase_progress must fold the task-attributed pi_runs rows
+(backend panel|pi|local, this task_id, in the work window) into the burn:
+tokens_since_step gains the PI output tokens (SUM — disjoint real work from a
+different agent, not a second measurement of one session) and token_turns / turns
+gain the PI exchange so the tile shows the PI agent's tok/s.
+
+FAIL today: phase_progress ignores pi_runs entirely.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_PID = "pi_fold_pid"
+
+
+def _conductor(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    proj_dir = tmp_path / "projects" / _PID
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    scores_db = str(proj_dir / "scores.db")
+    task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    import sqlite3
+    conn = sqlite3.connect(scores_db)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS session_outcomes ("
+            "session_id TEXT PRIMARY KEY, duration_s REAL, tokens_used INTEGER, "
+            "files_read INTEGER, files_modified INTEGER, skills_invoked INTEGER)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return task_svc, cond
+
+
+@pytest.fixture
+def isolated_pi_runs(tmp_path, monkeypatch):
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return prl
+
+
+def test_phase_progress_folds_task_attributed_pi_run(tmp_path, isolated_pi_runs):
+    task_svc, cond = _conductor(tmp_path)
+    prl = isolated_pi_runs
+
+    t = task_svc.create(title="PI-driven task")
+    cond.advance_task(t.id)  # onto the workflow (creates a history window)
+
+    now = time.time()
+    # A PI-panel exchange attributed to THIS task, in the work window (AFTER
+    # the task's first history row), with a matching project id (scores.db
+    # parent dir name).
+    prl.record_run(
+        backend="panel", model="qwen3:0.6b", purpose="panel-drive",
+        project=_PID, task_id=t.id, output_tokens=120, tokens=120,
+        ts_start=now, ts_end=now,
+    )
+
+    pp = cond.phase_progress(t.id)
+    assert pp["tokens_since_step"] >= 120, (
+        f"PI output tokens must fold into tokens_since_step, got {pp['tokens_since_step']}")
+    assert pp["turns"] >= 1, f"the PI exchange must count as a turn, got {pp['turns']}"
+    assert pp["token_turns"], "token_turns must include the PI burn point"
+    assert all({"out", "dt_s", "tok_s"} <= set(turn) for turn in pp["token_turns"])
+
+
+def test_pi_fold_ignores_other_tasks_and_out_of_window(tmp_path, isolated_pi_runs):
+    task_svc, cond = _conductor(tmp_path)
+    prl = isolated_pi_runs
+
+    t = task_svc.create(title="PI-driven task")
+    cond.advance_task(t.id)
+    now = time.time()
+
+    # Wrong task — must not fold.
+    prl.record_run(backend="panel", model="m", project=_PID,
+                   task_id="some-other-task", output_tokens=999, tokens=999,
+                   ts_start=now - 2, ts_end=now - 1)
+    # Right task but way in the future (out of window) — must not fold.
+    prl.record_run(backend="panel", model="m", project=_PID,
+                   task_id=t.id, output_tokens=888, tokens=888,
+                   ts_start=now + 9000, ts_end=now + 9001)
+
+    pp = cond.phase_progress(t.id)
+    assert pp["tokens_since_step"] == 0, pp["tokens_since_step"]
+    assert pp["turns"] == 0, pp["turns"]
+    assert pp["token_turns"] == []

--- a/services/prism-service/tests/unit/test_phase_progress_task_windowing.py
+++ b/services/prism-service/tests/unit/test_phase_progress_task_windowing.py
@@ -1,0 +1,240 @@
+"""RED — conductor tiles share turns across tasks (task 03a8bfe3).
+
+Owner-reported live bug: all concurrent conductor tiles render IDENTICAL
+turns/burn. phase_progress sums each linked session's ENTIRE transcript
+(claude_transcripts.live_tokens_for_session / live_token_events_for_session)
+and every task driven by ONE Claude session links the SAME session id in
+task_sessions — so N concurrent tasks all report the whole-session totals.
+
+Contract pinned here (plan AC-1..AC-4):
+  * A session SHARED by several tasks is intersected with each task's WORK
+    WINDOW — start = the task's first history timestamp (_task_window_start),
+    end = completed_at for done/cancelled tasks else now — so two concurrent
+    tasks report DIFFERENT turn sets / burn graphs / token totals (AC-1) and
+    a whole-session session_outcomes.tokens_used row never leaks into a
+    shared task's windowed total (AC-2).
+  * An EXCLUSIVE single-task session keeps its full span, including turns
+    recorded BEFORE the task's first history row — the #137 young-task
+    semantics are preserved verbatim (AC-3).
+  * The windowed read lives in claude_transcripts as
+    live_token_events_for_session_windowed (flat + nested subagent
+    transcripts, inclusive bounds, [] on an inverted window) so the per-file
+    (mtime,size) event cache is reused across the N tasks windowing one
+    shared session per poll (AC-4).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+_SERVICE_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services import claude_transcripts as ct  # noqa: E402
+
+_PID = "task_windowing_pid"
+
+
+def _write_transcript(path: Path, turns: list[tuple[float, int]]) -> None:
+    """Write a Claude transcript JSONL with one assistant turn per (epoch, out)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    from datetime import datetime, timezone
+
+    lines = []
+    for ep, tok in turns:
+        ts = datetime.fromtimestamp(ep, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+        lines.append(json.dumps({
+            "type": "assistant",
+            "timestamp": ts,
+            "message": {"usage": {"output_tokens": tok}},
+        }))
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _conductor(tmp_path):
+    """ConductorService whose scores.db lives at <tmp>/projects/<pid>/scores.db
+    so phase_progress derives project_id == _PID for the resolvers. Mirrors
+    tests/unit/test_phase_progress_token_turns.py."""
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    proj_dir = tmp_path / "projects" / _PID
+    proj_dir.mkdir(parents=True, exist_ok=True)
+    scores_db = str(proj_dir / "scores.db")
+    task_svc = TaskService(str(proj_dir / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    conn = sqlite3.connect(scores_db)
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS session_outcomes ("
+            "session_id TEXT PRIMARY KEY, duration_s REAL, tokens_used INTEGER, "
+            "files_read INTEGER, files_modified INTEGER, skills_invoked INTEGER)"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return task_svc, cond
+
+
+def _patch_resolvers(monkeypatch, source_path: str, override_dir: str):
+    """Bind the phase_progress resolvers at their module homes (the real seam)."""
+    monkeypatch.setattr(ct, "_project_source_path", lambda pid: source_path)
+    from prism_service.services import claude_memory as cm
+    monkeypatch.setattr(cm, "configured_project_dir", lambda pid: override_dir)
+
+
+def _two_tasks_one_session(tmp_path):
+    """One session JSONL, two tasks with DISJOINT work windows.
+
+    Timeline (all real wall-clock, separated by short sleeps so the task
+    history rows bracket disjoint windows):
+      task1 created+advanced -> [win1 opens]
+      task1 done             -> [win1 closes at completed_at]
+      task2 created+advanced -> [win2 opens .. now]
+    Then the shared transcript gets 3 turns inside win1 (100+110+120) and
+    2 turns inside win2 (500+600).
+    """
+    task_svc, cond = _conductor(tmp_path)
+    sid = "55555555-5555-5555-5555-555555555555"
+
+    t1 = task_svc.create(title="task one (earlier window)")
+    cond.advance_task(t1.id)
+    time.sleep(0.05)
+    task_svc.update(t1.id, status="done")
+    time.sleep(0.05)
+    t2 = task_svc.create(title="task two (later window)")
+    cond.advance_task(t2.id)
+    task_svc.update(t2.id, status="in_progress")
+
+    task_svc.link_session(t1.id, sid)
+    task_svc.link_session(t2.id, sid)
+
+    win1_start = cond._task_window_start(t1.id)
+    win1_end = cond._parse_iso(task_svc.get(t1.id).completed_at)
+    assert win1_end is not None and win1_end > win1_start
+    win2_start = cond._task_window_start(t2.id)
+    assert win2_start > win1_end
+
+    turns1 = [(win1_start + (win1_end - win1_start) * f, tok)
+              for f, tok in ((0.25, 100), (0.5, 110), (0.75, 120))]
+    turns2 = [(win2_start + 0.005, 500), (win2_start + 0.010, 600)]
+    d = tmp_path / "claudedir"
+    _write_transcript(d / f"{sid}.jsonl", turns1 + turns2)
+    return task_svc, cond, t1, t2, sid, d
+
+
+# ----------------------------------------------------------------------
+# AC-1 — two tasks sharing ONE session report their OWN windowed numbers.
+# ----------------------------------------------------------------------
+
+def test_shared_session_two_tasks_window_their_own_turns(tmp_path, monkeypatch):
+    _, cond, t1, t2, _sid, d = _two_tasks_one_session(tmp_path)
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp1 = cond.phase_progress(t1.id)
+    pp2 = cond.phase_progress(t2.id)
+
+    assert pp1["turns"] == 3, (
+        f"task1 must report ONLY its own 3 in-window turns, got {pp1['turns']} "
+        "(whole-session bleed — the shared-tile bug)"
+    )
+    assert pp2["turns"] == 2, (
+        f"task2 must report ONLY its own 2 in-window turns, got {pp2['turns']}"
+    )
+    assert [t["out"] for t in pp1["token_turns"]] == [100, 110, 120]
+    assert [t["out"] for t in pp2["token_turns"]] == [500, 600]
+    assert pp1["tokens_since_step"] == 330, pp1["tokens_since_step"]
+    assert pp2["tokens_since_step"] == 1100, pp2["tokens_since_step"]
+    assert pp1["token_turns"] != pp2["token_turns"], (
+        "concurrent tiles must not render IDENTICAL burn graphs"
+    )
+
+
+# ----------------------------------------------------------------------
+# AC-2 — whole-session outcome tokens must NOT leak into a shared task's
+# windowed total (max()-ing session_outcomes.tokens_used back in would
+# resurrect the bug the moment the post-hoc importer lands).
+# ----------------------------------------------------------------------
+
+def test_shared_session_outcome_tokens_do_not_leak(tmp_path, monkeypatch):
+    _, cond, t1, t2, sid, d = _two_tasks_one_session(tmp_path)
+    scores_db = str(tmp_path / "projects" / _PID / "scores.db")
+    conn = sqlite3.connect(scores_db)
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO session_outcomes "
+            "(session_id, duration_s, tokens_used, files_read, files_modified, "
+            "skills_invoked) VALUES (?, 0, 999999, 0, 0, 0)",
+            (sid,),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp1 = cond.phase_progress(t1.id)
+    pp2 = cond.phase_progress(t2.id)
+    assert pp1["tokens_since_step"] == 330, (
+        f"whole-session outcome tokens leaked into task1's shared window: "
+        f"{pp1['tokens_since_step']}"
+    )
+    assert pp2["tokens_since_step"] == 1100, (
+        f"whole-session outcome tokens leaked into task2's shared window: "
+        f"{pp2['tokens_since_step']}"
+    )
+
+
+# ----------------------------------------------------------------------
+# AC-3 — an EXCLUSIVE session keeps its FULL span (turns before the task's
+# first history row still count): #137 young-task semantics preserved.
+# ----------------------------------------------------------------------
+
+def test_exclusive_session_keeps_full_span(tmp_path, monkeypatch):
+    task_svc, cond = _conductor(tmp_path)
+    sid = "66666666-6666-6666-6666-666666666666"
+    d = tmp_path / "claudedir"
+    now = time.time()
+    # Work already on disk BEFORE the task exists (just-linked young task).
+    _write_transcript(d / f"{sid}.jsonl", [(now - 500, 80), (now - 400, 90)])
+
+    t = task_svc.create(title="young task, exclusive session")
+    cond.advance_task(t.id)
+    task_svc.link_session(t.id, sid)
+    _patch_resolvers(monkeypatch, source_path="", override_dir=str(d))
+
+    pp = cond.phase_progress(t.id)
+    assert pp["turns"] == 2, (
+        f"an exclusive session must keep its full span (#137 young-task "
+        f"semantics) — got {pp['turns']} turns"
+    )
+    assert pp["tokens_since_step"] == 170, pp["tokens_since_step"]
+
+
+# ----------------------------------------------------------------------
+# AC-4 — the windowed reader lives in claude_transcripts and reuses the
+# flat + nested subagent layout with inclusive bounds.
+# ----------------------------------------------------------------------
+
+def test_windowed_reader_filters_events(tmp_path):
+    assert hasattr(ct, "live_token_events_for_session_windowed"), (
+        "claude_transcripts must expose live_token_events_for_session_windowed "
+        "(the windowed per-turn read the conductor windows tasks through)"
+    )
+    sid = "77777777-7777-7777-7777-777777777777"
+    d = tmp_path / "claudedir"
+    _write_transcript(d / f"{sid}.jsonl", [(1000.0, 10), (2000.0, 20)])
+    _write_transcript(d / sid / "subagent.jsonl", [(1500.0, 15), (3000.0, 30)])
+
+    fn = ct.live_token_events_for_session_windowed
+    events = fn(sid, "", 1000.0, 2000.0, override_dir=str(d))
+    assert [tok for _, tok in events] == [10, 15, 20], (
+        f"inclusive [since, until] over flat+nested transcripts, got {events}"
+    )
+    assert fn(sid, "", 2000.0, 1000.0, override_dir=str(d)) == [], (
+        "inverted window must return []"
+    )

--- a/services/prism-service/tests/unit/test_pi_agent_run_recording.py
+++ b/services/prism-service/tests/unit/test_pi_agent_run_recording.py
@@ -1,0 +1,151 @@
+"""RED scaffold — pi_agent.invoke() records every run into pi_run_log.
+
+The recording seam is ADDITIVE: a successful runner job appends exactly
+one backend=pi manifest row carrying the runner's tools_used receipts;
+a spawn failure appends an ok=False row and still raises PiRuntimeError;
+a broken ledger never breaks invoke() (never raises into the caller).
+
+ALL FAIL today: pi_run_log does not exist and invoke() records nothing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+@pytest.fixture
+def fake_runner(tmp_path, monkeypatch):
+    """Point PRISM_PI_RUNNER at an existing file and stub node discovery
+    so invoke() reaches the subprocess seam without a real Node install."""
+    runner = tmp_path / "fake-runtime.mjs"
+    runner.write_text("// fake pi runner", encoding="utf-8")
+    monkeypatch.setenv("PRISM_PI_RUNNER", str(runner))
+    monkeypatch.setenv("PRISM_PI_NODE", "node-not-actually-spawned")
+    return runner
+
+
+def _completed(payload: dict, returncode: int = 0):
+    return subprocess.CompletedProcess(
+        args=["node"], returncode=returncode,
+        stdout=json.dumps(payload), stderr="")
+
+
+RESULT = {
+    "ok": True,
+    "text": "grounded answer",
+    "turns": 2,
+    "tools_used": [{"name": "brain_search", "ms": 31.5, "ok": True}],
+    "ms": 812.0,
+    "tokens": 57,
+    "model": "qwen3:0.6b",
+}
+
+
+def test_invoke_records_one_pi_row_with_receipts(
+        isolated_runs_dir, fake_runner, monkeypatch):
+    from prism_service.inference import pi_agent
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(pi_agent.subprocess, "run",
+                        lambda *a, **k: _completed(RESULT))
+    out = pi_agent.invoke("prompt text", project="proj-y")
+    assert out["ok"] is True
+
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1, "exactly one manifest row per invoke"
+    r = runs[0]
+    assert r["backend"] == "pi"
+    assert r["project"] == "proj-y"
+    assert r["model"] == "qwen3:0.6b"
+    assert r["tokens"] == 57
+    assert r["turns"] == 2
+    assert r["duration_ms"] == pytest.approx(812.0)
+    assert r["prompt_chars"] == len("prompt text")
+    assert r["tools_used"] == [{"name": "brain_search", "ms": 31.5, "ok": True}]
+    assert r["ok"] is True
+
+
+def test_invoke_purpose_explicit_and_inferred(
+        isolated_runs_dir, fake_runner, monkeypatch):
+    from prism_service.inference import pi_agent
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(pi_agent.subprocess, "run",
+                        lambda *a, **k: _completed(RESULT))
+
+    # Explicit purpose wins.
+    pi_agent.invoke("p1", purpose="panel-bridge")
+    # Reflection is inferred from the reflection engine's system prompt
+    # (reflection_runner is owned by another lane and passes no purpose).
+    pi_agent.invoke("p2", system="You are PRISM's reflection engine and "
+                                 "its memory/brain expert.")
+    # No purpose, no reflection marker -> adhoc.
+    pi_agent.invoke("p3")
+
+    purposes = [r["purpose"] for r in prl.list_recent(limit=10)]
+    assert purposes == ["adhoc", "reflect", "panel-bridge"]  # newest first
+
+
+def test_invoke_model_failure_row_is_not_ok(
+        isolated_runs_dir, fake_runner, monkeypatch):
+    from prism_service.inference import pi_agent
+    import prism_service.services.pi_run_log as prl
+
+    failed = dict(RESULT, ok=False, text="", error="model refused")
+    monkeypatch.setattr(pi_agent.subprocess, "run",
+                        lambda *a, **k: _completed(failed))
+    out = pi_agent.invoke("p")
+    assert out["ok"] is False
+
+    r = prl.list_recent(limit=1)[0]
+    assert r["ok"] is False
+    assert r["error"] == "model refused"
+
+
+def test_invoke_spawn_failure_records_error_row_and_raises(
+        isolated_runs_dir, fake_runner, monkeypatch):
+    from prism_service.inference import pi_agent
+    import prism_service.services.pi_run_log as prl
+
+    def _boom(*a, **k):
+        raise OSError("no node")
+    monkeypatch.setattr(pi_agent.subprocess, "run", _boom)
+
+    with pytest.raises(pi_agent.PiRuntimeError):
+        pi_agent.invoke("p")
+
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1
+    assert runs[0]["ok"] is False
+    assert "no node" in runs[0]["error"]
+
+
+def test_broken_ledger_never_breaks_invoke(
+        isolated_runs_dir, fake_runner, monkeypatch):
+    """Recording is additive — a raising ledger must not raise into the
+    caller path (AC-2)."""
+    from prism_service.inference import pi_agent
+    import prism_service.services.pi_run_log as prl
+
+    monkeypatch.setattr(pi_agent.subprocess, "run",
+                        lambda *a, **k: _completed(RESULT))
+
+    def _explode(**kwargs):
+        raise RuntimeError("ledger on fire")
+    monkeypatch.setattr(prl, "record_run", _explode)
+
+    out = pi_agent.invoke("p")
+    assert out["ok"] is True
+    assert out["text"] == "grounded answer"

--- a/services/prism-service/tests/unit/test_pi_run_log.py
+++ b/services/prism-service/tests/unit/test_pi_run_log.py
@@ -1,0 +1,133 @@
+"""RED scaffold — pi/local internal-inference run ledger (visual audit).
+
+Every internal pi/local inference run (pi_agent.invoke jobs incl.
+reflection backend=pi, local_llm.complete calls) must land in an
+auditable ledger: services/pi_run_log.py, mirroring the claude_run_log
+pattern (append-only DATA_DIR/pi_runs/manifest.jsonl, bounded trim,
+best-effort record that never raises, list_recent/get_run).
+
+ALL FAIL today: prism_service.services.pi_run_log does not exist.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    """Repoint pi_run_log at tmp_path — mirror of the claude_run_log
+    fixture so manifest writes never touch a live data volume."""
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+def _record(prl, **overrides):
+    kwargs = dict(
+        backend="pi",
+        model="qwen3:0.6b",
+        purpose="reflect",
+        project="proj-x",
+        prompt_chars=1234,
+        tools_used=[{"name": "brain_search", "ms": 40.2, "ok": True},
+                    {"name": "memory_recall", "ms": 12.0, "ok": False}],
+        duration_ms=1567.8,
+        tokens=42,
+        turns=3,
+        ok=True,
+        error="",
+    )
+    kwargs.update(overrides)
+    return prl.record_run(**kwargs)
+
+
+def test_record_and_list_round_trip(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    run_id = _record(prl)
+    assert run_id, "record_run must return the allocated run_id"
+
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1
+    r = runs[0]
+    assert r["run_id"] == run_id
+    assert r["backend"] == "pi"
+    assert r["model"] == "qwen3:0.6b"
+    assert r["purpose"] == "reflect"
+    assert r["project"] == "proj-x"
+    assert r["prompt_chars"] == 1234
+    assert r["duration_ms"] == pytest.approx(1567.8)
+    assert r["tokens"] == 42
+    assert r["turns"] == 3
+    assert r["ok"] is True
+    assert r["error"] == ""
+    # tools_used receipts ride the manifest row (no stream file for pi).
+    assert r["tools_used"] == [
+        {"name": "brain_search", "ms": 40.2, "ok": True},
+        {"name": "memory_recall", "ms": 12.0, "ok": False},
+    ]
+    assert isinstance(r["ts"], float) and r["ts"] > 0
+
+
+def test_list_recent_newest_first_and_project_filter(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    first = _record(prl, project="alpha", model="m-1")
+    second = _record(prl, project="beta", model="m-2")
+    third = _record(prl, project="alpha", model="m-3")
+
+    runs = prl.list_recent(limit=10)
+    assert [r["run_id"] for r in runs] == [third, second, first]
+
+    alpha = prl.list_recent(limit=10, project="alpha")
+    assert [r["run_id"] for r in alpha] == [third, first]
+    assert prl.list_recent(limit=10, project="never-seen") == []
+    # limit slices AFTER newest-first ordering.
+    assert [r["run_id"] for r in prl.list_recent(limit=1)] == [third]
+
+
+def test_get_run_returns_full_entry(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    run_id = _record(prl, backend="local", ok=False,
+                     error="URLError: connection refused", tools_used=[])
+    entry = prl.get_run(run_id)
+    assert entry is not None
+    assert entry["backend"] == "local"
+    assert entry["ok"] is False
+    assert entry["error"] == "URLError: connection refused"
+    assert prl.get_run("does-not-exist") is None
+
+
+def test_trim_to_limit_drops_oldest(isolated_runs_dir, monkeypatch):
+    import prism_service.services.pi_run_log as prl
+    monkeypatch.setattr(prl, "RUN_LOG_LIMIT", 2)
+
+    ids = [_record(prl, model=f"m-{i}") for i in range(4)]
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 2
+    assert [r["run_id"] for r in runs] == [ids[3], ids[2]]
+
+
+def test_record_run_failure_does_not_raise(isolated_runs_dir, monkeypatch):
+    """Ledger writes are best-effort — a broken manifest path must never
+    raise into the inference caller path (AC-1)."""
+    import prism_service.services.pi_run_log as prl
+    bad = isolated_runs_dir / "is_a_dir"
+    bad.mkdir(parents=True)
+    monkeypatch.setattr(prl, "_MANIFEST", bad)
+
+    # Should not raise; returns None on failure.
+    assert _record(prl) is None
+
+
+def test_error_text_is_truncated(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    run_id = _record(prl, ok=False, error="x" * 8192)
+    entry = prl.get_run(run_id)
+    assert entry is not None
+    assert len(entry["error"]) <= 1024

--- a/services/prism-service/tests/unit/test_pi_run_log_task_id.py
+++ b/services/prism-service/tests/unit/test_pi_run_log_task_id.py
@@ -1,0 +1,57 @@
+"""RED — pi_run_log gains task attribution (task fc08da8d).
+
+The pi_runs ledger had no task_id, so a run the PI agent made while driving a
+task could not be attributed to that task on the conductor tile or task detail.
+record_run must accept an additive `task_id` (default "") that rides the
+manifest row, and list_recent must gain an optional task_id filter.
+
+FAIL today: record_run has no task_id kwarg / the row omits task_id /
+list_recent ignores task_id.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def isolated_runs_dir(tmp_path, monkeypatch):
+    import prism_service.services.pi_run_log as prl
+    runs_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(prl, "_RUNS_DIR", runs_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", runs_dir / "manifest.jsonl")
+    return runs_dir
+
+
+def test_record_run_carries_task_id(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    run_id = prl.record_run(
+        backend="panel", model="qwen3:0.6b", purpose="panel-drive",
+        project="prism", task_id="fc08da8d-task", output_tokens=42, tokens=42,
+    )
+    assert run_id
+    entry = prl.get_run(run_id)
+    assert entry is not None
+    assert entry["task_id"] == "fc08da8d-task"
+
+
+def test_task_id_defaults_empty(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    run_id = prl.record_run(backend="pi", model="m", project="prism")
+    entry = prl.get_run(run_id)
+    assert entry is not None
+    assert entry["task_id"] == ""
+
+
+def test_list_recent_filters_by_task_id(isolated_runs_dir):
+    import prism_service.services.pi_run_log as prl
+
+    a = prl.record_run(backend="panel", model="m", project="prism", task_id="T-1")
+    _b = prl.record_run(backend="panel", model="m", project="prism", task_id="T-2")
+    c = prl.record_run(backend="panel", model="m", project="prism", task_id="T-1")
+
+    rows = prl.list_recent(limit=10, project="prism", task_id="T-1")
+    assert [r["run_id"] for r in rows] == [c, a]
+    assert prl.list_recent(limit=10, project="prism", task_id="never") == []

--- a/services/prism-service/tests/unit/test_pidfile_lifecycle.py
+++ b/services/prism-service/tests/unit/test_pidfile_lifecycle.py
@@ -146,6 +146,7 @@ def test_cmd_start_refuses_when_mcp_port_held(data_dir, monkeypatch, capsys):
     assert "already held by pid 49019" in capsys.readouterr().err
 
 
+@pytest.mark.daemon_exclusive  # task 91ac81e8: reaps a real orphan pid; flakes in-daemon
 def test_cmd_status_reports_unhealthy_and_self_heals_split_brain(data_dir, monkeypatch, capsys):
     # Two pids each own one port -> UNHEALTHY + reap the orphan, exit non-zero (AC-3).
     cli._write_pid(26138)
@@ -164,6 +165,7 @@ def test_cmd_status_reports_unhealthy_and_self_heals_split_brain(data_dir, monke
     assert killed == [49019]              # orphan reaped, keeper (UI pid) spared
 
 
+@pytest.mark.daemon_exclusive  # task 91ac81e8: reaps a real orphan pid; flakes in-daemon
 def test_cmd_stop_reaps_split_brain_orphan(data_dir, monkeypatch, capsys):
     cli._write_pid(26138)
     monkeypatch.setattr(cli, "_is_alive", lambda pid: True)

--- a/services/prism-service/tests/unit/test_prism_guide_concise.py
+++ b/services/prism-service/tests/unit/test_prism_guide_concise.py
@@ -1,0 +1,62 @@
+"""prism_guide must be a genuinely concise orientation (task 5f93f67a).
+
+The overview section (and thus the no-section default) embedded the entire
+PRISM_VERSION_NOTES changelog via _version_banner(), so a "READ FIRST" call
+cost ~50K tokens. The default + overview must be single-digit-K tokens; the
+exhaustive release history must remain reachable behind an explicit
+section='changelog'.
+
+RED before the fix: default ~201K chars, overview ~184K chars, and there is
+no 'changelog' section.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+# ~8K tokens at ~4 chars/token — a sane READ-FIRST budget.
+BUDGET = 32000
+
+
+def test_default_orientation_is_concise():  # AC-1
+    from prism_service.mcp.tools import _prism_guide
+    out = _prism_guide(None)
+    assert len(out) < BUDGET, (
+        f"default prism_guide is {len(out)} chars (~{len(out)//4} tokens); "
+        f"must be under {BUDGET}"
+    )
+    # Still a real orientation: names the key tools.
+    assert "brain_search" in out
+    assert "memory_store" in out
+
+
+def test_overview_is_concise_and_points_to_changelog():  # AC-2
+    from prism_service.mcp.tools import _prism_guide
+    out = _prism_guide("overview")
+    assert len(out) < BUDGET, (
+        f"overview is {len(out)} chars (~{len(out)//4} tokens); "
+        f"must be under {BUDGET}"
+    )
+    assert "changelog" in out.lower(), (
+        "overview must point readers to the changelog section"
+    )
+
+
+def test_full_history_relocated_behind_changelog_section():  # AC-3
+    from prism_service.mcp.tools import _prism_guide, _GUIDE_SECTIONS
+    from prism_service.__version__ import PRISM_VERSION_NOTES
+    assert "changelog" in _GUIDE_SECTIONS, (
+        "the exhaustive release history must live in an explicit "
+        "'changelog' section"
+    )
+    full = _prism_guide("changelog")
+    assert len(full) > 50000, (
+        "the full release history must remain reachable (not lost)"
+    )
+    assert PRISM_VERSION_NOTES[:2000] in full

--- a/services/prism-service/tests/unit/test_project_context_cache_isolation.py
+++ b/services/prism-service/tests/unit/test_project_context_cache_isolation.py
@@ -1,0 +1,55 @@
+"""ProjectContext cache must key by data dir, not project name (33a1397b).
+
+The process-global ``_contexts`` cache in project_context.py keyed on the
+project NAME alone. Under a changed ``PRISM_DATA_DIR`` (every test that
+monkeypatches a tmp data dir), ``get_project(name)`` returned the ALREADY
+cached context bound to the FIRST data dir, so writes leaked into a shared
+store and later tests' listing assertions saw phantom rows.
+
+Contract: two ``get_project`` calls for the SAME project id under DIFFERENT
+data dirs must return DISTINCT contexts bound to DISTINCT stores.
+
+  * AC-1 distinct context objects  — oracle: ctx_a is not ctx_b
+  * AC-2 distinct on-disk stores   — oracle: ctx_a._data_dir != ctx_b._data_dir
+"""
+
+from __future__ import annotations
+
+
+def _point_at(monkeypatch, data_dir):
+    """Route BOTH the env (the cache key source) and config's frozen
+    globals (the seeding/existence source) at *data_dir*, the way a real
+    isolated test must so a PRISM_DATA_DIR change actually takes effect."""
+    import prism_service.config as cfg
+    monkeypatch.setenv("PRISM_DATA_DIR", str(data_dir))
+    monkeypatch.setattr(cfg, "DATA_DIR", data_dir)
+    monkeypatch.setattr(cfg, "PROJECTS_DIR", data_dir / "projects")
+
+
+def test_get_project_cache_keys_by_data_dir(tmp_path, monkeypatch):
+    from prism_service import project_context as pc
+    from prism_service.config import project_data_dir
+
+    dir_a = tmp_path / "store_a"
+    dir_b = tmp_path / "store_b"
+
+    # First data dir: seed the project then resolve its context.
+    _point_at(monkeypatch, dir_a)
+    project_data_dir("isoproj")          # existence door under dir_a
+    ctx_a = pc.get_project("isoproj")
+
+    # Switch data dir (as a per-test monkeypatch does) and resolve again.
+    _point_at(monkeypatch, dir_b)
+    project_data_dir("isoproj")          # existence door under dir_b
+    ctx_b = pc.get_project("isoproj")
+
+    # AC-1: a data-dir change must yield a FRESH context. Pre-fix the
+    # name-only cache handed back the dir_a context here.
+    assert ctx_a is not ctx_b, (
+        "get_project returned the cached dir_a context under a new data dir "
+        "- cache must key by (data_dir, project_id)"
+    )
+    # AC-2: the two contexts must be bound to different on-disk stores.
+    assert ctx_a._data_dir != ctx_b._data_dir
+    assert str(dir_a) in str(ctx_a._data_dir)
+    assert str(dir_b) in str(ctx_b._data_dir)

--- a/services/prism-service/tests/unit/test_run_ledger_parity.py
+++ b/services/prism-service/tests/unit/test_run_ledger_parity.py
@@ -1,0 +1,229 @@
+"""Red suite — run-ledger parity/reconciliation
+(task d1d4fe00, claude-p-exit epic be898578).
+
+Wave 1 wired the local-backend seams (memory summary, graph enrich,
+brain ask) into claude_runs via claude_run_log.record_local_run; the
+audit lane wired pi_run_log recording INSIDE local_llm.complete. Every
+local run therefore DOUBLE-RECORDS: one claude_runs row + one pi_runs
+row for the same completion.
+
+Reconciled architecture under test here:
+  * pi_runs is THE ledger for backend pi|local (the /internal-agent
+    audit surface) — local_llm.complete is the single recording point,
+    carries the caller's purpose/project, records the input/output
+    token split on the row, and additively returns the row's run_id.
+  * claude_runs stays claude-only — the seams stop writing it and
+    claude_run_log.record_local_run is removed.
+
+Every test drives the REAL local_llm.complete (urlopen stubbed) so the
+single-recording-point claim is exercised end to end, not around it.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def ledgers(tmp_path, monkeypatch):
+    """Isolate BOTH ledgers so cross-talk between them is observable."""
+    import prism_service.services.claude_run_log as crl
+    import prism_service.services.pi_run_log as prl
+    c_dir = tmp_path / "claude_runs"
+    p_dir = tmp_path / "pi_runs"
+    monkeypatch.setattr(crl, "_RUNS_DIR", c_dir)
+    monkeypatch.setattr(crl, "_MANIFEST", c_dir / "manifest.jsonl")
+    monkeypatch.setattr(prl, "_RUNS_DIR", p_dir)
+    monkeypatch.setattr(prl, "_MANIFEST", p_dir / "manifest.jsonl")
+    return SimpleNamespace(claude_dir=c_dir, pi_dir=p_dir)
+
+
+def _rows(runs_dir):
+    mf = runs_dir / "manifest.jsonl"
+    if not mf.exists():
+        return []
+    return [json.loads(ln) for ln in
+            mf.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+
+class _FakeResponse(io.BytesIO):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_endpoint(monkeypatch, text: str,
+                   prompt_tokens: int = 19, completion_tokens: int = 7):
+    from prism_service.inference import local_llm
+    payload = json.dumps({
+        "choices": [{"message": {"role": "assistant", "content": text}}],
+        "usage": {"prompt_tokens": prompt_tokens,
+                  "completion_tokens": completion_tokens},
+    }).encode()
+    monkeypatch.setattr(
+        local_llm.urllib.request, "urlopen",
+        lambda req, timeout=0: _FakeResponse(payload))
+
+
+@pytest.fixture
+def forbid_claude(monkeypatch):
+    from prism_service.inference import claude_cli
+
+    def forbidden(*a, **k):
+        raise AssertionError(
+            "claude_cli.invoke must not run on the local backend")
+    monkeypatch.setattr(claude_cli, "invoke", forbidden)
+
+
+# ----------------------------------------------------------------------
+# AC-4 — local_llm.complete returns run_id + records the token split.
+# ----------------------------------------------------------------------
+def test_complete_returns_run_id_and_token_split(ledgers, monkeypatch):
+    from prism_service.inference import local_llm
+    import prism_service.services.pi_run_log as prl
+
+    _stub_endpoint(monkeypatch, "hello", prompt_tokens=23,
+                   completion_tokens=11)
+    out = local_llm.complete("brief", model="stub-micro",
+                             purpose="adhoc", project="proj-z")
+
+    assert out["run_id"], "complete must return the pi ledger run_id"
+    runs = prl.list_recent(limit=10)
+    assert len(runs) == 1
+    row = runs[0]
+    assert row["run_id"] == out["run_id"]
+    assert row["backend"] == "local"
+    assert row["tokens"] == 11          # completion side, unchanged meaning
+    assert row["input_tokens"] == 23    # additive split — never lost
+    assert row["output_tokens"] == 11
+    assert _rows(ledgers.claude_dir) == [], \
+        "a plain local completion must not touch claude_runs"
+
+
+# ----------------------------------------------------------------------
+# AC-1 — memory-summary local run: ONE pi row, ZERO claude_runs rows.
+# ----------------------------------------------------------------------
+def test_memory_summary_local_single_pi_row(ledgers, monkeypatch,
+                                            forbid_claude):
+    import prism_service.services.pi_run_log as prl
+    from prism_service.services import memory_summary_worker as msw
+
+    monkeypatch.setenv("PRISM_MEMORY_SUMMARY_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    _stub_endpoint(monkeypatch, "One clean tile sentence.",
+                   prompt_tokens=41, completion_tokens=9)
+
+    out = msw.summarize_one("mem-name", "mem-desc", "proj-z")
+    assert out == "One clean tile sentence."
+
+    pi_rows = prl.list_recent(limit=10)
+    assert len(pi_rows) == 1, \
+        "exactly one pi_runs row per local summary (no double-record)"
+    row = pi_rows[0]
+    assert row["backend"] == "local"
+    assert row["purpose"] == "memory_summary"
+    assert row["project"] == "proj-z"
+    assert row["input_tokens"] == 41
+    assert row["output_tokens"] == 9
+    assert _rows(ledgers.claude_dir) == [], \
+        "claude_runs must stay claude-only (no local seam rows)"
+
+
+# ----------------------------------------------------------------------
+# AC-2 — graph-enrich local run: ONE pi row, ZERO claude_runs rows.
+# ----------------------------------------------------------------------
+def test_graph_enrich_local_single_pi_row(ledgers, monkeypatch,
+                                          forbid_claude):
+    import prism_service.services.pi_run_log as prl
+    from prism_service.services import graph_enrich as ge
+
+    monkeypatch.setenv("PRISM_GRAPH_ENRICH_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    _stub_endpoint(monkeypatch,
+                   '{"name": "Pi Ledger", "purpose": "Audits runs."}',
+                   prompt_tokens=52, completion_tokens=13)
+
+    scope = {"scope_id": "prism/services", "level": 1,
+             "files": ["a.py", "b.py"], "symbols": ["Alpha"],
+             "input_hash": "cafebabe1234"}
+    assert ge.enrich_one(scope, "proj-z") == ("Pi Ledger", "Audits runs.")
+
+    pi_rows = prl.list_recent(limit=10)
+    assert len(pi_rows) == 1, \
+        "exactly one pi_runs row per local enrich (no double-record)"
+    row = pi_rows[0]
+    assert row["backend"] == "local"
+    assert row["purpose"] == "graph_enrich"
+    assert row["project"] == "proj-z"
+    assert row["input_tokens"] == 52
+    assert row["output_tokens"] == 13
+    assert _rows(ledgers.claude_dir) == [], \
+        "claude_runs must stay claude-only (no local seam rows)"
+
+
+# ----------------------------------------------------------------------
+# AC-3 — brain-ask local run: ONE pi row whose run_id fills the response.
+# ----------------------------------------------------------------------
+def test_brain_ask_local_single_pi_row(ledgers, monkeypatch, forbid_claude):
+    import prism_service.services.pi_run_log as prl
+    from prism_service.api import brain as brain_api
+
+    monkeypatch.setenv("PRISM_BRAIN_ASK_BACKEND", "local")
+    monkeypatch.setenv("PRISM_LOCAL_LLM_MODEL", "stub-micro")
+    _stub_endpoint(monkeypatch, "Grounded local answer [1].",
+                   prompt_tokens=77, completion_tokens=15)
+
+    body = brain_api.AskBody(q="where is the ledger?", project="proj-z")
+    resp = brain_api._ask_local(
+        body, body.q, "## Retrieved context\n\n(no matching context found)",
+        [{"source_file": "a.py", "entity_name": "f",
+          "entity_kind": "function", "rrf_score": 0.5, "content": "x"}])
+
+    assert resp["answer"] == "Grounded local answer [1]."
+    assert resp["tokens"] == {"input": 77, "output": 15}
+
+    pi_rows = prl.list_recent(limit=10)
+    assert len(pi_rows) == 1, \
+        "exactly one pi_runs row per local ask (no double-record)"
+    row = pi_rows[0]
+    assert row["backend"] == "local"
+    assert row["purpose"].startswith("brain_ask@")
+    assert row["project"] == "proj-z"
+    assert row["input_tokens"] == 77
+    assert row["output_tokens"] == 15
+    assert resp["run_id"] == row["run_id"], \
+        "the /ask response run_id must be the pi ledger row id"
+    assert _rows(ledgers.claude_dir) == [], \
+        "claude_runs must stay claude-only (no local seam rows)"
+
+
+# ----------------------------------------------------------------------
+# AC-5 — claude_runs is claude-only: record_local_run is gone,
+#         record_run (the claude path) still works.
+# ----------------------------------------------------------------------
+def test_claude_run_log_is_claude_only(ledgers, tmp_path):
+    import prism_service.services.claude_run_log as crl
+
+    assert not hasattr(crl, "record_local_run"), \
+        "record_local_run must be removed — pi|local rows belong in pi_runs"
+
+    run_id, stream_path = crl.new_run()
+    stream_path.write_text("", encoding="utf-8")
+    crl.record_run(
+        run_id=run_id, stream_path=stream_path,
+        ts_start=1.0, ts_end=2.0, project="proj-z",
+        purpose="tour_builder@abc", exit_code=0,
+        usage={"input_tokens": 5, "output_tokens": 3},
+        stderr_text="",
+    )
+    rows = _rows(ledgers.claude_dir)
+    assert len(rows) == 1
+    assert rows[0]["backend"] == "claude"
+    assert rows[0]["input_tokens"] == 5
+    assert rows[0]["output_tokens"] == 3

--- a/services/prism-service/tests/unit/test_task_hierarchy.py
+++ b/services/prism-service/tests/unit/test_task_hierarchy.py
@@ -71,7 +71,10 @@ def test_parent_id_independent_of_dependencies(tmp_path):
     fields and don't bleed into each other."""
     svc = _mk_service(tmp_path)
     epic = svc.create(title="epic")
-    child = svc.create(title="child", parent_id=epic.id, dependencies=["x"])
+    # Dependencies must name existing tasks (47d0179a) — use a real one.
+    dep = svc.create(title="blocking work")
+    child = svc.create(
+        title="child", parent_id=epic.id, dependencies=[dep.id])
     got = svc.get(child.id)
     assert got.parent_id == epic.id
-    assert got.dependencies == ["x"]
+    assert got.dependencies == [dep.id]

--- a/services/prism-service/tests/unit/test_task_misfire.py
+++ b/services/prism-service/tests/unit/test_task_misfire.py
@@ -50,6 +50,9 @@ def project(tmp_path, monkeypatch):
     from prism_service import project_context as pc
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-misfire")
     pc._contexts.clear()
     yield "test-misfire"
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_task_next_claim_lease.py
+++ b/services/prism-service/tests/unit/test_task_next_claim_lease.py
@@ -1,0 +1,87 @@
+"""Claim lease on task_next (task 41af13c0-6716-49a4-8c5a-7310bf8a0db8).
+
+STRESS-LOOP FINDING: task_next / conductor claiming had no lease — two
+concurrent drivers could grab the SAME task (observed live: 9f61d484 was
+double-driven). next_task now atomically stamps claimed_by + claimed_at and
+skips tasks claimed within a freshness window by a DIFFERENT session, so a
+second next_task from another session returns a DIFFERENT task. Unclaimed and
+expired-claim tasks are still returned (backward compatible).
+
+RED before the lease lands: next_task() takes no session_id, so the
+session-scoped calls raise TypeError and the distinct-task guarantee is absent.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _svc(tmp_path):
+    from prism_service.services.task_service import TaskService
+    return TaskService(str(tmp_path / "tasks.db"))
+
+
+# AC-1 — two distinct sessions never claim the same task.
+def test_distinct_sessions_get_distinct_tasks(tmp_path):
+    svc = _svc(tmp_path)
+    svc.create(title="A", priority=10)
+    svc.create(title="B", priority=5)
+    first = svc.next_task(session_id="sess-A")["task"]
+    second = svc.next_task(session_id="sess-B")["task"]
+    assert first.id != second.id, (
+        "a task freshly claimed by sess-A must not be handed to sess-B"
+    )
+
+
+# AC-2 — the claim is stamped onto the returned task (claimed_by/claimed_at).
+def test_next_task_stamps_claim(tmp_path):
+    svc = _svc(tmp_path)
+    svc.create(title="A", priority=10)
+    got = svc.next_task(session_id="sess-A")["task"]
+    row = svc.get(got.id)
+    assert row.claimed_by == "sess-A" and row.claimed_at, (
+        "next_task must stamp claimed_by + claimed_at on the returned task"
+    )
+
+
+# AC-3 — the same session re-claiming gets its own task back (idempotent).
+def test_same_session_reclaims_its_own(tmp_path):
+    svc = _svc(tmp_path)
+    svc.create(title="A", priority=10)
+    svc.create(title="B", priority=5)
+    first = svc.next_task(session_id="sess-A")["task"]
+    again = svc.next_task(session_id="sess-A")["task"]
+    assert first.id == again.id, "a session keeps its own fresh claim"
+
+
+# AC-4 — an expired claim is reclaimable by another session.
+def test_expired_claim_is_reclaimable(tmp_path):
+    svc = _svc(tmp_path)
+    svc.create(title="A", priority=10)
+    svc.create(title="B", priority=5)
+    first = svc.next_task(session_id="sess-A")["task"]
+    stale = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat()
+    svc._db.execute(
+        "UPDATE tasks SET claimed_at=? WHERE id=?", (stale, first.id))
+    svc._db.commit()
+    reclaimed = svc.next_task(session_id="sess-C", lease_window_s=900)["task"]
+    assert reclaimed.id == first.id, (
+        "a claim older than the freshness window is up for grabs again"
+    )
+
+
+# AC-5 — backward compatible: no session_id keeps the legacy behavior.
+def test_no_session_is_backward_compatible(tmp_path):
+    svc = _svc(tmp_path)
+    a = svc.create(title="A", priority=10)
+    svc.create(title="B", priority=5)
+    assert svc.next_task()["task"].id == a.id, (
+        "a session-less next_task still returns the highest-priority task"
+    )

--- a/services/prism-service/tests/unit/test_task_subtree_rollup.py
+++ b/services/prism-service/tests/unit/test_task_subtree_rollup.py
@@ -1,0 +1,216 @@
+"""RED scaffold — tasks render and roll up to ANY depth (task e72aba6d).
+
+PRISM stores a task tree via parent_id, but every consumer today looks ONE
+level deep: the detail API/page list only DIRECT children, and the epic
+green_gate roll-up considers only DIRECT children — so deep fanout is invisible
+past the first hop and a grandchild's incompleteness cannot block a
+grandparent.
+
+Pins, RED-first (these FAIL before descendants()/descendant_counts(), the
+subtree-annotated detail API, and the subtree-aware epic_rollup_verdict land):
+
+  * AC-1 — TaskService.descendants(id) walks the WHOLE subtree (transitive
+    children, task excluded) breadth-first and is cycle-safe; descendant_counts
+    returns (total, done) over that subtree.
+  * AC-2 — GET /api/tasks/{id} carries descendant_count + descendant_done for
+    the whole subtree AND annotates each DIRECT child with its own child_count.
+  * AC-3 — a 3-level tree (grandparent > parent > child) gates green ONLY when
+    every descendant is done: an incomplete grandchild blocks the grandparent's
+    green_gate; an intermediate node with weak proof does NOT block once its
+    leaf descendants are done+strong (leaf-scoped proof).
+"""
+
+from __future__ import annotations
+
+import asyncio  # noqa: F401  (imported for parity with sibling gate tests)
+import sys
+from pathlib import Path
+
+import pytest
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+# ── AC-1: subtree walk + counts on TaskService ─────────────────────────
+
+def _tree(tmp_path):
+    """g > p > c1, c2 ; and p2 (a second branch under g). Returns the svc
+    plus the created tasks so callers can mutate status."""
+    from prism_service.services.task_service import TaskService
+    svc = TaskService(str(tmp_path / "tasks.db"))
+    g = svc.create(title="grandparent")
+    p = svc.create(title="parent", parent_id=g.id)
+    c1 = svc.create(title="child-1", parent_id=p.id)
+    c2 = svc.create(title="child-2", parent_id=p.id)
+    p2 = svc.create(title="parent-2", parent_id=g.id)
+    return svc, g, p, c1, c2, p2
+
+
+def test_descendants_walks_whole_subtree(tmp_path):
+    svc, g, p, c1, c2, p2 = _tree(tmp_path)
+    ids = {t.id for t in svc.descendants(g.id)}
+    # The WHOLE subtree (not just the two direct children p, p2).
+    assert ids == {p.id, c1.id, c2.id, p2.id}, ids
+    # The task itself is never in its own descendant set.
+    assert g.id not in ids
+    # A mid-tree node returns only ITS subtree.
+    assert {t.id for t in svc.descendants(p.id)} == {c1.id, c2.id}
+    # A leaf has no descendants.
+    assert svc.descendants(c1.id) == []
+
+
+def test_descendants_is_cycle_safe(tmp_path):
+    svc, g, p, c1, c2, p2 = _tree(tmp_path)
+    # Corrupt the store directly (bypassing _validate_parent) to close a
+    # cycle g -> ... -> c1 -> g, then prove the walk TERMINATES via the
+    # visited-guard instead of hanging.
+    svc._db.execute("UPDATE tasks SET parent_id=? WHERE id=?", (c1.id, g.id))
+    svc._db.commit()
+    ids = {t.id for t in svc.descendants(g.id)}
+    assert g.id not in ids  # the walk must not re-add the root through the cycle
+    assert c1.id in ids
+
+
+def test_descendant_counts_totals_and_done(tmp_path):
+    svc, g, p, c1, c2, p2 = _tree(tmp_path)
+    svc.update(c1.id, status="done")
+    total, done = svc.descendant_counts(g.id)
+    assert total == 4 and done == 1, (total, done)
+    # Cancelled descendants drop out of BOTH totals (never block a roll-up).
+    svc.update(c2.id, status="cancelled")
+    total, done = svc.descendant_counts(g.id)
+    assert total == 3 and done == 1, (total, done)
+
+
+# ── AC-2: subtree annotations on the detail API ────────────────────────
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    from prism_service import config as cfg
+    from prism_service import project_context as pc
+    monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
+    cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    pc._contexts.clear()
+    yield "test-e72aba6d"
+    pc._contexts.clear()
+
+
+def test_detail_api_exposes_subtree_counts_and_child_count(project):
+    from prism_service.api.tasks import get_task
+    from prism_service.project_context import get_project
+    svc = get_project(project).task_svc
+    g = svc.create(title="grandparent")
+    p = svc.create(title="parent", parent_id=g.id)
+    c1 = svc.create(title="child-1", parent_id=p.id)
+    svc.create(title="child-2", parent_id=p.id)
+    svc.update(c1.id, status="done")
+
+    out = get_task(g.id, project=project)
+    # Whole-subtree roll-up (grandparent has 3 descendants, 1 done).
+    assert out["descendant_count"] == 3, out.get("descendant_count")
+    assert out["descendant_done"] == 1, out.get("descendant_done")
+    # Direct children are annotated with their OWN subtree size so the UI
+    # can lazy-render a tree node's chevron without re-walking the list.
+    children = {c["id"]: c for c in out["children"]}
+    assert set(children) == {p.id}
+    assert children[p.id]["child_count"] == 2, children[p.id]
+
+
+# ── AC-3: subtree-aware epic roll-up (pure verdict) ────────────────────
+
+class _Node:
+    def __init__(self, id, status, proof, parent_id):
+        self.id = id
+        self.status = status
+        self.completion_proof = proof
+        self.parent_id = parent_id
+
+
+_STRONG = "pytest -q: 9 passed; screenshot :8888/x.png"
+
+
+def test_rollup_blocks_while_a_grandchild_is_incomplete():
+    from prism_service.services.conductor_service import epic_rollup_verdict
+    # Grandparent's whole subtree: parent (done, strong) + child (NOT done).
+    subtree = [
+        _Node("p", "done", _STRONG, "g"),
+        _Node("c", "in_progress", _STRONG, "p"),
+    ]
+    ok, reason = epic_rollup_verdict(subtree)
+    assert ok is False, reason
+    assert "not done" in reason.lower() or "child" in reason.lower()
+
+
+def test_rollup_passes_when_whole_subtree_done_even_if_intermediate_proof_weak():
+    from prism_service.services.conductor_service import epic_rollup_verdict
+    # Every descendant done; the INTERMEDIATE node carries NO proof of its own
+    # (its proof is its children's roll-up) — only the LEAF needs strong proof.
+    subtree = [
+        _Node("p", "done", "", "g"),           # intermediate, weak/absent proof
+        _Node("c", "done", _STRONG, "p"),      # leaf, strong proof
+    ]
+    ok, reason = epic_rollup_verdict(subtree)
+    assert ok is True, reason
+
+
+def test_rollup_still_fails_on_weak_leaf_proof():
+    from prism_service.services.conductor_service import epic_rollup_verdict
+    subtree = [
+        _Node("p", "done", _STRONG, "g"),
+        _Node("cccc1234", "done", "", "p"),    # leaf with weak/absent proof
+    ]
+    ok, reason = epic_rollup_verdict(subtree)
+    assert ok is False
+    assert "proof" in reason.lower()
+
+
+# ── AC-3 integration: subtree roll-up rides the REAL green_gate ────────
+
+def _services(tmp_path):
+    from prism_service.services.conductor_service import ConductorService
+    from prism_service.services.task_service import TaskService
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"), enable_engine=False, task_svc=task_svc)
+    return task_svc, cond
+
+
+def _drive_to_green_gate(task_svc, cond, t):
+    guard = 0
+    cleared = 0
+    while task_svc.get(t.id).workflow_step != "green_gate" and guard < 30:
+        if task_svc.get(t.id).gate_state == "pending":
+            cleared += 1
+            cond.gate_decide(
+                t.id, "approve",
+                reason="walk; independent re-run: pytest -> 1 failed",
+                override=True, actor=f"walk-bot-{cleared}",
+                session_id=f"walk-bot-{cleared}")
+        else:
+            cond.advance_task(t.id, validation="step")
+        guard += 1
+    assert task_svc.get(t.id).workflow_step == "green_gate"
+
+
+def test_grandparent_green_gate_blocks_on_incomplete_grandchild(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    g = task_svc.create(title="grandparent epic")
+    p = task_svc.create(title="parent epic", parent_id=g.id)
+    task_svc.update(p.id, status="done",
+                    completion_proof="pytest -q: 9 passed; :8888/p.png")
+    # A grandchild that is NOT done — invisible to a one-level roll-up.
+    gc = task_svc.create(title="grandchild", parent_id=p.id)
+
+    _drive_to_green_gate(task_svc, cond, g)
+    res = cond.gate_decide(g.id, "approve", reason="try to close the epic")
+    assert res["ok"] is False, res
+    assert task_svc.get(g.id).gate_state != "passed"
+
+    # Complete the grandchild with strong proof; now the whole subtree is done.
+    task_svc.update(gc.id, status="done",
+                    completion_proof="pytest -q: 9 passed; :8888/gc.png")
+    res2 = cond.gate_decide(g.id, "approve", reason="whole subtree complete")
+    assert res2["ok"] is True, res2

--- a/services/prism-service/tests/unit/test_task_subtree_rollup.py
+++ b/services/prism-service/tests/unit/test_task_subtree_rollup.py
@@ -94,6 +94,7 @@ def project(tmp_path, monkeypatch):
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
     pc._contexts.clear()
+    pc.create_project("test-e72aba6d")  # reads must not auto-create — make it
     yield "test-e72aba6d"
     pc._contexts.clear()
 
@@ -201,16 +202,29 @@ def test_grandparent_green_gate_blocks_on_incomplete_grandchild(tmp_path):
     p = task_svc.create(title="parent epic", parent_id=g.id)
     task_svc.update(p.id, status="done",
                     completion_proof="pytest -q: 9 passed; :8888/p.png")
-    # A grandchild that is NOT done — invisible to a one-level roll-up.
-    gc = task_svc.create(title="grandchild", parent_id=p.id)
+    # A grandchild that is NOT done — invisible to a one-level roll-up (which
+    # sees only the done direct child p and would false-green the grandparent).
+    task_svc.create(title="grandchild", parent_id=p.id)
 
     _drive_to_green_gate(task_svc, cond, g)
     res = cond.gate_decide(g.id, "approve", reason="try to close the epic")
     assert res["ok"] is False, res
     assert task_svc.get(g.id).gate_state != "passed"
+    assert "done" in str(res.get("reason", "")).lower()
 
-    # Complete the grandchild with strong proof; now the whole subtree is done.
+
+def test_grandparent_green_gate_passes_when_whole_subtree_done(tmp_path):
+    task_svc, cond = _services(tmp_path)
+    g = task_svc.create(title="grandparent epic")
+    p = task_svc.create(title="parent epic", parent_id=g.id)
+    # The INTERMEDIATE node is done but carries NO proof of its own — its proof
+    # is the leaf's roll-up (leaf-scoped proof, any depth).
+    task_svc.update(p.id, status="done")
+    gc = task_svc.create(title="grandchild", parent_id=p.id)
     task_svc.update(gc.id, status="done",
                     completion_proof="pytest -q: 9 passed; :8888/gc.png")
-    res2 = cond.gate_decide(g.id, "approve", reason="whole subtree complete")
-    assert res2["ok"] is True, res2
+
+    _drive_to_green_gate(task_svc, cond, g)
+    res = cond.gate_decide(g.id, "approve", reason="whole subtree complete")
+    assert res["ok"] is True, res
+    assert task_svc.get(g.id).gate_state == "passed"

--- a/services/prism-service/tests/unit/test_task_title_rename.py
+++ b/services/prism-service/tests/unit/test_task_title_rename.py
@@ -40,6 +40,9 @@ def project(tmp_path, monkeypatch):
     from prism_service import project_context as pc
     monkeypatch.setattr(cfg, "PROJECTS_DIR", tmp_path / "projects")
     cfg.PROJECTS_DIR.mkdir(parents=True, exist_ok=True)
+    # get_project no longer creates on miss (d37193da):
+    # seed the sandboxed project dir explicitly.
+    cfg.project_data_dir("test-title-rename")
     pc._contexts.clear()
     yield "test-title-rename"
     pc._contexts.clear()

--- a/services/prism-service/tests/unit/test_task_tree_ui.py
+++ b/services/prism-service/tests/unit/test_task_tree_ui.py
@@ -1,0 +1,101 @@
+"""UI contract — recursive collapsible task tree + descendant board badge
+(task e72aba6d, "tasks render and roll up to any depth").
+
+The PRISM SPA has no JS test runner, so the UI-FIRST acceptance criteria are
+pinned by asserting the ACTUAL web source (TSX) — the same pattern as
+tests/unit/test_animate_conductor_tasks_ui.py and the sibling *_ui.py contracts.
+
+These assert the real seams and ALL FAIL today (there is no TaskTree component;
+the detail page lists DIRECT children only; the board badge counts DIRECT
+children):
+
+  * a TaskTree component exists and renders RECURSIVELY (a node renders itself
+    for its children — any depth) with an expand/collapse chevron per parent.
+  * TaskDetailPage imports TaskTree, renders a SUBTREE done roll-up header
+    (descendant_done / descendant_count), and drops the old flat
+    "Child tasks (X/Y done)" one-level list.
+  * TasksPage's corner badge counts the whole DESCENDANT subtree (not just
+    direct children) with an accurate "descendant task(s)" tooltip.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SRC = _HERE.parent.parent.parent / "prism_service" / "web" / "src"
+_TREE = _SRC / "components" / "tasks" / "TaskTree.tsx"
+_DETAIL = _SRC / "pages" / "TaskDetailPage.tsx"
+_TASKS = _SRC / "pages" / "TasksPage.tsx"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+# ── TaskTree component — recursive + collapsible ───────────────────────
+
+def test_task_tree_component_exists_and_exports():
+    assert _TREE.exists(), "web/src/components/tasks/TaskTree.tsx must exist"
+    src = _read(_TREE)
+    assert "TaskTree" in src, "the component must be named/exported TaskTree"
+    assert "export" in src
+
+
+def test_task_tree_is_recursive_to_any_depth():
+    src = _read(_TREE)
+    # A recursive node component renders ITSELF for each child. The node name
+    # must appear both as a definition AND as a self-reference in its own JSX.
+    assert "TaskTreeNode" in src, \
+        "an inner recursive node component (TaskTreeNode) is expected"
+    assert src.count("TaskTreeNode") >= 2, \
+        "TaskTreeNode must render itself recursively for children (any depth)"
+    assert "children" in src, "the node must render its children collection"
+
+
+def test_task_tree_has_collapsible_chevron_and_checkbox():
+    src = _read(_TREE)
+    assert "useState" in src, "expand/collapse state must be local per node"
+    # A rotating chevron toggle (unicode caret or an aria/expand affordance).
+    assert ("▸" in src or "▾" in src or "chevron" in src.lower()
+            or "expand" in src.lower()), "each parent node needs an expand/collapse chevron"
+    # Reuse the existing Checkbox + Hermes status tones (no invented palette).
+    assert "Checkbox" in src, "reuse the shared done Checkbox"
+    assert "var(--accent-" in src, "status tones must use Hermes accent tokens"
+
+
+def test_task_tree_nodes_are_navigable():
+    src = _read(_TREE)
+    # Clicking a node still opens its detail (navigate to /tasks/:id).
+    assert "/tasks/" in src or "navigate" in src, \
+        "a tree node must remain clickable through to its detail page"
+
+
+# ── TaskDetailPage — subtree tree + roll-up header ─────────────────────
+
+def test_detail_page_renders_task_tree_and_subtree_rollup():
+    src = _read(_DETAIL)
+    assert "TaskTree" in src, "TaskDetailPage must render the recursive TaskTree"
+    assert "descendant_count" in src and "descendant_done" in src, \
+        "the section header must show the SUBTREE done roll-up " \
+        "(descendant_done / descendant_count)"
+
+
+def test_detail_page_drops_flat_one_level_child_list():
+    src = _read(_DETAIL)
+    # The old flat list header was 'Child tasks (X/Y done)' — a one-level view.
+    assert "Child tasks (" not in src, \
+        "the flat one-level 'Child tasks (X/Y done)' list must be replaced by " \
+        "the recursive subtree tree"
+
+
+# ── TasksPage — board badge counts the whole descendant subtree ────────
+
+def test_board_badge_counts_descendant_subtree():
+    src = _read(_TASKS)
+    assert "descendant" in src.lower(), \
+        "the board badge must reflect the whole descendant subtree"
+    assert "descendantCount" in src, \
+        "a descendantCount map (whole-subtree) must back the corner badge"
+    assert "descendant task" in src, \
+        "the badge tooltip must read 'N descendant task(s)'"

--- a/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
+++ b/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
@@ -65,8 +65,18 @@ def _write_tree(root: Path, *, daemon_exclusive_failing: bool = False,
     optionally a FAILING daemon_exclusive test and/or a FAILING plain
     test. The passing test guarantees the suite is non-empty so a fully
     deselected run never collapses to pytest's exit-5 (no tests ran)."""
+    # Register the marker exactly as the real suite does (root pyproject),
+    # so the isolated run emits no unknown-mark warning — otherwise the
+    # warnings summary would print the deselected test's path and defeat the
+    # "was it deselected?" assertion below.
     (root / "pyproject.toml").write_text(
-        "[project]\nname = 'svc'\nversion = '0'\n", encoding="utf-8")
+        "[project]\nname = 'svc'\nversion = '0'\n\n"
+        "[tool.pytest.ini_options]\n"
+        "markers = [\n"
+        "    \"daemon_exclusive: contends with the live daemon; excluded "
+        "in-daemon\",\n"
+        "]\n",
+        encoding="utf-8")
     tests = root / "tests"
     tests.mkdir(exist_ok=True)
     (tests / "test_normal_pass.py").write_text(

--- a/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
+++ b/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
@@ -1,0 +1,161 @@
+"""In-daemon Tier0 must exclude ``daemon_exclusive`` tests (task 91ac81e8).
+
+VerifierService runs the full pytest suite as a subprocess of the LIVE
+daemon at green_gate. A handful of process-lifecycle / pidfile /
+learning-loop tests contend with the running daemon's pid/process space
+and flake ONLY in-daemon (they pass standalone), so a genuinely 0-failed
+tree could never clear green_gate mechanically — every green needed a
+distinct-actor override, the exact gate-theater the reinforcement
+doctrine targets.
+
+Fix: mark the contending tests ``@pytest.mark.daemon_exclusive`` and have
+the in-daemon Tier0 pytest run add ``-m "not daemon_exclusive"``. The
+marked tests STILL run standalone / in CI (no ``-m`` filter there); the
+verifier is NOT weakened — a real failure in a NON-excluded test still
+fails Tier0.
+
+Contract encoded here:
+  * AC-1 — a FAILING daemon_exclusive test is DESELECTED by the in-daemon
+    Tier0 run, so a green tree stays green (tooling.pytest claim=pass and
+    the excluded nodeid never appears in the run output).
+  * AC-2 — a FAILING non-excluded test still fails Tier0 with exit 1 (the
+    ``-m`` filter must not swallow real regressions).
+  * AC-3 — the 5 named process-lifecycle tests carry the marker so the
+    exclusion actually targets them (guards against silent un-marking).
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services.verifier_service import run_tier0   # noqa: E402
+
+
+# ----------------------------------------------------------------------
+# Temp-repo builders — a git repo whose tests land in Tier0's diff scope
+# ----------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), capture_output=True, text=True, timeout=30,
+    )
+
+
+def _init_repo(ws: Path) -> None:
+    ws.mkdir(parents=True, exist_ok=True)
+    _git(ws, "init")
+    (ws / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(ws, "add", "README.md")
+    _git(ws, "commit", "-m", "seed")
+
+
+def _write_tree(root: Path, *, daemon_exclusive_failing: bool = False,
+                plain_failing: bool = False) -> None:
+    """A minimal python project: pyproject + a passing normal test, plus
+    optionally a FAILING daemon_exclusive test and/or a FAILING plain
+    test. The passing test guarantees the suite is non-empty so a fully
+    deselected run never collapses to pytest's exit-5 (no tests ran)."""
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = 'svc'\nversion = '0'\n", encoding="utf-8")
+    tests = root / "tests"
+    tests.mkdir(exist_ok=True)
+    (tests / "test_normal_pass.py").write_text(
+        "def test_normal_pass():\n    assert True\n", encoding="utf-8")
+    if daemon_exclusive_failing:
+        (tests / "test_daemon_only.py").write_text(
+            "import pytest\n\n\n"
+            "@pytest.mark.daemon_exclusive\n"
+            "def test_daemon_only_failure():\n"
+            "    assert False, 'contends with the live daemon'\n",
+            encoding="utf-8")
+    if plain_failing:
+        (tests / "test_plain_failure.py").write_text(
+            "def test_plain_failure():\n"
+            "    assert False, 'a real regression'\n", encoding="utf-8")
+
+
+def _pytest_claim(claims):
+    hits = [c for c in claims if c.kind == "tooling.pytest"]
+    assert hits, ("Tier0 emitted no tooling.pytest claim — the full-suite "
+                  "run never fired")
+    return hits[0]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — daemon_exclusive failure is deselected in-daemon
+# ----------------------------------------------------------------------
+
+
+def test_daemon_exclusive_failure_is_excluded_from_tier0(tmp_path):
+    ws = tmp_path / "repo"
+    _init_repo(ws)
+    _write_tree(ws, daemon_exclusive_failing=True)
+
+    claim = _pytest_claim(run_tier0(ws))
+    assert claim.status == "pass", (
+        "a FAILING daemon_exclusive test was NOT deselected by the "
+        f"in-daemon Tier0 run: {claim.feedback} / "
+        f"{claim.evidence.get('stdout', '')[:500]}")
+    # Proof it was DESELECTED, not silently collected+passed: a -q run
+    # prints a failing test's nodeid; a deselected one never appears.
+    assert "test_daemon_only" not in claim.evidence.get("stdout", ""), (
+        "the daemon_exclusive test ran in-daemon; it must be deselected")
+
+
+# ----------------------------------------------------------------------
+# AC-2 — verifier NOT weakened: a non-excluded failure still fails
+# ----------------------------------------------------------------------
+
+
+def test_non_excluded_failure_still_fails_tier0(tmp_path):
+    ws = tmp_path / "repo"
+    _init_repo(ws)
+    _write_tree(ws, plain_failing=True)
+
+    claim = _pytest_claim(run_tier0(ws))
+    assert claim.status == "fail", (
+        "a real failing (non-excluded) test must still fail Tier0 — the "
+        f"-m filter swallowed a regression (got {claim.status})")
+    assert claim.evidence.get("exit_code") == 1, (
+        f"expected a real test failure (exit 1), got "
+        f"exit={claim.evidence.get('exit_code')}")
+    assert "test_plain_failure" in claim.evidence.get("stdout", ""), (
+        "the planted non-excluded failure never ran")
+
+
+# ----------------------------------------------------------------------
+# AC-3 — the named process-lifecycle tests carry the marker
+# ----------------------------------------------------------------------
+
+_MARKED = [
+    ("tests.unit.test_pidfile_lifecycle",
+     "test_cmd_status_reports_unhealthy_and_self_heals_split_brain"),
+    ("tests.unit.test_pidfile_lifecycle",
+     "test_cmd_stop_reaps_split_brain_orphan"),
+    ("tests.integration.test_event_handlers_phase3",
+     "test_session_imported_burst_coalesces_to_one_pass"),
+    ("tests.integration.test_event_handlers_phase3",
+     "test_session_imported_reinforces_instead_of_duplicating"),
+    ("tests.integration.test_learning_loop_self_sustaining",
+     "test_completed_reflection_writes_rollup_and_feeds_outcome"),
+]
+
+
+def test_named_process_lifecycle_tests_are_marked_daemon_exclusive():
+    for mod_name, fn_name in _MARKED:
+        mod = importlib.import_module(mod_name)
+        fn = getattr(mod, fn_name)
+        marks = {m.name for m in getattr(fn, "pytestmark", [])}
+        assert "daemon_exclusive" in marks, (
+            f"{mod_name}::{fn_name} lost its @pytest.mark.daemon_exclusive "
+            "marker — the in-daemon exclusion no longer targets it")

--- a/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
+++ b/services/prism-service/tests/unit/test_verifier_daemon_exclusive.py
@@ -158,6 +158,14 @@ _MARKED = [
      "test_session_imported_reinforces_instead_of_duplicating"),
     ("tests.integration.test_learning_loop_self_sustaining",
      "test_completed_reflection_writes_rollup_and_feeds_outcome"),
+    # task 279ef52d: network-server tests — bind a real ephemeral
+    # HTTPServer + serve_forever thread; flake under in-daemon load.
+    ("tests.unit.test_memory_summary_backend",
+     "test_complete_reports_prompt_and_completion_tokens"),
+    ("tests.integration.test_local_llm_inference",
+     "test_complete_roundtrips_against_stub"),
+    ("tests.integration.test_local_llm_inference",
+     "test_json_mode_and_system_prompt"),
 ]
 
 

--- a/services/prism-service/tests/unit/test_verifier_tier0_workspace.py
+++ b/services/prism-service/tests/unit/test_verifier_tier0_workspace.py
@@ -1,0 +1,212 @@
+"""Tier0 full-suite pytest workspace tests (task 271dacc9).
+
+Green-gate Tier0 must run the suite from the SERVICE workspace, not the
+repo root. At the repo root, pytest falls back to full rootdir collection
+(the root pyproject's testpaths no longer exists) and walks the fork data
+dir (data-selfimprove/projects/prism/graphify-src/** — a stale full repo
+mirror), where duplicate ``tests.*`` module basenames collide ("import
+file mismatch") and every collection ERRORS -> tier0=fail -> every
+green_gate needs a manual distinct-actor override (latched 9f20b605 and
+e70cdcda).
+
+Contract encoded here:
+  * AC-1 — the full-suite pytest run executes from the service suite root
+    (derived from layout / running package, never a hardcoded path) and
+    records its run cwd in the claim evidence.
+  * AC-2 — a data-dir mirror with colliding tests modules no longer
+    false-fails collection.
+  * AC-3 — the verifier is NOT weakened: a real failing test in the
+    service tree still fails Tier0 with exit 1 (test failure), not a
+    collection error.
+  * AC-4 — the resolved PRISM data dir is defensively --ignore'd when it
+    lies inside the suite root.
+  * AC-5 — ruff falls back to ``python -m ruff`` when the binary is not
+    on PATH but the module is importable.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services.verifier_service import run_tier0   # noqa: E402
+
+
+# ----------------------------------------------------------------------
+# Layout builders — a temp git repo mimicking the fork's poisoned shape
+# ----------------------------------------------------------------------
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=str(cwd), capture_output=True, text=True, timeout=30,
+    )
+
+
+def _init_repo(ws: Path) -> None:
+    """git repo with one commit so `git diff HEAD` resolves; everything
+    written AFTERWARDS is untracked and lands in Tier0's diff scope."""
+    ws.mkdir(parents=True, exist_ok=True)
+    _git(ws, "init")
+    (ws / "README.md").write_text("seed\n", encoding="utf-8")
+    _git(ws, "add", "README.md")
+    _git(ws, "commit", "-m", "seed")
+
+
+def _write_service_tree(root: Path, failing: bool = False) -> None:
+    """A minimal prism-service-shaped distribution: pyproject.toml +
+    prism_service package + tests/."""
+    (root / "prism_service").mkdir(parents=True, exist_ok=True)
+    (root / "prism_service" / "__init__.py").write_text("", encoding="utf-8")
+    (root / "pyproject.toml").write_text(
+        "[project]\nname = 'svc'\nversion = '0'\n", encoding="utf-8")
+    tests = root / "tests"
+    tests.mkdir(exist_ok=True)
+    (tests / "test_suite_marker.py").write_text(
+        "def test_real_suite_marker():\n    assert True\n", encoding="utf-8")
+    if failing:
+        (tests / "test_planted_failure.py").write_text(
+            "def test_planted_failure():\n"
+            "    assert False, 'planted red'\n", encoding="utf-8")
+
+
+def _write_colliding_mirror(base: Path) -> None:
+    """A stale repo mirror (graphify-src-style) whose rootless `tests`
+    dir carries the SAME test module basename as the real suite —
+    collected together they raise 'import file mismatch'."""
+    mirror = (base / "projects" / "prism" / "graphify-src" /
+              "services" / "prism-service" / "tests")
+    mirror.mkdir(parents=True, exist_ok=True)
+    (mirror / "test_suite_marker.py").write_text(
+        "def test_real_suite_marker():\n    assert True\n", encoding="utf-8")
+
+
+def _pytest_claim(claims):
+    hits = [c for c in claims if c.kind == "tooling.pytest"]
+    assert hits, ("Tier0 emitted no tooling.pytest claim — the full-suite "
+                  "run never fired")
+    return hits[0]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — suite-root derivation (pure)
+# ----------------------------------------------------------------------
+
+
+def test_pytest_suite_root_prefers_service_layout(tmp_path):
+    from prism_service.services.verifier_service import _pytest_suite_root
+    ws = tmp_path / "repo"
+    svc = ws / "services" / "prism-service"
+    _write_service_tree(svc)
+    assert _pytest_suite_root(ws) == svc.resolve()
+
+
+def test_pytest_suite_root_falls_back_to_workspace(tmp_path):
+    from prism_service.services.verifier_service import _pytest_suite_root
+    ws = tmp_path / "generic"
+    ws.mkdir()
+    (ws / "pyproject.toml").write_text("[project]\nname='g'\nversion='0'\n",
+                                       encoding="utf-8")
+    assert _pytest_suite_root(ws) == ws.resolve()
+
+
+# ----------------------------------------------------------------------
+# AC-2 — the fork's poisoned layout must not false-fail Tier0
+# ----------------------------------------------------------------------
+
+
+def test_tier0_green_despite_datadir_mirror_collision(tmp_path):
+    ws = tmp_path / "repo"
+    _init_repo(ws)
+    # repo root is python-detected (like the real fork root pyproject)
+    (ws / "pyproject.toml").write_text(
+        "[project]\nname = 'repo'\nversion = '0'\n", encoding="utf-8")
+    _write_service_tree(ws / "services" / "prism-service")
+    _write_colliding_mirror(ws / "data-selfimprove")
+
+    claim = _pytest_claim(run_tier0(ws))
+    assert claim.status == "pass", (
+        f"collection-explosion layout false-failed Tier0: {claim.feedback} "
+        f"/ {claim.evidence.get('stdout', '')[:400]}")
+    # AC-1 teeth: the claim proves WHERE it ran
+    cwd = str(claim.evidence.get("cwd", ""))
+    assert cwd.replace("\\", "/").endswith("services/prism-service"), (
+        f"full suite did not run from the service suite root (cwd={cwd!r})")
+
+
+# ----------------------------------------------------------------------
+# AC-3 — verifier NOT weakened: real failures still fail, exit 1
+# ----------------------------------------------------------------------
+
+
+def test_tier0_fails_on_real_test_failure_not_collection_noise(tmp_path):
+    ws = tmp_path / "repo"
+    _init_repo(ws)
+    (ws / "pyproject.toml").write_text(
+        "[project]\nname = 'repo'\nversion = '0'\n", encoding="utf-8")
+    _write_service_tree(ws / "services" / "prism-service", failing=True)
+    _write_colliding_mirror(ws / "data-selfimprove")
+
+    claim = _pytest_claim(run_tier0(ws))
+    assert claim.status == "fail", (
+        "a REAL failing test in the service tree must fail Tier0 "
+        f"(got {claim.status})")
+    # exit 1 = tests ran and failed; exit 2 would be the collection
+    # explosion masking the real signal.
+    assert claim.evidence.get("exit_code") == 1, (
+        f"expected a real test failure (exit 1), got "
+        f"exit={claim.evidence.get('exit_code')} — collection error?")
+    assert "test_planted_failure" in claim.evidence.get("stdout", ""), (
+        "the planted failing test never ran — Tier0 failed for the wrong "
+        "reason (collection noise, not the red test)")
+
+
+# ----------------------------------------------------------------------
+# AC-4 — resolved data dir INSIDE the suite root is defensively ignored
+# ----------------------------------------------------------------------
+
+
+def test_data_dir_inside_suite_root_is_ignored(tmp_path, monkeypatch):
+    ws = tmp_path / "svc-root"
+    _init_repo(ws)
+    _write_service_tree(ws)                      # workspace IS the suite root
+    _write_colliding_mirror(ws / "datadir")      # data dir inside the repo
+    monkeypatch.setenv("PRISM_DATA_DIR", str(ws / "datadir"))
+
+    claim = _pytest_claim(run_tier0(ws))
+    assert claim.status == "pass", (
+        "a data dir INSIDE the suite root poisoned collection: "
+        f"{claim.feedback} / {claim.evidence.get('stdout', '')[:400]}")
+
+
+# ----------------------------------------------------------------------
+# AC-5 — ruff module fallback (no more 'ruff not installed' skips)
+# ----------------------------------------------------------------------
+
+
+def test_ruff_cmd_module_fallback(monkeypatch):
+    import importlib.util
+    import shutil as _shutil
+    from prism_service.services import verifier_service as vs
+
+    # on PATH -> bare binary
+    monkeypatch.setattr(_shutil, "which",
+                        lambda name: "ruff" if name == "ruff" else None)
+    assert vs._ruff_cmd() == ["ruff"]
+
+    # not on PATH but importable -> python -m ruff
+    monkeypatch.setattr(_shutil, "which", lambda name: None)
+    monkeypatch.setattr(importlib.util, "find_spec",
+                        lambda name: object() if name == "ruff" else None)
+    assert vs._ruff_cmd() == [sys.executable, "-m", "ruff"]
+
+    # neither -> None (claim stays 'skipped')
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert vs._ruff_cmd() is None


### PR DESCRIPTION
Lane of hardening epic 2a5e72a7 — conductor task 279ef52d.

**Note on the compare view:** this lane necessarily stacks on the local `feat/self-improvement-engine` branch (where the `daemon_exclusive` convention from task 91ac81e8 lives — it is not on origin/main yet), so GitHub shows ~102 inherited engine commits. The lane's own diff is exactly 2 commits / 3 files / 11 insertions:

- `bf6c524` test(279ef52d): RED — extends the `_MARKED` meta-test guard in `tests/unit/test_verifier_daemon_exclusive.py` with the 3 network-server tests. Receipt: `python -m pytest tests/unit/test_verifier_daemon_exclusive.py -q` → **1 failed, 2 passed** (markers missing).
- `f9a5fb9` fix(tests): apply `@pytest.mark.daemon_exclusive` to the 3 tests that bind a real ephemeral `HTTPServer(("127.0.0.1", 0))` + `serve_forever` thread:
  - `tests/unit/test_memory_summary_backend.py::test_complete_reports_prompt_and_completion_tokens` (the named stress-loop flake)
  - `tests/integration/test_local_llm_inference.py::test_complete_roundtrips_against_stub`
  - `tests/integration/test_local_llm_inference.py::test_json_mode_and_system_prompt`

**Receipts:** meta-test + both marked files → 13 passed; `-m daemon_exclusive --collect-only -q` → 8/1454 (was 5/1454); total collection unchanged at 1454. Marker already registered in root `pyproject.toml:14`; the in-daemon Tier0 verifier deselects via `-m "not daemon_exclusive"`; tests still run standalone/CI. urlopen-monkeypatched tests deliberately NOT marked (no socket bind — keeps Tier0 coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)