### PR TITLE
hardening: reflection janitor stops dispensing empty 'task None' briefs

### DIFF
--- a/services/prism-service/prism_service/mcp/tools.py
+++ b/services/prism-service/prism_service/mcp/tools.py
@@ -2885,7 +2885,6 @@ def _maybe_augment_with_nudge(
     the candidate. Disabled globally by PRISM_MCP_AUGMENT_NUDGES=false.
     """
     import os as _os
-    import sqlite3 as _sq3
     from datetime import datetime, timedelta, timezone
 
     if _os.environ.get("PRISM_MCP_AUGMENT_NUDGES", "").lower() == "false":
@@ -2906,28 +2905,18 @@ def _maybe_augment_with_nudge(
     now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(minutes=5)).isoformat()
 
-    conn = _sq3.connect(scores_path, timeout=5.0)
-    conn.row_factory = _sq3.Row
+    # Task 1a7bc848 — only nudge for a DISPENSABLE reflection candidate.
+    # Runner-owned memory-op rows (merge/forget/...) and null-context rows
+    # must never emit PRISM_REFLECTION_PENDING: they can only ever render
+    # as the un-actionable "task None" brief. The janitor classifies and
+    # stamps last_nudged_at on the row it returns.
     try:
-        # Oldest pending candidate not nudged in the last 5 min.
-        row = conn.execute(
-            "SELECT id, task_id FROM consolidation_candidates "
-            "WHERE status='pending' "
-            "  AND (last_nudged_at IS NULL OR last_nudged_at <= ?) "
-            "ORDER BY queued_at ASC LIMIT 1",
-            (cutoff,),
-        ).fetchone()
-        if row is None:
-            return result
-        cid = row["id"]
-        tid = row["task_id"] or ""
-        conn.execute(
-            "UPDATE consolidation_candidates SET last_nudged_at=? WHERE id=?",
-            (now.isoformat(), cid),
-        )
-        conn.commit()
-    finally:
-        conn.close()
+        nudge = ctx.janitor_svc.next_pending_for_nudge(cutoff)
+    except Exception:
+        return result
+    if nudge is None:
+        return result
+    cid, tid = nudge
 
     header = (
         f"\u26a0\ufe0f PRISM_REFLECTION_PENDING candidate={cid} task={tid}\n"

--- a/services/prism-service/prism_service/services/consolidation_data.py
+++ b/services/prism-service/prism_service/services/consolidation_data.py
@@ -332,6 +332,21 @@ def enqueue_for_session(
         return None
     if task_id is None:
         task_id = resolve_task_id_for_session(scores_db, session_id)
+    # Task 1a7bc848 — enqueue-side guard. A session row with no task link
+    # and no usable scope context can only ever dispense as the empty
+    # "task None" brief; refuse it here (covers the /backfill endpoint and
+    # the brain_engine record bridge). Runner-owned triggers are exempt:
+    # memory-ops (distill_procedural etc.) enqueue op-shaped scopes that
+    # the memory-ops runner — not the reflection loop — consumes.
+    from prism_service.services.janitor_service import (
+        is_runner_owned, scope_has_reflection_context,
+    )
+    if (
+        task_id is None
+        and not is_runner_owned(trigger, scope or {})
+        and not scope_has_reflection_context(scope or {})
+    ):
+        return None
     conn = sqlite3.connect(scores_db)
     conn.row_factory = sqlite3.Row
     try:
@@ -400,17 +415,24 @@ def prune_noise_candidates(scores_db: str) -> int:
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
-            "SELECT id, task_id, scope_json FROM consolidation_candidates "
-            "WHERE status='pending'"
+            "SELECT id, task_id, trigger, scope_json "
+            "FROM consolidation_candidates WHERE status='pending'"
         ).fetchall()
         doomed: list[str] = []
+        from prism_service.services.janitor_service import is_runner_owned
         for r in rows:
             if r["task_id"] is not None:
                 continue
             try:
-                sc = json.loads(r["scope_json"] or "{}").get("signal_counts") or {}
+                scope = json.loads(r["scope_json"] or "{}")
             except Exception:
-                sc = {}
+                scope = {}
+            # Task 1a7bc848 — never delete memory-ops runner work items;
+            # they carry no task/signals by design (merge member_ids etc.)
+            # but are real pending work for memory_ops/runner.py.
+            if is_runner_owned(r["trigger"], scope):
+                continue
+            sc = scope.get("signal_counts") or {}
             if all(int(sc.get(k) or 0) == 0 for k in (
                 "pushbacks", "bg_signals", "tool_failures", "memory_writes",
             )):

--- a/services/prism-service/prism_service/services/janitor_service.py
+++ b/services/prism-service/prism_service/services/janitor_service.py
@@ -15,6 +15,7 @@ import json
 import sqlite3
 import uuid
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Callable, Optional
 
 
@@ -46,6 +47,50 @@ _RESPONSE_SCHEMA: dict[str, str] = {
     "invalidate_memory_ids": "[{id, reason}]",
     "confidence": "float 0-1",
 }
+
+
+# Task 1a7bc848 — candidate classification. consolidation_candidates is a
+# SHARED queue: the memory-ops runner (memory_ops/runner.py) enqueues its
+# own work items (merge / forget / verify_staleness / distill_procedural)
+# with task_id=NULL and op-shaped scopes. Those are NOT reflection briefs;
+# dispensing one via check() renders the empty "task None" brief.
+_RUNNER_OWNED_TRIGGERS: frozenset = frozenset({
+    "merge", "forget", "verify_staleness", "distill_procedural",
+})
+
+
+def is_runner_owned(trigger: Optional[str], scope: dict) -> bool:
+    """True when the candidate is a memory-ops runner work item — owned
+    by memory_ops/runner.py, never dispensable as a reflection brief."""
+    return (trigger in _RUNNER_OWNED_TRIGGERS) or bool(scope.get("op"))
+
+
+def scope_has_reflection_context(scope: dict) -> bool:
+    """True when the scope carries something a reflection sub-agent can
+    actually investigate — the exact fields _build_brief surfaces:
+    file_paths / memory_ids / task_ids / transcript_excerpt, or any
+    nonzero signal_counts bucket."""
+    for key in ("file_paths", "memory_ids", "task_ids"):
+        if scope.get(key):
+            return True
+    if (scope.get("transcript_excerpt") or "").strip():
+        return True
+    # v6.2.18 contract (task ed7292bd, test_consolidation_noise_filter):
+    # a session that MODIFIED files is signal even with empty buckets.
+    try:
+        if int(scope.get("files_modified", 0) or 0) > 0:
+            return True
+    except (TypeError, ValueError):
+        pass
+    counts = scope.get("signal_counts") or {}
+    if isinstance(counts, dict):
+        for v in counts.values():
+            try:
+                if int(v or 0) > 0:
+                    return True
+            except (TypeError, ValueError):
+                continue
+    return False
 
 
 def _now_utc() -> datetime:
@@ -105,6 +150,38 @@ class JanitorService:
             return json.loads(row["scope_json"] or "{}")
         except (json.JSONDecodeError, TypeError):
             return {}
+
+    def _task_resolves(self, task_id: Optional[str]) -> bool:
+        """True when ``task_id`` names a real row in the sibling tasks.db.
+
+        Guards the likely_misfire: a non-null-but-garbage task_id must
+        not carry an otherwise-empty brief through the dispense gate.
+        When tasks.db is absent (standalone scores.db fixtures) a
+        non-null id is trusted — we cannot verify, and dropping real
+        work would be worse."""
+        if not task_id:
+            return False
+        tasks_db = Path(self._db_path).parent / "tasks.db"
+        if not tasks_db.exists():
+            return True
+        try:
+            conn = sqlite3.connect(str(tasks_db))
+            try:
+                row = conn.execute(
+                    "SELECT 1 FROM tasks WHERE id=? LIMIT 1", (task_id,)
+                ).fetchone()
+            finally:
+                conn.close()
+        except sqlite3.OperationalError:
+            return True  # tasks table absent/locked — never drop real work
+        return row is not None
+
+    def _has_reflection_grounding(
+        self, task_id: Optional[str], scope: dict,
+    ) -> bool:
+        """A brief is actionable iff it has investigable scope context or
+        a task_id that resolves to a real task."""
+        return scope_has_reflection_context(scope) or self._task_resolves(task_id)
 
     # ------------------------------------------------------------------
     # enqueue
@@ -198,31 +275,88 @@ class JanitorService:
     # ------------------------------------------------------------------
 
     def check(self, session_id: str) -> dict:
-        """Return {ready, brief}. Dispenses max one candidate per call."""
+        """Return {ready, brief}. Dispenses max one candidate per call.
+
+        Task 1a7bc848 — dispense gate. Runner-owned memory-op rows are
+        skipped (left pending for memory_ops/runner.py), and rows with
+        neither a resolvable task_id nor usable scope context are
+        terminally retired (status='abandoned') so the queue DRAINS
+        instead of cycling un-actionable "task None" briefs through
+        abandon-backoff forever."""
         now = self._clock()
         age_cutoff = (now - timedelta(seconds=self.MIN_QUEUE_AGE_S)).isoformat()
         backoff_cutoff = (now - timedelta(seconds=self.ABANDON_BACKOFF_S)).isoformat()
-        row = self._db.execute(
+        rows = self._db.execute(
             "SELECT * FROM consolidation_candidates "
             "WHERE status='pending' "
             "  AND queued_at <= ? "
             "  AND (dispensed_at IS NULL OR dispensed_at <= ?) "
-            "ORDER BY queued_at ASC LIMIT 1",
+            "ORDER BY queued_at ASC",
             (age_cutoff, backoff_cutoff),
-        ).fetchone()
-        if row is None:
+        ).fetchall()
+
+        chosen: Optional[sqlite3.Row] = None
+        retired: list[str] = []
+        for row in rows:
+            scope = self._scope_of(row)
+            if is_runner_owned(row["trigger"], scope):
+                continue  # memory-ops work item — not a reflection brief
+            if not self._has_reflection_grounding(row["task_id"], scope):
+                retired.append(row["id"])
+                continue
+            chosen = row
+            break
+
+        if retired:
+            placeholders = ",".join("?" * len(retired))
+            self._db.execute(
+                f"UPDATE consolidation_candidates SET status='abandoned' "
+                f"WHERE id IN ({placeholders})",
+                retired,
+            )
+            self._db.commit()
+
+        if chosen is None:
             return {"ready": False, "brief": None}
 
         # Claim it
         self._db.execute(
             "UPDATE consolidation_candidates "
             "SET status='dispensed', dispensed_at=? WHERE id=?",
-            (self._iso(now), row["id"]),
+            (self._iso(now), chosen["id"]),
         )
         self._db.commit()
 
-        brief = self._build_brief(row)
+        brief = self._build_brief(chosen)
         return {"ready": True, "brief": brief}
+
+    def next_pending_for_nudge(self, nudge_cutoff_iso: str) -> Optional[tuple]:
+        """Oldest pending, not-recently-nudged, DISPENSABLE reflection
+        candidate — the only kind worth nagging an agent about (task
+        1a7bc848: runner-owned and null-context rows must never emit
+        PRISM_REFLECTION_PENDING). Stamps last_nudged_at on the returned
+        row. Returns (candidate_id, task_id_or_empty) or None."""
+        rows = self._db.execute(
+            "SELECT * FROM consolidation_candidates "
+            "WHERE status='pending' "
+            "  AND (last_nudged_at IS NULL OR last_nudged_at <= ?) "
+            "ORDER BY queued_at ASC",
+            (nudge_cutoff_iso,),
+        ).fetchall()
+        for row in rows:
+            scope = self._scope_of(row)
+            if is_runner_owned(row["trigger"], scope):
+                continue
+            if not self._has_reflection_grounding(row["task_id"], scope):
+                continue
+            self._db.execute(
+                "UPDATE consolidation_candidates SET last_nudged_at=? "
+                "WHERE id=?",
+                (self._iso(), row["id"]),
+            )
+            self._db.commit()
+            return row["id"], row["task_id"] or ""
+        return None
 
     def _build_brief(self, row: sqlite3.Row) -> dict:
         scope = self._scope_of(row)

--- a/services/prism-service/tests/unit/test_janitor_null_brief_gate.py
+++ b/services/prism-service/tests/unit/test_janitor_null_brief_gate.py
@@ -1,0 +1,240 @@
+"""Task 1a7bc848 — RED tests: the reflection janitor must never dispense
+empty "task None" briefs.
+
+Pins the dispense-seam gate:
+  * AC-1: a null-context row (no task, empty scope) is never dispensed and
+    is terminally retired (status='abandoned') so it can't re-surface.
+  * AC-2: runner-owned memory-op candidates (trigger='merge', scope.op)
+    are never dispensed AND stay pending for the memory-ops runner.
+  * AC-3: garbage ahead in the queue does not head-of-line block a real
+    actionable candidate.
+  * AC-4: a non-null task_id that does not resolve in the sibling
+    tasks.db counts as no-context (likely_misfire guard) — while a REAL
+    task row with empty scope still dispenses.
+  * AC-5: enqueue_for_session refuses new null-context session rows;
+    runner-owned triggers (distill_procedural) are exempt.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+class _Clock:
+    def __init__(self, start: datetime) -> None:
+        self._t = start
+
+    def __call__(self) -> datetime:
+        return self._t
+
+    def advance(self, **delta) -> None:
+        self._t = self._t + timedelta(**delta)
+
+
+def _mk_service(tmp_path: Path, now=None):
+    """JanitorService on a fresh scores.db (schema seeded via Brain)."""
+    from prism_service.engines.brain_engine import Brain
+    from prism_service.services.janitor_service import JanitorService
+
+    scores_db = str(tmp_path / "scores.db")
+    Brain(
+        brain_db=str(tmp_path / "brain.db"),
+        graph_db=str(tmp_path / "graph.db"),
+        scores_db=scores_db,
+    )
+    clock = _Clock(now or datetime(2026, 7, 2, 12, 0, tzinfo=timezone.utc))
+    return JanitorService(scores_db, clock=clock), clock
+
+
+def _mk_tasks_db(tmp_path: Path, task_ids: list[str]) -> None:
+    """Create the sibling tasks.db with real task rows so the janitor's
+    task-resolvability check has something to resolve against."""
+    conn = sqlite3.connect(str(tmp_path / "tasks.db"))
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS tasks ("
+            "  id TEXT PRIMARY KEY, title TEXT NOT NULL,"
+            "  created_at TEXT NOT NULL)"
+        )
+        for tid in task_ids:
+            conn.execute(
+                "INSERT INTO tasks (id, title, created_at) VALUES (?, ?, ?)",
+                (tid, f"task {tid}", "2026-07-02T00:00:00+00:00"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _status_of(svc, cid: str) -> str:
+    row = svc._db.execute(
+        "SELECT status FROM consolidation_candidates WHERE id=?", (cid,)
+    ).fetchone()
+    return row["status"]
+
+
+# ----------------------------------------------------------------------
+# AC-1 — null-context rows: never dispensed, terminally retired
+# ----------------------------------------------------------------------
+
+
+def test_check_retires_null_context_row_terminally(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    cid = svc.enqueue(task_id=None, trigger="session_completed", scope={})
+    clock.advance(hours=2)
+
+    res = svc.check(session_id="S-1")
+    assert res["ready"] is False, (
+        "a candidate with no task and no scope context must never be "
+        "dispensed as a reflection brief"
+    )
+    assert res["brief"] is None
+    assert _status_of(svc, cid) == "abandoned", (
+        "null-context rows must be terminally retired so they drain "
+        "instead of cycling through abandon-backoff forever"
+    )
+
+    # And it must never re-surface — not after backoff, not ever.
+    clock.advance(hours=6)
+    res2 = svc.check(session_id="S-2")
+    assert res2["ready"] is False
+
+
+# ----------------------------------------------------------------------
+# AC-2 — runner-owned candidates are not reflection briefs
+# ----------------------------------------------------------------------
+
+
+def test_check_skips_runner_owned_candidate_leaves_pending(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    cid = svc.enqueue(
+        task_id=None, trigger="merge",
+        scope={"op": "merge", "member_ids": ["mx-aaaaaa", "mx-bbbbbb"]},
+    )
+    clock.advance(hours=2)
+
+    res = svc.check(session_id="S-1")
+    assert res["ready"] is False, (
+        "memory-op runner work items (trigger='merge') must never be "
+        "dispensed to the caller-side reflection loop — this is exactly "
+        "the 'task None' brief"
+    )
+    assert _status_of(svc, cid) == "pending", (
+        "runner-owned candidates belong to the memory-ops runner and "
+        "must stay pending for it — not retired, not dispensed"
+    )
+
+
+def test_check_skips_verify_staleness_trigger(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    cid = svc.enqueue(
+        task_id=None, trigger="verify_staleness",
+        scope={"memory_id": "mx-cccccc", "drifted_files": ["src/a.py"]},
+    )
+    clock.advance(hours=2)
+    res = svc.check(session_id="S-1")
+    assert res["ready"] is False
+    assert _status_of(svc, cid) == "pending"
+
+
+# ----------------------------------------------------------------------
+# AC-3 — garbage does not head-of-line block real candidates
+# ----------------------------------------------------------------------
+
+
+def test_check_dispenses_actionable_past_garbage(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    garbage = svc.enqueue(task_id=None, trigger="session_completed", scope={})
+    clock.advance(minutes=5)
+    real = svc.enqueue(
+        task_id="T-77", trigger="task_done",
+        scope={"task_ids": ["T-77"], "file_paths": ["src/real.py"]},
+    )
+    clock.advance(hours=2)
+
+    res = svc.check(session_id="S-1")
+    assert res["ready"] is True
+    assert res["brief"]["candidate_id"] == real
+    assert res["brief"]["context"]["affected_files"] == ["src/real.py"]
+    assert "task None" not in res["brief"]["question"]
+    # The garbage ahead of it drained terminally in the same pass.
+    assert _status_of(svc, garbage) == "abandoned"
+    assert _status_of(svc, real) == "dispensed"
+
+
+# ----------------------------------------------------------------------
+# AC-4 — unresolvable task_id is NOT context (likely_misfire guard)
+# ----------------------------------------------------------------------
+
+
+def test_unresolvable_task_id_counts_as_no_context(tmp_path):
+    svc, clock = _mk_service(tmp_path)
+    _mk_tasks_db(tmp_path, ["T-real"])
+    ghost = svc.enqueue(task_id="ghost-0000", trigger="task_done", scope={})
+    clock.advance(minutes=5)
+    real = svc.enqueue(task_id="T-real", trigger="task_done", scope={})
+    clock.advance(hours=2)
+
+    res = svc.check(session_id="S-1")
+    assert res["ready"] is True
+    assert res["brief"]["candidate_id"] == real, (
+        "a resolvable task_id is real grounding even with an empty scope"
+    )
+    assert res["brief"]["context"]["task_id"] == "T-real"
+    assert _status_of(svc, ghost) == "abandoned", (
+        "a task_id that resolves to nothing must not carry an empty "
+        "brief through the gate (likely_misfire: gate keys on the "
+        "task_id column only)"
+    )
+
+
+# ----------------------------------------------------------------------
+# AC-5 — enqueue-side guard for session bridge rows
+# ----------------------------------------------------------------------
+
+
+def test_enqueue_for_session_refuses_null_context(tmp_path):
+    svc, _clock = _mk_service(tmp_path)  # seeds schema
+    scores_db = str(tmp_path / "scores.db")
+    from prism_service.services.consolidation_data import enqueue_for_session
+
+    cid = enqueue_for_session(scores_db, "S-empty", scope=None)
+    assert cid is None, (
+        "a session with no task link and no usable scope must not "
+        "enqueue a candidate — it can only ever become a 'task None' brief"
+    )
+    n = svc._db.execute(
+        "SELECT COUNT(*) AS n FROM consolidation_candidates "
+        "WHERE session_id='S-empty'"
+    ).fetchone()["n"]
+    assert n == 0
+
+    # Runner-owned triggers are exempt: distill_procedural enqueues
+    # cluster rows with zero signal_counts by design.
+    cid2 = enqueue_for_session(
+        scores_db, "distill-proc::k1",
+        scope={
+            "cluster": True, "member_sessions": ["a", "b"],
+            "shared_skills": ["verify"], "task_id": None,
+            "signal_counts": {"pushbacks": 0, "bg_signals": 0,
+                              "tool_failures": 0, "memory_writes": 0},
+        },
+        trigger="distill_procedural",
+    )
+    assert cid2 is not None
+
+    # A session with a real transcript excerpt still enqueues.
+    cid3 = enqueue_for_session(
+        scores_db, "S-rich",
+        scope={"transcript_excerpt": "Pushbacks (2): ...",
+               "signal_counts": {"pushbacks": 2}},
+    )
+    assert cid3 is not None

--- a/services/prism-service/tests/unit/test_mcp_augmentation.py
+++ b/services/prism-service/tests/unit/test_mcp_augmentation.py
@@ -78,6 +78,27 @@ def test_mcp_response_not_augmented_when_none(project):
     assert "PRISM_REFLECTION_PENDING" not in out
 
 
+def test_mcp_response_not_augmented_for_garbage_rows(project):
+    """Task 1a7bc848 (AC-6) — runner-owned memory-op candidates and
+    null-context rows must never trigger the reflection nudge: they can
+    only ever dispense as the un-actionable 'task None' brief."""
+    # Runner-owned merge work item (memory-ops runner consumes these).
+    _call("janitor_enqueue", {
+        "trigger": "merge",
+        "scope": {"op": "merge", "member_ids": ["mx-aaaaaa", "mx-bbbbbb"]},
+    }, project_id=project)
+    # Null-context session row (no task, empty scope).
+    _call("janitor_enqueue", {
+        "trigger": "session_completed",
+        "scope": {},
+    }, project_id=project)
+    out = _text(_call("task_list", project_id=project))
+    assert "PRISM_REFLECTION_PENDING" not in out, (
+        "nudge fired for a queue containing only runner-owned/garbage "
+        "rows — no dispensable reflection brief exists"
+    )
+
+
 def test_augmentation_rate_limited_5min_per_session(project):
     _seed_pending(project)
     first = _text(_call("task_list", project_id=project))


### PR DESCRIPTION
## Summary

Fixes PRISM conductor task `1a7bc848` (epic 2a5e72a7, REFLECTION lane): every brief the reflection janitor dispensed was the byte-identical, un-actionable *"Did the approach taken on task None produce durable, well-integrated code?"* — null task_id, empty affected_files/memory_ids/task_ids, empty transcript_excerpt — and the `PRISM_REFLECTION_PENDING` nudge nagged every MCP-touching session about it forever.

**Root cause:** `consolidation_candidates` is a shared queue. The memory-ops runner enqueues its own work items (trigger `merge`/`forget`/`verify_staleness`/`distill_procedural`, `task_id NULL`, op-shaped scope such as `{"op":"merge","member_ids":[...]}` — `memory_ops/merge.py:120`), and `JanitorService.check()` dispensed the oldest pending row unconditionally. `_build_brief` only reads `file_paths`/`memory_ids`/`task_ids`/`transcript_excerpt`, so runner rows (and legacy null-context session rows) rendered as the empty brief; abandon-backoff recycled each one up to 3 dispenses. Live pre-fix evidence on the dev fork (`GET http://127.0.0.1:9999/api/consolidation?project=prism`): 6 pending rows, 5 of them trigger=`merge` null-task zero-signal (1dc30cdc, a4f1cff7, e690341f, a41c93d6, a3cc6cfd); `/next-brief` showed the merge scope directly, and the nudge fired mid-drive with an empty `task=`.

**Fix (dispense seam + enqueue guard):**
- `check()` classifies candidates: runner-owned rows are skipped and left `pending` for `memory_ops/runner.py` (never dispensed, never retired); rows with neither a resolvable task_id nor usable scope context are terminally retired (`status='abandoned'`) so the backlog **drains** — no db migration needed.
- likely_misfire guard: a non-null task_id must resolve in the sibling `tasks.db`; a garbage id cannot carry an empty brief through the gate (scope context is independently sufficient).
- `PRISM_REFLECTION_PENDING` now routes through `JanitorService.next_pending_for_nudge` — it only fires for a genuinely dispensable brief.
- `enqueue_for_session` refuses new null-context session rows (covers `/api/consolidation/backfill` + the brain_engine bridge); runner triggers exempt; the v6.2.18 `files_modified>0` contract (task ed7292bd) is preserved.
- `prune_noise_candidates` no longer deletes runner-owned work items.

## Receipts

- RED: `f801911` — `python -m pytest tests/unit/test_janitor_null_brief_gate.py tests/unit/test_mcp_augmentation.py::test_mcp_response_not_augmented_for_garbage_rows -q` → **7 failed** (each at the real seam).
- GREEN: `b8728d0` — same command → **12 passed**; full `python -m pytest tests/unit -q` → **961 passed in 81.73s**; `tests/integration/test_learning_loop_e2e.py` + `test_learning_loop_self_sustaining.py` → **17 passed**. (Python: `E:/.prism/.venvs/dev/Scripts/python`, cwd `services/prism-service`.)
- All four SDLC gates cleared; story/plan/green on verifier merit, red_gate via distinct-actor override (gate verifier scoped to the daemon checkout, blind to this worktree — committed failing-test trace cited). ADR memory `mx-10597a`.

## Notes

- **Takes effect after a daemon bounce** — the running self-improve fork on :9999 keeps its old in-process code until restarted; on the first `janitor_check` after the bounce, remaining null-context stragglers retire and runner rows stop surfacing.
- PRISM_VERSION intentionally **not** bumped — the merger bumps once for the consolidated hardening workstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)