### PR TITLE
hardening: gate teeth (failed-gate block, lane-commit verify, daemon_exclusive)

### DIFF
--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -1282,20 +1282,32 @@ class ConductorService:
         current_id = task.workflow_step or ""
         current_step = self._step_by_id(current_id)
 
-        # Refuse if we're sitting on a gate that hasn't been decided.
+        # Refuse if we're sitting on a gate that hasn't been decided —
+        # or one that FAILED. A failed gate latches the state machine
+        # (task baab6b51, live-probe 9f20b605): recovery goes through
+        # gate_decide(action='approve', override=True, distinct actor),
+        # never through a plain advance.
         if (current_step is not None
                 and current_step["type"] == "gate"
-                and task.gate_state == "pending"):
+                and task.gate_state in ("pending", "failed")):
+            if task.gate_state == "pending":
+                refusal_reason = (
+                    f"gate '{current_id}' is pending; "
+                    "call gate_decide before advancing"
+                )
+            else:
+                refusal_reason = (
+                    f"gate '{current_id}' is failed; advance is latched — "
+                    "remediate and recover via gate_decide "
+                    "action='approve' with override=True (distinct actor)"
+                )
             return {
                 "ok": False,
                 "task_id": task_id,
                 "from_step": current_id,
                 "to_step": current_id,
                 "gate_state": task.gate_state,
-                "reason": (
-                    f"gate '{current_id}' is pending; "
-                    "call gate_decide before advancing"
-                ),
+                "reason": refusal_reason,
             }
 
         current_index = self._step_index(current_id)

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import re
 import sqlite3
 import sys
@@ -1458,6 +1459,48 @@ class ConductorService:
                 continue
         return None
 
+    @staticmethod
+    def _lane_workspace(project_root: str, task_id: str) -> Optional[str]:
+        """Resolve the checkout that carries the task's LANE COMMIT — the
+        git worktree of *project_root* whose branch-local history
+        (merge-base(origin/main, HEAD)..HEAD) contains a commit tagged
+        [conductor:<first-8-of-task-id>]. Parallel-lane doctrine (task
+        24582b8b): gates verify the gate-claiming lane's committed work,
+        never the shared tree. Best-effort — any git failure returns None
+        (caller falls back to project_root). A lane already merged to
+        origin/main is outside the branch-local range, so done lanes
+        never shadow a live one."""
+        if not (project_root and task_id):
+            return None
+        import subprocess
+        marker = f"[conductor:{task_id[:8]}]"
+        try:
+            r = subprocess.run(
+                ["git", "worktree", "list", "--porcelain"],
+                cwd=project_root, capture_output=True, text=True, timeout=10)
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            return None
+        if r.returncode != 0:
+            return None
+        paths = [ln[len("worktree "):].strip()
+                 for ln in r.stdout.splitlines()
+                 if ln.startswith("worktree ")]
+        for wt in paths:
+            base = ConductorService._merge_base_baseline(wt)
+            rev_range = f"{base}..HEAD" if base else "HEAD"
+            try:
+                log = subprocess.run(
+                    ["git", "log", "--fixed-strings", f"--grep={marker}",
+                     "--format=%H", rev_range],
+                    cwd=wt, capture_output=True, text=True, timeout=10)
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                continue
+            if log.returncode == 0 and log.stdout.strip():
+                # git emits forward-slash paths even on Windows —
+                # normalize to the host convention for consumers.
+                return os.path.normpath(wt)
+        return None
+
     def _conformance_payload(self) -> dict:
         """Best-effort intended-vs-observed verdict for the green_gate
         conformance note: Brain-stored principles diffed against the
@@ -1573,7 +1616,15 @@ class ConductorService:
             # status=error 'nothing to verify'). project_root is the host
             # working tree wired by ProjectContext.attach_project_root.
             if self._project_root:
-                run_kwargs["workspace"] = str(self._project_root)
+                # LANE-COMMIT SCOPING (task 24582b8b): when the task's
+                # [conductor:<id8>] commit lives on a lane worktree branch,
+                # verify THAT checkout — a concurrent lane's red scaffold in
+                # the shared tree must not fail this lane's gate (and this
+                # lane's committed red/green must be visible to Tier0).
+                workspace = (self._lane_workspace(str(self._project_root),
+                                                  task.id)
+                             or str(self._project_root))
+                run_kwargs["workspace"] = workspace
                 # Scope Tier0 to the COMMITTED BRANCH diff, not just the
                 # working tree. In a source-run dev checkout the working tree
                 # is only untracked .dev-data noise, so a branch's COMMITTED
@@ -1582,7 +1633,7 @@ class ConductorService:
                 # gate fell back to override. baseline = merge-base(origin/main,
                 # HEAD); `git diff <baseline>` then includes the branch's
                 # committed test/impl files so the gate verifies on real proof.
-                base = self._merge_base_baseline(str(self._project_root))
+                base = self._merge_base_baseline(workspace)
                 if base:
                     run_kwargs["baseline_rev"] = base
             v = self._verifier_svc.run(**run_kwargs)

--- a/services/prism-service/tests/unit/test_conductor_v2_state_machine.py
+++ b/services/prism-service/tests/unit/test_conductor_v2_state_machine.py
@@ -326,3 +326,67 @@ def test_task_history_records_validation_on_advance(tmp_path):
     advance_rows = [r for r in rows if r.action == "advance_task"]
     assert advance_rows, "advance_task must produce a task_history row"
     assert "validation=plan_coverage" in advance_rows[-1].details
+
+
+# ----------------------------------------------------------------------
+# Failed gates must latch the state machine (task baab6b51)
+# ----------------------------------------------------------------------
+
+
+def test_advance_refused_when_gate_failed(tmp_path):
+    """A FAILED gate must block advance_task just like a pending one.
+
+    Live-probe finding (task 9f20b605): advance_task only checked
+    gate_state == 'pending', so a task sitting on a REJECTED gate could
+    legally be advanced past it with no override and no re-decision.
+    """
+    task_svc, cond = _services(tmp_path)
+    t = task_svc.create(title="Failed gate latches")
+    steps = _workflow()
+    gate_index = next(i for i, s in enumerate(steps) if s["type"] == "gate")
+    for _ in range(gate_index + 1):
+        cond.advance_task(t.id)
+    cond.gate_decide(t.id, action="reject", reason="verifier said no")
+
+    refused = cond.advance_task(t.id)
+
+    assert refused["ok"] is False
+    assert "failed" in refused["reason"]
+    assert refused["from_step"] == steps[gate_index]["id"]
+    assert refused["to_step"] == steps[gate_index]["id"]
+
+    # Task state untouched: still latched on the failed gate, with the
+    # rejection reason preserved.
+    refreshed = task_svc.get(t.id)
+    assert refreshed.workflow_step == steps[gate_index]["id"]
+    assert refreshed.gate_state == "failed"
+    assert refreshed.gate_reason == "verifier said no"
+
+
+def test_failed_gate_recovers_via_override_then_advances(tmp_path):
+    """The latch releases ONLY through the gate_decide recovery path
+    (approve + override=True, distinct actor); afterwards advance_task
+    proceeds normally."""
+    task_svc, cond = _services(tmp_path)
+    t = task_svc.create(title="Recover failed gate")
+    steps = _workflow()
+    gate_index = next(i for i, s in enumerate(steps) if s["type"] == "gate")
+    for _ in range(gate_index + 1):
+        cond.advance_task(t.id)
+    cond.gate_decide(t.id, action="reject", reason="nope")
+
+    # Latched: advance must be refused while the gate is failed.
+    assert cond.advance_task(t.id)["ok"] is False
+
+    recovered = cond.gate_decide(
+        t.id, action="approve", override=True,
+        actor="independent-verifier",
+        reason="remediated; pytest -q green",
+    )
+    assert recovered["ok"] is True
+    assert recovered["gate_state"] == "passed"
+
+    refreshed = task_svc.get(t.id)
+    assert refreshed.workflow_step == steps[gate_index + 1]["id"]
+    onward = cond.advance_task(t.id)
+    assert onward["ok"] is True

--- a/services/prism-service/tests/unit/test_conductor_v2_state_machine.py
+++ b/services/prism-service/tests/unit/test_conductor_v2_state_machine.py
@@ -209,8 +209,14 @@ def test_advance_at_final_step_returns_refusal(tmp_path):
         safety -= 1
         snapshot = task_svc.get(t.id)
         if snapshot.gate_state == "pending":
+            # Reason must satisfy the red/green artifact teeth (runner +
+            # fail/pass signal) — a failed gate now LATCHES advance_task
+            # (task baab6b51), so the walk can no longer skate past a
+            # rejected artifact check.
             cond.gate_decide(
-                t.id, action="approve", reason="test: walk to end"
+                t.id, action="approve",
+                reason="test: walk to end; pytest -q -> 1 failed then "
+                       "re-run all passed",
             )
             continue
         if snapshot.workflow_step == steps[-1]["id"]:

--- a/services/prism-service/tests/unit/test_conductor_v2_verifier_gate.py
+++ b/services/prism-service/tests/unit/test_conductor_v2_verifier_gate.py
@@ -415,3 +415,111 @@ def test_late_attach_verifier_service(tmp_path):
     )
     assert result["ok"] is True
     assert late.calls and late.calls[0]["task_id"] == t.id
+
+
+# ----------------------------------------------------------------------
+# Lane-commit workspace resolution (task 24582b8b) — gates must verify
+# the gate-claiming lane's committed work, not the shared tree.
+# ----------------------------------------------------------------------
+
+import subprocess
+
+
+def _git(cwd, *args) -> str:
+    r = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True,
+                       text=True, check=True)
+    return r.stdout.strip()
+
+
+def _make_shared_repo_with_lane(tmp_path, marker: str):
+    """A real git topology mirroring parallel-lane dev: a shared checkout
+    on main (with origin/main) plus a lane worktree whose branch carries
+    one commit tagged with the [conductor:<id8>] marker. Returns
+    (shared_root, lane_path, branch_point_sha)."""
+    shared = tmp_path / "shared"
+    shared.mkdir()
+    _git(shared, "init", "-b", "main")
+    _git(shared, "config", "user.email", "t@t")
+    _git(shared, "config", "user.name", "t")
+    (shared / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(shared, "add", "base.txt")
+    _git(shared, "commit", "-m", "base")
+    # origin/main = the branch point (self-remote keeps the fixture cheap).
+    _git(shared, "remote", "add", "origin", str(shared))
+    _git(shared, "fetch", "origin")
+    branch_point = _git(shared, "rev-parse", "HEAD")
+    lane = tmp_path / "lane"
+    _git(shared, "worktree", "add", "-b", "lane-branch", str(lane))
+    _git(lane, "config", "user.email", "t@t")
+    _git(lane, "config", "user.name", "t")
+    (lane / "lane.txt").write_text("lane work\n", encoding="utf-8")
+    _git(lane, "add", "lane.txt")
+    _git(lane, "commit", "-m", f"feat: lane work {marker}")
+    return shared, lane, branch_point
+
+
+def _services_with_root(tmp_path, verifier, project_root: str):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    task_svc = TaskService(str(tmp_path / "tasks.db"))
+    cond = ConductorService(
+        str(tmp_path / "scores.db"),
+        enable_engine=False,
+        task_svc=task_svc,
+        verifier_svc=verifier,
+        project_root=project_root,
+    )
+    return task_svc, cond
+
+
+def test_green_gate_verifies_lane_worktree_commit(tmp_path):
+    """AC-1/AC-2: when the task's [conductor:<id8>] commit lives on a lane
+    worktree branch, verifier.run() must be scoped to THAT worktree (and
+    its branch point), not the shared project_root tree."""
+    verifier = FakeVerifier({"status": "pass", "tier0": "pass",
+                             "tier1": "pass", "tier2": "skipped",
+                             "summary": "lane green"})
+    task_svc, cond = _services_with_root(tmp_path, verifier, "")
+    t = task_svc.create(title="lane-scoped green gate")
+    marker = f"[conductor:{t.id[:8]}]"
+    shared, lane, branch_point = _make_shared_repo_with_lane(tmp_path, marker)
+    cond.attach_project_root(str(shared))
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: lane-scoped gate; pytest -q -> 12 passed, 0 failed",
+    )
+
+    assert result["ok"] is True
+    assert verifier.calls, "verifier must be consulted"
+    call = verifier.calls[0]
+    assert call["workspace"] == str(lane), (
+        "green_gate must verify the lane worktree carrying the "
+        f"{marker} commit, not the shared tree")
+    assert call["baseline_rev"] == branch_point
+
+
+def test_gate_workspace_falls_back_to_project_root_without_lane_commit(
+        tmp_path):
+    """AC-3: no [conductor:<id8>] commit anywhere -> legacy scoping to
+    project_root is preserved."""
+    verifier = FakeVerifier({"status": "pass", "tier0": "pass",
+                             "tier1": "pass", "tier2": "skipped",
+                             "summary": "green"})
+    task_svc, cond = _services_with_root(tmp_path, verifier, "")
+    t = task_svc.create(title="no lane commit")
+    shared, _lane, _bp = _make_shared_repo_with_lane(
+        tmp_path, "[conductor:someother]")
+    cond.attach_project_root(str(shared))
+    _walk_to_gate(cond, t.id, _green_gate_id())
+
+    result = cond.gate_decide(
+        t.id, action="approve",
+        reason="test: fallback scoping; pytest -q -> 12 passed, 0 failed",
+    )
+
+    assert result["ok"] is True
+    assert verifier.calls
+    assert verifier.calls[0]["workspace"] == str(shared)


### PR DESCRIPTION
GATE-TEETH lane of the hardening backlog (epic 2a5e72a7). Two conductor-gated SDLC drives, each red -> green in this branch. (Task 279ef52d daemon_exclusive markers was reassigned to a parallel lane and is NOT in this PR.)

## 1. Failed gates must block conductor_advance (task baab6b51)

- Bug: `ConductorService.advance_task` only refused `gate_state='pending'` — a task on a verifier-REJECTED (failed) gate could be advanced past it with no override (live-probe 9f20b605: plan_gate(failed) -> write_failing_tests).
- Fix: the advance guard now latches on `gate_state in ('pending', 'failed')`; recovery is only via `gate_decide(action='approve', override=True, distinct actor)`.
- Receipts: RED 3d21b70 (`pytest tests/unit/test_conductor_v2_state_machine.py::test_advance_refused_when_gate_failed ... -> 2 failed, assert True is False`), GREEN e32684b (`pytest tests/unit -q -> 956 passed`).
- Note: `test_advance_at_final_step_returns_refusal` previously skated past its own failed red_gate via this bypass; its walk reason now satisfies the red/green artifact teeth.

## 2. Green gates verify the lane commit, not the shared tree (task 24582b8b)

- Bug: `_verify_gate` always scoped `verifier.run()` to the shared daemon checkout, so a concurrent lane's deliberate red scaffold mechanically failed every OTHER lane's green_gate (stress-loop 8f92751f), and the claiming lane's committed work was invisible to Tier-0.
- Fix: new `ConductorService._lane_workspace(project_root, task_id)` resolves the git worktree whose branch-local (merge-base(origin/main,HEAD)..HEAD) history carries the task's `[conductor:<id8>]` commit; `verifier.run()` gets that workspace + its merge-base as `baseline_rev`. No lane commit -> legacy project_root scoping. Merged lanes can't shadow live ones (outside the branch-local range).
- Receipts: RED 736797c (`pytest ...::test_green_gate_verifies_lane_worktree_commit -> workspace 'shared' != 'lane'`), GREEN 396cadb (`pytest tests/unit -q -> 958 passed`, real git-worktree fixture).

## Notes for the merger

- PRISM_VERSION intentionally NOT bumped — bump once at merge per the consolidated-workstream convention.
- Full `pytest tests/` in this worktree: 1211 passed; 5 pre-existing failures reproduce identically on the base commit 3f63eb7 (4 = the `test_implement_*` suite whose own guard forbids running from a worktree path; 1 = `test_tasks_timeline_rich_markdown_ui` asserting against SPA source with pending uncommitted canonical edits). None touch files in this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
