### PR TITLE
hardening: test/lint infra (testpaths ghost, data-dir pytest reach, ruff lane)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,12 @@ name = "prism-devtools"
 version = "5.0.0"
 
 [tool.pytest.ini_options]
-testpaths = ["plugins/prism-devtools/tools/prism-cli/tests"]
+testpaths = [
+    "services/prism-service/tests",
+    "benchmarks/tests",
+    "benchmarks/longmemeval/tests",
+    "plugins/prism-devtools/tests",
+]
 
 [tool.pylint.messages_control]
 disable = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,15 @@ name = "prism-devtools"
 version = "5.0.0"
 
 [tool.pytest.ini_options]
+# Never recurse into PRISM data dirs: they hold untracked repo mirrors
+# (e.g. data-*/projects/*/graphify-src) that shadow test modules and blow
+# up collection (Tier0 explosion, tasks c944660b/271dacc9). Extends the
+# pytest defaults (setting norecursedirs replaces them).
+norecursedirs = [
+    "*.egg", ".*", "build", "dist", "node_modules", "venv",
+    "data", "data-*", ".dev-data", "graphify-src", "web_dist",
+    "__pycache__", "site-packages",
+]
 testpaths = [
     "services/prism-service/tests",
     "benchmarks/tests",

--- a/services/prism-service/prism_service/services/verifier_service.py
+++ b/services/prism-service/prism_service/services/verifier_service.py
@@ -23,9 +23,10 @@ without mutating Brain / Memory / Tasks / Workflow.
 
 from __future__ import annotations
 
+import importlib.util
 import json
-import os
 import shutil
+import sys
 import sqlite3
 import subprocess
 import time
@@ -264,8 +265,9 @@ def _run_python_tools(workspace: Path, py_files: list[str]) -> list[Claim]:
     claims: list[Claim] = []
     if not py_files:
         return claims
-    if shutil.which("ruff"):
-        rc, out, err = _run_tool(["ruff", "check", *py_files], workspace)
+    ruff_cmd = _ruff_cmd()
+    if ruff_cmd:
+        rc, out, err = _run_tool([*ruff_cmd, "check", *py_files], workspace)
         claims.append(_claim(0, "tooling.ruff", ",".join(py_files[:5]), rc, out, err))
     else:
         claims.append(Claim(tier=0, kind="tooling.ruff", target="", status="skipped",
@@ -302,6 +304,21 @@ def _pytest_available() -> bool:
         return True
     import importlib.util
     return importlib.util.find_spec("pytest") is not None
+
+
+def _ruff_cmd() -> Optional[list[str]]:
+    """Resolve how to invoke ruff, or None when it isn't installed.
+
+    PATH exe first; else fall back to ``python -m ruff`` when the ruff
+    package is importable in the daemon interpreter (task 43a44af6: user-site
+    installs put ruff.exe in a Scripts dir that is often OFF the daemon's
+    PATH, which made the Tier0 lane report 'skipped: ruff not installed'
+    even with ruff pip-installed)."""
+    if shutil.which("ruff"):
+        return ["ruff"]
+    if importlib.util.find_spec("ruff") is not None:
+        return [sys.executable, "-m", "ruff"]
+    return None
 
 
 def _run_node_tools(workspace: Path, js_files: list[str]) -> list[Claim]:

--- a/services/prism-service/pyproject.toml
+++ b/services/prism-service/pyproject.toml
@@ -36,6 +36,10 @@ dependencies = [
   "tree-sitter>=0.21,<1",
   "tree-sitter-languages>=1.10",
   "pyyaml>=6",
+  # Runtime dep, not just dev tooling: the verifier's Tier0 lane shells out
+  # to ruff at daemon runtime (verifier_service._ruff_cmd); without it every
+  # gate reports tooling.ruff status=skipped (task 43a44af6).
+  "ruff>=0.4",
 ]
 
 [project.optional-dependencies]

--- a/services/prism-service/requirements.txt
+++ b/services/prism-service/requirements.txt
@@ -26,3 +26,6 @@ graphifyy>=0.4.29,<0.5
 # Without these the chunker falls back to regex which loses structural info.
 tree-sitter>=0.21,<1
 tree-sitter-languages>=1.10
+
+# Verifier Tier0 lint lane (runtime, not just dev - task 43a44af6)
+ruff>=0.4

--- a/services/prism-service/tests/unit/test_root_pyproject_data_dirs_unreachable.py
+++ b/services/prism-service/tests/unit/test_root_pyproject_data_dirs_unreachable.py
@@ -1,0 +1,45 @@
+"""Regression test for task c944660b: PRISM data dirs must be outside pytest reach.
+
+The data dir (e.g. data-selfimprove/) lives untracked inside the repo tree and
+holds a full stale repo mirror at projects/prism/graphify-src/** (staged by
+graph_service.py: self._project_dir / "graphify-src"). Recursive collection
+descending into it shadowed test modules (Tier0 collection explosion).
+Pin the invariant: root pyproject declares norecursedirs patterns that prune
+every data-dir basename pytest could meet at the repo root.
+"""
+from __future__ import annotations
+
+import sys
+from fnmatch import fnmatch
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+# Basenames that must never be recursed into from the repo root.
+DATA_DIR_BASENAMES = ["data", "data-selfimprove", "graphify-src", "web_dist"]
+
+
+def _repo_root() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "plugins").is_dir():
+            return parent
+    raise AssertionError("repo root with pyproject.toml + plugins/ not found")
+
+
+def test_root_norecursedirs_prunes_data_dirs():
+    root = _repo_root()
+    config = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    ini = config["tool"]["pytest"]["ini_options"]
+    patterns = ini.get("norecursedirs", [])
+    assert patterns, (
+        "root pyproject must declare norecursedirs - without it pytest "
+        "recurses into PRISM data dirs (stale repo mirrors) on explicit-arg runs"
+    )
+    for basename in DATA_DIR_BASENAMES:
+        assert any(fnmatch(basename, pat) for pat in patterns), (
+            f"norecursedirs does not prune '{basename}' - a data-dir repo "
+            "mirror would be collected"
+        )

--- a/services/prism-service/tests/unit/test_root_pyproject_testpaths.py
+++ b/services/prism-service/tests/unit/test_root_pyproject_testpaths.py
@@ -1,0 +1,41 @@
+"""Regression test for task f5dd6dc5: root pyproject testpaths must not point at ghosts.
+
+The repo-root pyproject.toml [tool.pytest.ini_options] testpaths once referenced
+plugins/prism-devtools/tools/prism-cli/tests, a directory that no longer exists.
+pytest 9 then silently falls back to FULL recursive rootdir collection (the
+Tier0 collection-explosion enabler, 271dacc9). Pin the invariant: every entry
+in root testpaths exists on disk and contains at least one test file.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover
+    import tomli as tomllib
+
+
+def _repo_root() -> Path:
+    """Walk up from this file to the repo root (dir holding root pyproject.toml)."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").is_file() and (parent / "plugins").is_dir():
+            return parent
+    raise AssertionError("repo root with pyproject.toml + plugins/ not found")
+
+
+def test_root_testpaths_entries_exist_and_hold_tests():
+    root = _repo_root()
+    config = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
+    testpaths = config["tool"]["pytest"]["ini_options"]["testpaths"]
+    assert testpaths, "root testpaths must not be empty"
+    for entry in testpaths:
+        target = root / entry
+        assert target.is_dir(), (
+            f"root pyproject testpaths entry '{entry}' does not exist - "
+            "pytest will warn and fall back to full rootdir collection"
+        )
+        assert any(target.rglob("test_*.py")), (
+            f"root pyproject testpaths entry '{entry}' contains no test files"
+        )

--- a/services/prism-service/tests/unit/test_verifier_ruff_cmd.py
+++ b/services/prism-service/tests/unit/test_verifier_ruff_cmd.py
@@ -1,0 +1,37 @@
+"""Regression tests for task 43a44af6: the Tier0 ruff lane must light up
+whenever the ruff package is present in the daemon env — PATH exe OR
+importable module — and only report skipped when neither resolves.
+"""
+from __future__ import annotations
+
+import sys
+
+from prism_service.services import verifier_service as vs
+
+
+def test_ruff_cmd_prefers_path_exe(monkeypatch):
+    monkeypatch.setattr(vs.shutil, "which", lambda name: "C:/tools/ruff.exe")
+    assert vs._ruff_cmd() == ["ruff"]
+
+
+def test_ruff_cmd_falls_back_to_module(monkeypatch):
+    monkeypatch.setattr(vs.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        vs.importlib.util, "find_spec", lambda name: object() if name == "ruff" else None
+    )
+    assert vs._ruff_cmd() == [sys.executable, "-m", "ruff"]
+
+
+def test_ruff_cmd_none_when_absent(monkeypatch):
+    monkeypatch.setattr(vs.shutil, "which", lambda name: None)
+    monkeypatch.setattr(vs.importlib.util, "find_spec", lambda name: None)
+    assert vs._ruff_cmd() is None
+
+
+def test_lane_emits_skipped_claim_when_ruff_absent(monkeypatch, tmp_path):
+    monkeypatch.setattr(vs.shutil, "which", lambda name: None)
+    monkeypatch.setattr(vs.importlib.util, "find_spec", lambda name: None)
+    claims = vs._run_python_tools(tmp_path, ["foo.py"])
+    ruff_claims = [c for c in claims if c.kind == "tooling.ruff"]
+    assert len(ruff_claims) == 1
+    assert ruff_claims[0].status == "skipped"


### PR DESCRIPTION
INFRA lane of the PRISM hardening backlog (epic 2a5e72a7). Three conductor tasks, each driven through the full gated SDLC (story_gate / plan_gate / red_gate / green_gate all passed; rubric gates with zero override).

## 1. Root pyproject testpaths points at a ghost (f5dd6dc5)
Root `pyproject.toml` testpaths referenced the long-gone `plugins/prism-devtools/tools/prism-cli/tests`, so pytest 9 warned and fell back to FULL recursive rootdir collection (the Tier0 collection-explosion enabler, 271dacc9).
- Fix: testpaths now enumerates the four real suites: `services/prism-service/tests`, `benchmarks/tests`, `benchmarks/longmemeval/tests`, `plugins/prism-devtools/tests`.
- Regression pin: `services/prism-service/tests/unit/test_root_pyproject_testpaths.py` asserts every entry exists and holds tests.
- Receipts: before = `PytestConfigWarning: No files were found in testpaths` + 1300 collected via fallback; after = no warning, 1301 collected (`python -m pytest -q --collect-only` at repo root). Commits a0fe787 (RED) + 708e030.

## 2. Data dir repo mirror sits inside pytest reach (c944660b)
PRISM data dirs (e.g. `data-selfimprove/`) live untracked in the repo tree and hold a stale full repo mirror at `projects/*/graphify-src/**` (staged by `graph_service.py:523`); explicit-arg pytest runs (`pytest .`) recursed into them, shadowing test modules.
- Fix: `norecursedirs` in root pyproject (pytest defaults restated + `data`, `data-*`, `.dev-data`, `graphify-src`, `web_dist`, `site-packages`).
- Location decision: graphify-src staging STAYS under the data dir (ingest already skips it, `source_service.py:342`); pytest exclusion is the guard.
- Regression pin: `tests/unit/test_root_pyproject_data_dirs_unreachable.py`.
- Receipts: probe test planted at `data-selfimprove/projects/prism/graphify-src/tests/` was collected before (1), collected after = 0; legit collection stable at 1302. Commits 1508798 (RED) + ef24703.

## 3. Ruff lane lights up in the daemon env (43a44af6)
Verifier Tier0 reported `tooling.ruff status=skipped "ruff not installed"`: ruff lived only in the `[dev]` extra (CI has it via pr-checks.yml; daemon installs do not), and the `shutil.which`-only lookup misses user-site installs whose Scripts dir is off PATH.
- Fix: `ruff>=0.4` promoted to prism-service core `[project].dependencies` + `requirements.txt` (the verifier shells out to ruff at daemon runtime — it is a runtime dep); new `verifier_service._ruff_cmd()` falls back to `python -m ruff` when the package is importable (mirrors `_pytest_available()`).
- Receipts: dep-count metric 0 -> 1 in both files; end-to-end with ruff installed but `which()=None`, the lane emits a real pass/fail claim (it immediately caught a real F401 in verifier_service.py, removed here). Tests: `tests/unit/test_verifier_ruff_cmd.py` (4). Commits d7c954e (RED) + 287fb08.
- **CAVEAT: the live fork daemon keeps reporting skipped until its env is pip-reinstalled (picking up the new core dep) and bounced — intentionally not performed from this lane.**

## Verification
- Full service suite (worktree, `E:/.prism/.venvs/dev` python): 1215 passed; the 5 failures are pre-existing base-tree worktree-env artifacts that reproduce identically with all changes stashed (e.g. `test_only_canonical_workflow_targeted` asserts a non-worktree cwd).
- `python -m pytest -q --collect-only` at repo root: 1302 collected, zero warnings.
- PRISM_VERSION intentionally NOT bumped (no UI-visible surface); merger bumps once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)