### PR TITLE
hardening: full suite green from agent worktrees

### DIFF
--- a/services/prism-service/prism_service/web/src/components/Markdown.tsx
+++ b/services/prism-service/prism_service/web/src/components/Markdown.tsx
@@ -145,10 +145,26 @@ export function renderInline(text: string): ReactNode {
     if (!next) { parts.push(<span key={key++}>{highlight(rest)}</span>); break; }
     if (next.index > 0) parts.push(<span key={key++}>{highlight(rest.slice(0, next.index))}</span>);
     if (next === code) {
-      // Marked code chips (backtick spans) become resolving xref links, so
-      // every surface that renders markdown inherits clickable tokens. Plain
-      // prose never reaches this branch, so words outside backticks stay inert.
-      parts.push(<XrefLink key={key++} token={next[1]} />);
+      const token = next[1];
+      if (/\s/.test(token)) {
+        // A whitespace-bearing span (a shell command, a multi-word fragment)
+        // can never resolve as an xref symbol/file — render the plain inline
+        // <code> chip directly (FR-2) and skip the resolver round-trip.
+        parts.push(
+          <code
+            key={key++}
+            className="text-[0.85em] font-mono px-1 py-0.5 rounded break-all align-baseline bg-[color:var(--surface-2)] text-[color:var(--text-secondary)]"
+          >
+            {token}
+          </code>,
+        );
+      } else {
+        // Single-token code chips become resolving xref links, so every
+        // surface that renders markdown inherits clickable tokens; an
+        // unresolved token stays an inert <code> chip inside XrefLink. Plain
+        // prose never reaches this branch, so words outside backticks stay inert.
+        parts.push(<XrefLink key={key++} token={token} />);
+      }
     } else if (next === link) {
       const href = next[2];
       const external = /^https?:\/\//.test(href);

--- a/services/prism-service/tests/integration/test_implement_dependency_aware_branch_base.py
+++ b/services/prism-service/tests/integration/test_implement_dependency_aware_branch_base.py
@@ -41,6 +41,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.worktree_guard import worktree_of_canonical
+
 _HERE = Path(__file__).resolve()
 _SERVICE_ROOT = _HERE.parent.parent.parent
 _WORKFLOWS = _SERVICE_ROOT.parent.parent / ".claude" / "workflows"
@@ -234,14 +236,18 @@ def test_dry_run_reports_dep_aware_base():
 # ── AC: only the canonical workflow is edited (worktree untouched) ───────
 
 def test_only_canonical_workflow_targeted():
-    """Guard: this suite asserts against the canonical workflow path, never
-    a worktree copy — the worktree under .claude/worktrees syncs separately
-    and is explicitly out of scope (plan_doc)."""
+    """Guard: this suite asserts against the canonical workflow lineage,
+    never a stray copy. A linked git worktree of the canonical repo IS a
+    legitimate home (agent lanes run the suite there); a bare copy or a
+    foreign clone parked under a worktrees-like path is still rejected —
+    decided by git identity via tests.worktree_guard (task 7faed505)."""
     assert _WORKFLOWS.name == "workflows"
-    assert "worktrees" not in str(_WORKFLOWS), (
-        "test is pointed at a worktree copy — only the canonical "
-        ".claude/workflows/implement.js is in scope"
-    )
+    if "worktrees" in str(_WORKFLOWS):
+        assert worktree_of_canonical(_WORKFLOWS), (
+            "test is pointed at a stray copy under a worktrees path — only "
+            "the canonical .claude/workflows/implement.js or a linked git "
+            "worktree of the canonical repo is in scope"
+        )
     assert (_WORKFLOWS / "implement.js").exists(), (
         "canonical .claude/workflows/implement.js not found"
     )

--- a/services/prism-service/tests/integration/test_implement_source_of_truth_writeback.py
+++ b/services/prism-service/tests/integration/test_implement_source_of_truth_writeback.py
@@ -44,6 +44,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from tests.worktree_guard import worktree_of_canonical
+
 _HERE = Path(__file__).resolve()
 _SERVICE_ROOT = _HERE.parent.parent.parent
 _WORKFLOWS = _SERVICE_ROOT.parent.parent / ".claude" / "workflows"
@@ -81,7 +83,12 @@ def _step_schema_block(src: str) -> str:
     """The STEP_SCHEMA object — the per-step structured-output contract that
     every non-locate step returns. AC7's source_tier field belongs here."""
     start = src.index("const STEP_SCHEMA = {")
-    end = src.index("// ── Phase: Pre-flight", start)
+    # The schema object ends where the Pre-flight phase begins. Match the
+    # stable comment TEXT, not its decorative dash style: the committed
+    # implement.js is byte-clean ASCII ("// -- Phase: Pre-flight"), while an
+    # earlier draft used U+2500 box-drawing rules ("// ── ...") — indexing on
+    # the dashes made this helper ValueError against the real committed file.
+    end = src.index("Phase: Pre-flight", start)
     return src[start:end]
 
 
@@ -238,14 +245,18 @@ def test_step_rejects_empty_or_mistiered_cite():
 # ── Guard: only the canonical workflow is edited (worktree untouched) ─────
 
 def test_only_canonical_workflow_targeted():
-    """Guard: this suite asserts against the canonical workflow path, never
-    a worktree copy — the worktree under .claude/worktrees syncs separately
-    and is explicitly out of scope."""
+    """Guard: this suite asserts against the canonical workflow lineage,
+    never a stray copy. A linked git worktree of the canonical repo IS a
+    legitimate home (agent lanes run the suite there); a bare copy or a
+    foreign clone parked under a worktrees-like path is still rejected —
+    decided by git identity via tests.worktree_guard (task 7faed505)."""
     assert _WORKFLOWS.name == "workflows"
-    assert "worktrees" not in str(_WORKFLOWS), (
-        "test is pointed at a worktree copy — only the canonical "
-        ".claude/workflows/implement.js is in scope"
-    )
+    if "worktrees" in str(_WORKFLOWS):
+        assert worktree_of_canonical(_WORKFLOWS), (
+            "test is pointed at a stray copy under a worktrees path — only "
+            "the canonical .claude/workflows/implement.js or a linked git "
+            "worktree of the canonical repo is in scope"
+        )
     assert (_WORKFLOWS / "implement.js").exists(), (
         "canonical .claude/workflows/implement.js not found"
     )

--- a/services/prism-service/tests/integration/test_worktree_aware_location_guard.py
+++ b/services/prism-service/tests/integration/test_worktree_aware_location_guard.py
@@ -1,0 +1,134 @@
+"""RED contract — worktree-aware location self-check (task 7faed505).
+
+The test_implement_* suites carry a location guard
+(`test_only_canonical_workflow_targeted`) that asserted a blanket
+`"worktrees" not in str(_WORKFLOWS)`. That reds EVERY run from a legitimate
+agent worktree (.claude/worktrees/<name>) of the canonical repo, so every
+lane's full-suite receipt carried a "pre-existing failures" caveat.
+
+New contract, pinned here: the guard delegates to ONE shared helper,
+`tests.worktree_guard.worktree_of_canonical(workflows_dir)`, which decides
+by GIT IDENTITY — never by path whitelisting:
+
+  * ACCEPT — a linked git worktree of the canonical repo: `git rev-parse`
+    reports --git-dir != --git-common-dir (linked, not main checkout) AND
+    the common repo's root hosts .claude/workflows/implement.js.
+  * REJECT — a bare directory copy under a worktrees-like path (no git
+    metadata at all): rev-parse fails or resolves elsewhere.
+  * REJECT — a genuinely foreign clone (its own .git: git-dir ==
+    git-common-dir), even when parked under a path containing "worktrees".
+
+The original protection (the suite must assert against the canonical
+.claude/workflows/implement.js, never a stray copy) is therefore KEPT —
+only the false positive on legitimate worktrees is removed.
+
+ALL RED today: tests/worktree_guard.py does not exist and both guard suites
+still hard-assert the blanket path check.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+def _helper():
+    """Lazy import so the RED state fails each test (not collection)."""
+    from tests.worktree_guard import worktree_of_canonical
+
+    return worktree_of_canonical
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(cwd), "-c", "user.email=guard@test",
+         "-c", "user.name=guard-test", *args],
+        check=True, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture
+def canonical_repo(tmp_path: Path) -> Path:
+    """A throwaway 'canonical' repo hosting .claude/workflows/implement.js."""
+    repo = tmp_path / "canonical"
+    wf = repo / ".claude" / "workflows"
+    wf.mkdir(parents=True)
+    (wf / "implement.js").write_text("// canonical implement.js\n",
+                                     encoding="utf-8")
+    _git(tmp_path, "init", "-q", str(repo))
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "seed canonical workflow")
+    return repo
+
+
+# -- ACCEPT: a linked git worktree of the canonical repo ---------------------
+
+def test_linked_worktree_of_canonical_is_accepted(canonical_repo: Path):
+    """The real agent layout: `git worktree add` under
+    <canonical>/.claude/worktrees/<name>. Its .claude/workflows must be a
+    legitimate home for the guard suites."""
+    wt = canonical_repo / ".claude" / "worktrees" / "agent-guardtest"
+    _git(canonical_repo, "worktree", "add", "-q", str(wt))
+    workflows = wt / ".claude" / "workflows"
+    assert workflows.is_dir(), "worktree checkout must carry the workflows dir"
+    assert "worktrees" in str(workflows)  # the exact string the old guard red on
+    assert _helper()(workflows) is True, (
+        "a linked git worktree of the canonical repo must be ACCEPTED as a "
+        "legitimate home (git-common-dir points back at the canonical .git)"
+    )
+
+
+# -- REJECT: a bare copy parked under a worktrees-like path ------------------
+
+def test_bare_copy_under_worktrees_path_is_rejected(canonical_repo: Path,
+                                                    tmp_path: Path):
+    """A plain file copy (no git metadata) placed under .claude/worktrees/*
+    is exactly the stray the original guard existed to catch — still red."""
+    copy = tmp_path / "elsewhere" / ".claude" / "worktrees" / "agent-copy"
+    shutil.copytree(canonical_repo, copy,
+                    ignore=shutil.ignore_patterns(".git"))
+    workflows = copy / ".claude" / "workflows"
+    assert (workflows / "implement.js").exists()
+    assert _helper()(workflows) is False, (
+        "a bare directory copy (no git identity) must still be REJECTED"
+    )
+
+
+# -- REJECT: a genuinely foreign clone ----------------------------------------
+
+def test_foreign_clone_is_rejected(canonical_repo: Path, tmp_path: Path):
+    """An independent clone owns its own .git (git-dir == git-common-dir):
+    it is NOT a linked worktree of the canonical repo and stays rejected,
+    even when parked under a path containing 'worktrees'."""
+    clone = tmp_path / "worktrees" / "foreign-clone"
+    _git(tmp_path, "clone", "-q", str(canonical_repo), str(clone))
+    workflows = clone / ".claude" / "workflows"
+    assert (workflows / "implement.js").exists()
+    assert _helper()(workflows) is False, (
+        "a foreign clone (its own .git) must still be REJECTED — worktree "
+        "awareness must not blanket-whitelist every git checkout"
+    )
+
+
+# -- The two guard suites must share THIS helper (no drift) -------------------
+
+def test_guard_suites_delegate_to_shared_helper():
+    """Both test_implement_* location guards must consume the ONE shared
+    helper, so the accept/reject contract cannot drift per-file."""
+    from tests import worktree_guard
+    from tests.integration import (
+        test_implement_dependency_aware_branch_base as branch_base,
+        test_implement_source_of_truth_writeback as writeback,
+    )
+
+    assert getattr(branch_base, "worktree_of_canonical", None) \
+        is worktree_guard.worktree_of_canonical, (
+        "dependency_aware_branch_base guard must import the shared helper"
+    )
+    assert getattr(writeback, "worktree_of_canonical", None) \
+        is worktree_guard.worktree_of_canonical, (
+        "source_of_truth_writeback guard must import the shared helper"
+    )

--- a/services/prism-service/tests/worktree_guard.py
+++ b/services/prism-service/tests/worktree_guard.py
@@ -1,0 +1,51 @@
+"""Shared location self-check for the test_implement_* guard suites.
+
+The guard suites assert about their own home: they must target the canonical
+.claude/workflows/implement.js, never a stray copy. The original check was a
+blanket `"worktrees" not in path`, which also redded every legitimate agent
+worktree (.claude/worktrees/<name>) of the canonical repo — the "5
+pre-existing failures" caveat on every lane's full-suite receipt.
+
+`worktree_of_canonical` decides by GIT IDENTITY instead (task 7faed505):
+
+  * ACCEPT — a linked git worktree of the canonical repo: `git rev-parse`
+    reports --git-dir != --git-common-dir (linked worktrees keep their git
+    dir under <canonical>/.git/worktrees/<name>) AND the common repo's root
+    hosts .claude/workflows/implement.js.
+  * REJECT — a bare directory copy (no git identity: rev-parse fails, or
+    ascends to an enclosing repo whose git-dir == common-dir).
+  * REJECT — a genuinely foreign clone (its own .git: git-dir == common-dir).
+
+Contract red-tested in tests/integration/test_worktree_aware_location_guard.py.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def worktree_of_canonical(workflows: Path) -> bool:
+    """True iff `workflows` (<home>/.claude/workflows) sits inside a LINKED
+    git worktree of the canonical repo. Never path-whitelists: the decision
+    is git identity plus canonical-workflow membership."""
+    home = workflows.parents[1]
+
+    def _rev(flag: str) -> Path:
+        out = subprocess.run(
+            ["git", "-C", str(home), "rev-parse", "--path-format=absolute",
+             flag],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+        return Path(out).resolve()
+
+    try:
+        git_dir = _rev("--git-dir")
+        common = _rev("--git-common-dir")
+    except (subprocess.CalledProcessError, OSError):
+        return False  # no git identity at all — a bare copy
+    if git_dir == common:
+        # A main checkout or an independent clone — not a linked worktree.
+        return False
+    canonical_root = common.parent
+    return (canonical_root / ".claude" / "workflows" / "implement.js").is_file()


### PR DESCRIPTION
## What

Task `7faed505` (epic 2a5e72a7, SUITE lane): a full `python -m pytest tests/` from a fresh agent worktree of the repo showed **5 failures that reproduce on the clean base (3f63eb7)**, so every agent lane's full-suite receipt carried a "5 pre-existing failures" caveat, eroding green_gate meaning.

## Root causes and fixes

1. **Worktree-hostile location guard (2 failures)** — `test_only_canonical_workflow_targeted` (in `test_implement_dependency_aware_branch_base.py` + `test_implement_source_of_truth_writeback.py`) asserted a blanket `"worktrees" not in path`. Now decided by **git identity** via the new shared helper `tests/worktree_guard.py::worktree_of_canonical`: a *linked* worktree (`git rev-parse --git-dir != --git-common-dir`) whose common repo hosts `.claude/workflows/implement.js` is a legitimate home; a bare copy (no git identity) or a genuinely foreign clone (`git-dir == git-common-dir`) is still rejected. That protection stays red-tested in the new `tests/integration/test_worktree_aware_location_guard.py` (real tmp git repos: worktree accepted, copy + clone rejected, both guard suites must share the one helper).
2. **Delimiter-brittle schema extraction (2 failures)** — `_step_schema_block` indexed on `// ── Phase: Pre-flight` (U+2500 box-drawing) but the committed `implement.js` is byte-clean ASCII (`// -- Phase: Pre-flight`), so both AC7 tests `ValueError`'d even though `source_tier` IS implemented (implement.js:255). The helper now ends the block at the stable text `Phase: Pre-flight`, dash-style agnostic. **No implement.js change.**
3. **Markdown FR-2 (1 failure)** — the test requires inline code spans to render as `<code>` in `Markdown.tsx`, but the XrefLink refactor moved the chip wholly into `XrefLink.tsx`. Implemented fresh from the test's spec: whitespace-bearing spans (shell commands, multi-word fragments — never resolvable xref symbols) render a direct inert `<code>` chip and skip the resolver round-trip; single-token spans keep XrefLink. Hermes CSS vars only.

## Receipts

Before (worktree at base 3f63eb7, `cwd=services/prism-service`):

```
FAILED tests/integration/test_implement_dependency_aware_branch_base.py::test_only_canonical_workflow_targeted
FAILED tests/integration/test_implement_source_of_truth_writeback.py::test_step_schema_has_source_tier_field
FAILED tests/integration/test_implement_source_of_truth_writeback.py::test_source_tier_enumerates_brain_grep_web
FAILED tests/integration/test_implement_source_of_truth_writeback.py::test_only_canonical_workflow_targeted
FAILED tests/integration/test_tasks_timeline_rich_markdown_ui.py::test_markdown_parses_structured_blocks
5 failed, 1209 passed, 5 warnings in 106.94s
```

After (same worktree, same command):

```
1218 passed, 4 warnings in 105.57s (0:01:45)
EXIT=0
```

SDLC: full conductor drive (story_gate, plan_gate, green_gate all cleared by the rubric/machine verifier with **zero overrides**; red_gate required one distinct-actor override because the daemon verifier runs outside a worktree and is structurally blind to this red — trace committed in 1b802d1). Decision memory `mx-11beb7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)