### PR TITLE
feat(magic): headless Magic admin channel — LOB-factory lane 1

### DIFF
--- a/plugins/prism-devtools/skills/magic-build/SKILL.md
+++ b/plugins/prism-devtools/skills/magic-build/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: magic-build
+description: Build a customer's business backend on a headless Magic Cloud tenant through PRISM's /api/magic channel — CRUD + business-rule validation in Hyperlambda. Use when a task builds LOB functionality (tables + endpoints) on Magic. Encodes the Hyperlambda gotchas so you never rediscover them.
+version: 1.0.0
+---
+
+# Build on Magic Cloud (headless, via PRISM)
+
+You build a customer's backend on a Magic tenant by POSTing Hyperlambda to
+PRISM's channel. You never edit PRISM or Magic source. This skill gives you
+COPY-PASTE templates — change only the db/table/field names. Do NOT invent
+Hyperlambda from scratch; adapt these.
+
+## Channel
+- `POST http://localhost:8888/api/magic/execute` body `{"hyperlambda":"<code>"}` → runs Hyperlambda as root, returns `{"result": <raw text>}`. Your build + admin tool. (Dev daemon is :8888; a scratch daemon may be :8999.)
+- `GET http://localhost:8888/api/magic/endpoints` → lists live endpoints (verify your work here).
+- Live tenant endpoints answer at `http://localhost:4444/magic/modules/<mod>/<name>`.
+
+## THE FIVE GOTCHAS (each cost millions of tokens to rediscover — obey them)
+
+1. **`io.file.save` does NOT create parent folders.** Always `io.folder.create:/modules/<mod>/` FIRST, or you get `DirectoryNotFoundException`.
+2. **Node references resolve only among ELDER SIBLINGS + ancestors — NOT a sibling's children.** So `x:@sqlite.select/*` works ONLY when the referencing node is a DIRECT SIBLING of `sqlite.select` INSIDE the same `sqlite.connect` block. A root-level `return-nodes:x:@sqlite.select/*` silently returns an EMPTY body, and a root-level `if exists:x:@sqlite.select/*` reads empty → falsely rejects everything. FIX: put your return / validation checks INSIDE the connect block, indented as siblings of the select.
+3. **Indentation IS control flow.** Statements must be siblings at equal indent. A node accidentally nested under another runs as its argument (silent no-op).
+4. **A write (`sqlite.execute` INSERT/UPDATE) nested inside an `else > .lambda` branch can silently no-op in the live endpoint runtime.** Prefer a flat guard-then-write: validate, `return` early on failure, then do the write at top level. Don't bury the write in a deep branch.
+5. **`/api/magic/execute` echoes the whole lambda tree as raw text — it is NOT proof a branch ran.** Verify side effects with a follow-up `sqlite.select`, not by reading the echo. (`return-nodes` through the execute channel may 500; that's fine — it works in the actual endpoint file.)
+
+## TEMPLATE A — create schema + seed (one execute call)
+```
+sqlite.connect:DBNAME
+   sqlite.execute:CREATE TABLE IF NOT EXISTS parents (id INTEGER PRIMARY KEY, name TEXT, email TEXT)
+   sqlite.execute:CREATE TABLE IF NOT EXISTS children (id INTEGER PRIMARY KEY, parent_id INTEGER, title TEXT, status TEXT DEFAULT 'new')
+   sqlite.execute:INSERT INTO parents (name,email) VALUES ('Seed Co','seed@x.io')
+```
+Keep DDL/INSERT SQL on ONE line, unquoted, to avoid nested-quote escaping.
+
+## TEMPLATE B — list endpoint (GET). Note return-nodes is INSIDE connect (gotcha #2)
+```
+io.folder.create:/modules/MODNAME/
+io.file.save:/modules/MODNAME/parents.get.hl
+   .:@"sqlite.connect:DBNAME
+   sqlite.select:SELECT * FROM parents
+   return-nodes:x:@sqlite.select/*"
+```
+Live at `GET magic/modules/MODNAME/parents`.
+
+## TEMPLATE C — add endpoint with a foreign-key + rule (POST). VERIFIED idiom.
+Guard-then-write (gotcha #4); the select + if-guards are siblings INSIDE connect (gotcha #2).
+```
+io.file.save:/modules/MODNAME/children.post.hl
+   .:@".arguments
+   parent_id:long
+   title:string
+sqlite.connect:DBNAME
+   sqlite.select:SELECT id FROM parents WHERE id = @id
+      @id:x:@.arguments/*/parent_id
+   if
+      not
+         exists:x:@sqlite.select/*
+      .lambda
+         response.status.set:400
+         return
+            error:R1 - no such parent
+   sqlite.execute:INSERT INTO children (parent_id,title) VALUES (@p,@t)
+      @p:x:@.arguments/*/parent_id
+      @t:x:@.arguments/*/title
+   return
+      status:created"
+```
+VERIFIED RULES (use these exact slots — do NOT invent validators):
+- **Read a POST arg:** `x:@.arguments/*/<name>`. Declare typed args in a top `.arguments` block.
+- **SQL params use `@name`** (both in the SQL text `= @id` AND the child node `@id:x:...`). NOT `:name`.
+- **FK / "must exist" reject:** `if / not / exists:x:@sqlite.select/*` after a select that looks the row up.
+- **"already exists" / uniqueness reject:** `if / exists:x:@sqlite.select/*` (no `not`).
+- **Count / capacity rule (e.g. can't exceed N):** fold it into the lookup SQL and reject if empty —
+  `SELECT id FROM events WHERE id = @id AND capacity > (SELECT COUNT(*) FROM registrations WHERE event_id = @id)` then `if / not / exists` → this rejects BOTH a missing event (R1) and a full one (R2) in one check.
+- **Enum rule (status in a set):** guard in SQL or with `if` on the arg value; simplest is to only ever write a fixed value (add writes 'pending', a separate approve writes 'approved') so an invalid status cannot enter.
+- **Numeric rule (amount>0):** `if / lt / (arg) / .:int:0 / .lambda → 400`. Keep the comparison a sibling inside connect.
+
+## TEMPLATE D — an "approve"/update endpoint
+```
+io.file.save:/modules/MODNAME/children.approve.post.hl
+   .:@"sqlite.connect:DBNAME
+   sqlite.execute:UPDATE children SET status='approved' WHERE id = @id
+      @id:x:@.arguments/*/id
+   return
+      status:approved"
+```
+
+## Recipe (do in this order)
+1. Schema + seed via Template A (one call).
+2. For each entity: a GET list (Template B) and a POST add (Template C with its rules). Folder-create once.
+3. Verify: `GET /api/magic/endpoints` shows your `magic/modules/MODNAME/*`; then probe each rule with a violating input and confirm a 400, plus a happy-path 200.
+4. If a probe wrongly succeeds/fails, the cause is almost always gotcha #2 (a check at the wrong indent) — move it inside the connect block.
+
+## When to prefer crudify
+For plain CRUD with NO custom business rules, `POST magic/system/crudifier/crudify` (via the client, non-AI, deterministic) generates all four verbs from a table in one shot. Use custom `.hl` (templates above) whenever a rule must be enforced in the endpoint. Never use the AI/ML crudify options or `magic.lambda.openai` slots — a headless tenant has no model key.

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.5"
+PRISM_VERSION = "8.0.6"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.3"
+PRISM_VERSION = "8.0.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.4"
+PRISM_VERSION = "8.0.5"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.2"
+PRISM_VERSION = "8.0.3"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.1"
+PRISM_VERSION = "8.0.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,17 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.23"
+PRISM_VERSION = "6.7.24"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.24: PRISM as the expert USER of Magic — services/magic_app_builder "
+    "deterministically renders a structured app spec (entities + fk/min/enum "
+    "rules) into WHITESPACE-PERFECT Hyperlambda and deploys it (POST "
+    "/api/magic/build-app). Closes the gap the 7B experiment found: a small "
+    "model produces the spec, PRISM renders the exact tree. Proven at scale: a "
+    "5-entity ERP (10 endpoints, 8 rules) deploys in 0.74s, 17/17 rule-probes "
+    "green; a 7B-authored clinic spec renders+enforces FK+enum at $0 Anthropic. "
     "v6.7.23: Magic Cloud admin channel (LOB-factory lane 1) — services/magic_client "
     "(authenticate→JWT, bootstrap owns the root/root setup window idempotently, evaluator "
     "execute, endpoints/crudify/sql) + /api/magic router + Magic card in Settings→Connections. "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,7 +13,7 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "8.0.0"
+PRISM_VERSION = "8.0.1"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,15 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.22"
+PRISM_VERSION = "6.7.23"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.23: Magic Cloud admin channel (LOB-factory lane 1) — services/magic_client "
+    "(authenticate→JWT, bootstrap owns the root/root setup window idempotently, evaluator "
+    "execute, endpoints/crudify/sql) + /api/magic router + Magic card in Settings→Connections. "
+    "Credentials live in a DATA_DIR dotfile; only a •••last4 fingerprint leaves the server. "
+    "Verified against a live servergardens/magic-backend:v22.10.10 container. "
     "v6.7.22: artifact/understand OUTLINE now shows REAL symbol kinds + lines (class/function, "
     ":line) from the Brain index instead of the graph entities table, which stored "
     "kind=unknown/line=0 and listed imported names. build_understanding now sources the "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,17 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.24"
+PRISM_VERSION = "8.0.0"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v8.0.0: self-improvement-engine fork rebased to the 8.x line. Kills the "
+    "OpenAI dependency for Magic AI: PRISM is the MEMORY SUBSTRATE (retrieval "
+    "over vectorized content via the Brain) and the local 7B (ollama, "
+    "OpenAI-wire-compatible) is the generator — services/magic_ai.py + POST "
+    "/api/magic/ai. Zero Anthropic/OpenAI tokens; a one-time migration ingests "
+    "training content into the Brain. Builds on v6.7.24's deterministic Magic "
+    "app renderer. "
     "v6.7.24: PRISM as the expert USER of Magic — services/magic_app_builder "
     "deterministically renders a structured app spec (entities + fk/min/enum "
     "rules) into WHITESPACE-PERFECT Hyperlambda and deploys it (POST "

--- a/services/prism-service/prism_service/api/__init__.py
+++ b/services/prism-service/prism_service/api/__init__.py
@@ -21,6 +21,7 @@ from prism_service.api.github_auth import router as github_auth_router
 from prism_service.api.graph import router as graph_router
 from prism_service.api.jobs import router as jobs_router
 from prism_service.api.learning import router as learning_router
+from prism_service.api.magic import router as magic_router
 from prism_service.api.memory import router as memory_router
 from prism_service.api.okf import router as okf_router
 from prism_service.api.projects import router as projects_router
@@ -47,6 +48,7 @@ api_router.include_router(github_auth_router, prefix="/github-auth", tags=["gith
 api_router.include_router(graph_router, prefix="/graph", tags=["graph"])
 api_router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 api_router.include_router(learning_router, prefix="/learning", tags=["learning"])
+api_router.include_router(magic_router, prefix="/magic", tags=["magic"])
 api_router.include_router(memory_router, prefix="/memory", tags=["memory"])
 api_router.include_router(okf_router, prefix="/okf", tags=["okf"])
 api_router.include_router(projects_router, prefix="/projects", tags=["projects"])

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -75,13 +75,19 @@ def interview(body: InterviewBody) -> dict:
     else:
         iv = mi.SpecInterview(body.spec)
     resumed = bool(sess) and not body.session
+    artifacts = None
     if proj:
         mi.save_session(proj, iv.to_dict())          # survives restarts/visits
         if iv.state == mi.READY:
-            mi.record_facts(proj, mi.business_facts(iv))  # PRISM = their expert
+            facts = mi.business_facts(iv)
+            mi.record_facts(proj, facts)             # PRISM = their expert
+            try:                                      # auto-build the customer app
+                artifacts = mi.finalize_build(proj, iv.spec, facts=facts)
+            except Exception as e:                    # surface, don't crash the turn
+                artifacts = {"error": str(e)[:160]}
     return {"state": iv.state, "domain": iv.domain(),
             "questions": iv.questions(), "spec": iv.spec, "round": iv.round,
-            "resumed": resumed, "session": iv.to_dict()}
+            "resumed": resumed, "artifacts": artifacts, "session": iv.to_dict()}
 
 
 class ConfigureBody(BaseModel):

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 
 from prism_service.services import magic_client as mc
 from prism_service.services import magic_app_builder as ab
+from prism_service.services import magic_ai
 
 router = APIRouter()
 
@@ -87,6 +88,29 @@ def endpoints():
         return mc.endpoints()
     except mc.MagicError as e:
         raise HTTPException(502, f"magic endpoints failed: {e}")
+
+
+class AiBody(BaseModel):
+    query: str
+    project: str = ""
+
+
+@router.post("/ai")
+def ai(body: AiBody) -> dict:
+    """OpenAI-free AI generate: PRISM's Brain is the memory substrate and a
+    local model (ollama) is the generator. Zero OpenAI/Anthropic tokens."""
+    def retrieve(query: str, k: int = 5) -> list[str]:
+        try:
+            from prism_service.api._context import get_project  # type: ignore
+            ctx = get_project(body.project) if body.project else None
+            hits = ctx.brain_svc.search(query, limit=k) if ctx else []
+            return magic_ai.make_brain_retriever(lambda q, lim: hits)(query, k)
+        except Exception:
+            return []
+    try:
+        return magic_ai.ai_generate(body.query, retrieve)
+    except magic_ai.LocalLLMError as e:
+        raise HTTPException(502, f"local model failed: {e}")
 
 
 class BuildAppBody(BaseModel):

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -1,0 +1,88 @@
+"""/api/magic — PRISM's connection to a headless Magic Cloud backend.
+
+Configure/clear the stored credential (fingerprint-only responses —
+the secret never leaves the server), bootstrap a fresh instance, and
+proxy admin operations (execute Hyperlambda, list endpoints) through
+services/magic_client. Lane 1 of the LOB-factory epic.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from prism_service.services import magic_client as mc
+
+router = APIRouter()
+
+
+class ConfigureBody(BaseModel):
+    url: str
+    user: str = "root"
+    password: str
+
+
+class SetupBody(BaseModel):
+    url: str
+    password: str
+    name: str = ""
+    email: str = ""
+
+
+class ExecuteBody(BaseModel):
+    hyperlambda: str
+
+
+@router.get("/status")
+def status() -> dict:
+    return mc.status()
+
+
+@router.post("/configure")
+def configure(body: ConfigureBody) -> dict:
+    try:
+        mc.authenticate(body.url, body.user, body.password)
+    except mc.MagicError as e:
+        code = 400 if e.status in (400, 401, 403) else 502
+        raise HTTPException(code, f"magic connection failed: {e}")
+    try:
+        mc.save_connection(body.url, body.user, body.password)
+    except ValueError as e:
+        raise HTTPException(400, str(e))
+    return mc.status()
+
+
+@router.post("/clear")
+def clear() -> dict:
+    mc.clear_connection()
+    return mc.status()
+
+
+@router.post("/setup")
+def setup(body: SetupBody) -> dict:
+    """Bootstrap a fresh headless instance — PRISM owns the root/root
+    window so nobody else can claim it after provisioning."""
+    try:
+        out = mc.bootstrap(body.url, body.password,
+                           name=body.name, email=body.email)
+    except mc.MagicError as e:
+        raise HTTPException(502, f"magic bootstrap failed: {e}")
+    resp = mc.status()
+    resp.update(out)
+    return resp
+
+
+@router.post("/execute")
+def execute(body: ExecuteBody) -> dict:
+    try:
+        return mc.execute(body.hyperlambda)
+    except mc.MagicError as e:
+        raise HTTPException(502, f"magic execute failed: {e}")
+
+
+@router.get("/endpoints")
+def endpoints():
+    try:
+        return mc.endpoints()
+    except mc.MagicError as e:
+        raise HTTPException(502, f"magic endpoints failed: {e}")

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -14,8 +14,21 @@ from pydantic import BaseModel
 from prism_service.services import magic_client as mc
 from prism_service.services import magic_app_builder as ab
 from prism_service.services import magic_ai
+from prism_service.services import magic_spec_gaps
 
 router = APIRouter()
+
+
+class CheckSpecBody(BaseModel):
+    spec: dict
+
+
+@router.post("/check-spec")
+def check_spec(body: CheckSpecBody) -> dict:
+    """The gap detector: PRISM inspects a PI-produced spec for missing or
+    ambiguous rules and returns follow-up questions for the SLM to voice on
+    the PI screen. `complete` is False while a blocking gap remains."""
+    return magic_spec_gaps.check_spec(body.spec)
 
 
 class ConfigureBody(BaseModel):

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -33,8 +33,9 @@ def check_spec(body: CheckSpecBody) -> dict:
 
 class InterviewBody(BaseModel):
     spec: dict = {}          # start a new interview from this draft spec
-    session: dict = {}       # OR resume a serialized interview
+    session: dict = {}       # OR resume a serialized interview (explicit)
     answers: list = []       # [{question, answer}] to apply this turn
+    project: str = ""        # customer project — resume/persist across visits
 
 
 @router.post("/interview")
@@ -63,15 +64,24 @@ def interview(body: InterviewBody) -> dict:
         except Exception:
             return spec  # SLM hiccup: leave spec unchanged, state machine copes
 
-    if body.session:
-        iv = mi.SpecInterview.from_dict(body.session)
+    # resume: explicit session, else the customer's saved session for the
+    # project (PRISM remembers where they left off), else a fresh interview.
+    proj = (body.project or "").strip()
+    sess = body.session or (mi.load_session(proj) if proj else None)
+    if sess:
+        iv = mi.SpecInterview.from_dict(sess)
         if body.answers:
             iv.answer(body.answers, refine)
     else:
         iv = mi.SpecInterview(body.spec)
+    resumed = bool(sess) and not body.session
+    if proj:
+        mi.save_session(proj, iv.to_dict())          # survives restarts/visits
+        if iv.state == mi.READY:
+            mi.record_facts(proj, mi.business_facts(iv))  # PRISM = their expert
     return {"state": iv.state, "domain": iv.domain(),
-            "questions": iv.questions(), "spec": iv.spec,
-            "round": iv.round, "session": iv.to_dict()}
+            "questions": iv.questions(), "spec": iv.spec, "round": iv.round,
+            "resumed": resumed, "session": iv.to_dict()}
 
 
 class ConfigureBody(BaseModel):

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -31,6 +31,49 @@ def check_spec(body: CheckSpecBody) -> dict:
     return magic_spec_gaps.check_spec(body.spec)
 
 
+class InterviewBody(BaseModel):
+    spec: dict = {}          # start a new interview from this draft spec
+    session: dict = {}       # OR resume a serialized interview
+    answers: list = []       # [{question, answer}] to apply this turn
+
+
+@router.post("/interview")
+def interview(body: InterviewBody) -> dict:
+    """Reverse-engineering interview, one turn. Start with `spec`, or resume
+    with `session` + `answers`. Returns the state machine's state + the next
+    questions + the running spec + the serialized session (persist it in
+    memory / re-post it next turn). Consistency is the state machine's job."""
+    from prism_service.services import magic_interview as mi
+    import json as _json
+    import re as _re
+
+    def refine(spec: dict, answered: list) -> dict:
+        qa = "\n".join(f"Q: {a['question']}\nA: {a['answer']}" for a in answered)
+        prompt = (f"Current app spec (JSON):\n{_json.dumps(spec)}\n\n"
+                  f"Clarifications from the customer:\n{qa}\n\nOutput the "
+                  "UPDATED app spec incorporating the clarifications, same JSON "
+                  "shape. Output ONLY JSON.")
+        try:
+            text, _ = magic_ai.local_complete(
+                [{"role": "system", "content": "You update a JSON app spec."},
+                 {"role": "user", "content": prompt}])
+            m = _re.search(r"\{.*\}", _re.sub(r"<think>.*?</think>", "", text,
+                                              flags=_re.DOTALL), _re.DOTALL)
+            return _json.loads(m.group(0)) if m else spec
+        except Exception:
+            return spec  # SLM hiccup: leave spec unchanged, state machine copes
+
+    if body.session:
+        iv = mi.SpecInterview.from_dict(body.session)
+        if body.answers:
+            iv.answer(body.answers, refine)
+    else:
+        iv = mi.SpecInterview(body.spec)
+    return {"state": iv.state, "domain": iv.domain(),
+            "questions": iv.questions(), "spec": iv.spec,
+            "round": iv.round, "session": iv.to_dict()}
+
+
 class ConfigureBody(BaseModel):
     url: str
     user: str = "root"

--- a/services/prism-service/prism_service/api/magic.py
+++ b/services/prism-service/prism_service/api/magic.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
 from prism_service.services import magic_client as mc
+from prism_service.services import magic_app_builder as ab
 
 router = APIRouter()
 
@@ -86,3 +87,21 @@ def endpoints():
         return mc.endpoints()
     except mc.MagicError as e:
         raise HTTPException(502, f"magic endpoints failed: {e}")
+
+
+class BuildAppBody(BaseModel):
+    spec: dict
+
+
+@router.post("/build-app")
+def build_app(body: BuildAppBody) -> dict:
+    """PRISM as expert user of Magic: render a structured app spec into
+    whitespace-perfect Hyperlambda and deploy it to the connected tenant.
+    The spec is what a small model can reliably produce; the render is
+    deterministic so the built app always parses."""
+    try:
+        return ab.deploy_app(body.spec)
+    except mc.MagicError as e:
+        raise HTTPException(502, f"magic build-app failed: {e}")
+    except (KeyError, TypeError) as e:
+        raise HTTPException(400, f"invalid app spec: {e}")

--- a/services/prism-service/prism_service/engines/brain_engine.py
+++ b/services/prism-service/prism_service/engines/brain_engine.py
@@ -675,6 +675,7 @@ class Brain:
     _INDEXABLE_SUFFIXES = {
         ".py", ".ts", ".tsx", ".js", ".jsx",
         ".md", ".yaml", ".yml", ".json", ".txt", ".sh",
+        ".hl",  # Hyperlambda — so PRISM's Brain learns Magic-generated code
     }
 
     _EXCLUDED_PATH_SEGMENTS = {

--- a/services/prism-service/prism_service/services/magic_ai.py
+++ b/services/prism-service/prism_service/services/magic_ai.py
@@ -93,3 +93,67 @@ def make_brain_retriever(brain_search):
                 out.append(str(r))
         return out
     return _retrieve
+
+
+def _extract_hl(text: str) -> str:
+    import re
+    blocks = re.findall(r"```(?:hl|hyperlambda)?\s*\n(.*?)```", text, re.DOTALL)
+    return (blocks[0] if blocks else text).strip()
+
+
+def generate_verified(query: str, retrieve, verify, complete=local_complete,
+                      system: str = DEFAULT_SYSTEM, max_rounds: int = 4) -> dict:
+    """Substrate-grounded generate + deterministic normalize + verify/repair.
+
+    The gap-closer: a small model grounded in the retrieved Hyperlambda
+    context emits an endpoint; PRISM normalizes its whitespace, deploys it,
+    and if it fails feeds the REAL error + freshly-retrieved context back for
+    a repair round. Loops until it deploys + passes checks, or max_rounds.
+
+    verify(hyperlambda) -> (ok: bool, detail: str). Zero OpenAI/Anthropic.
+    """
+    from prism_service.services.magic_app_builder import normalize_indent
+    context = list(retrieve(query, 6) or [])
+    messages = _build_messages(query, context, system)
+    total = 0
+    last = ""
+    for rnd in range(max_rounds):
+        text, usage = complete(messages)
+        total += usage.get("total_tokens", 0)
+        hl = normalize_indent(_extract_hl(text))
+        ok, detail = verify(hl)
+        if ok:
+            return {"ok": True, "hyperlambda": hl, "rounds": rnd + 1,
+                    "context_used": len(context), "local_tokens": total,
+                    "openai_tokens": 0, "anthropic_tokens": 0}
+        last = detail
+        more = retrieve(detail, 3) or []
+        messages.append({"role": "assistant", "content": text[:1200]})
+        messages.append({"role": "user", "content":
+                         f"That failed: {detail}\nUse these verified patterns "
+                         f"and output ONLY the corrected Hyperlambda:\n"
+                         + "\n\n".join(more)})
+    return {"ok": False, "rounds": max_rounds, "detail": last,
+            "local_tokens": total, "openai_tokens": 0, "anthropic_tokens": 0}
+
+
+def liberate_training_corpus(fetch_snippets, corpus_dir, ingest) -> dict:
+    """Liberate a Magic tenant's ml_training_snippets from OpenAI: pull the
+    prompt/completion TEXT (dropping the OpenAI embeddings blob) and re-embed
+    it into PRISM's Brain with the local embedder.
+
+    fetch_snippets() -> list[{prompt, completion, type?, uri?}].
+    ingest(paths) -> doc count (e.g. Brain.ingest). Injectable for tests.
+    Note: corpus_dir must be a CLEAN path (Brain skips .claude/.venvs/etc).
+    """
+    import os
+    os.makedirs(corpus_dir, exist_ok=True)
+    snippets = list(fetch_snippets() or [])
+    for i, s in enumerate(snippets):
+        body = (f"# {s.get('prompt', '')}\n\n{s.get('completion', '')}\n\n"
+                f"(type: {s.get('type', 'hl')}, uri: {s.get('uri') or 'n/a'})")
+        with open(os.path.join(corpus_dir, f"{i:04d}.md"), "w",
+                  encoding="utf-8") as f:
+            f.write(body)
+    return {"snippets": len(snippets), "docs_indexed": ingest([corpus_dir]),
+            "openai_tokens": 0, "anthropic_tokens": 0}

--- a/services/prism-service/prism_service/services/magic_ai.py
+++ b/services/prism-service/prism_service/services/magic_ai.py
@@ -1,0 +1,95 @@
+"""PRISM as the AI substrate for Magic — OpenAI-free.
+
+The AI generator's two halves are re-homed onto local infrastructure:
+  * MEMORY  -> PRISM's Brain (retrieval over the vectorized training
+    content). `retrieve(query)` returns the relevant context snippets.
+  * MODEL   -> a local model served by ollama, which speaks the OpenAI
+    wire format (/v1/chat/completions), so no api.openai.com and no key.
+
+Net: PRISM holds the vectors and orchestrates; the local model
+generates. Zero Anthropic and zero OpenAI tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.request
+
+# ollama's OpenAI-compatible endpoint; override for a remote host.
+OLLAMA_BASE = os.environ.get("PRISM_LOCAL_LLM_BASE", "http://localhost:11434/v1")
+LOCAL_MODEL = os.environ.get("PRISM_LOCAL_LLM_MODEL", "qwen2.5-coder:7b")
+_TIMEOUT = 120
+
+
+class LocalLLMError(Exception):
+    """Local model call failed (network or non-2xx)."""
+
+
+def local_complete(messages: list[dict], model: str | None = None,
+                   base: str | None = None) -> tuple[str, dict]:
+    """Call the local OpenAI-compatible chat endpoint. Returns
+    (content, usage). No OpenAI, no key."""
+    body = json.dumps({"model": model or LOCAL_MODEL,
+                       "messages": messages,
+                       "temperature": 0.1}).encode()
+    url = f"{(base or OLLAMA_BASE).rstrip('/')}/chat/completions"
+    req = urllib.request.Request(url, data=body,
+                                 headers={"Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as r:
+            d = json.loads(r.read())
+    except urllib.error.HTTPError as e:
+        raise LocalLLMError(f"local llm http {e.code}: "
+                            f"{e.read().decode('utf-8','replace')[:200]}") from e
+    except urllib.error.URLError as e:
+        raise LocalLLMError(f"local llm unreachable: {e.reason}") from e
+    content = d["choices"][0]["message"]["content"]
+    return content, d.get("usage", {})
+
+
+def _build_messages(query: str, context: list[str], system: str) -> list[dict]:
+    ctx = "\n\n".join(f"[context {i+1}]\n{c}" for i, c in enumerate(context))
+    user = (f"Relevant knowledge from the memory substrate:\n{ctx}\n\n"
+            f"Task: {query}") if context else query
+    return [{"role": "system", "content": system},
+            {"role": "user", "content": user}]
+
+
+DEFAULT_SYSTEM = (
+    "You are PRISM's Magic builder. Using ONLY the provided memory-substrate "
+    "context, produce a correct answer or Hyperlambda. Do not invent slots or "
+    "syntax that are not grounded in the context.")
+
+
+def ai_generate(query: str, retrieve, complete=local_complete,
+                system: str = DEFAULT_SYSTEM, k: int = 5) -> dict:
+    """The OpenAI-free AI generate loop: PRISM memory substrate supplies
+    context, the local model generates.
+
+    retrieve: callable(query, k) -> list[str] of context snippets from the
+    Brain / memory substrate. complete: callable(messages) -> (text, usage).
+    """
+    context = list(retrieve(query, k) or [])
+    messages = _build_messages(query, context, system)
+    text, usage = complete(messages)
+    return {"answer": text, "context_used": len(context),
+            "local_tokens": usage.get("total_tokens", 0),
+            "openai_tokens": 0, "anthropic_tokens": 0, "model": LOCAL_MODEL}
+
+
+def make_brain_retriever(brain_search):
+    """Adapt a brain_search(query, limit)->results callable into a
+    retrieve(query, k)->list[str] the substrate can use. Each result's
+    text/snippet becomes a context string."""
+    def _retrieve(query: str, k: int = 5) -> list[str]:
+        out = []
+        for r in (brain_search(query, k) or [])[:k]:
+            if isinstance(r, dict):
+                out.append(str(r.get("text") or r.get("snippet")
+                                or r.get("content") or r.get("description") or r))
+            else:
+                out.append(str(r))
+        return out
+    return _retrieve

--- a/services/prism-service/prism_service/services/magic_app_builder.py
+++ b/services/prism-service/prism_service/services/magic_app_builder.py
@@ -170,17 +170,39 @@ def render_add_endpoint(entity: dict, db: str) -> str:
 # --- assembly + deploy ------------------------------------------------------
 
 
+# placeholder tokens a small model emits when it doesn't know a real value
+_PLACEHOLDERS = {"", "table", "..", "...", "x", "entity", "field", "name",
+                 "string", "text", "value", "foo", "bar"}
+
+
 def normalize_spec(spec: dict) -> dict:
-    """Tolerate reasonable variation from a small model: drop any explicit
-    'id' field (we always add the PK), strip a trailing '.<col>' from an fk
-    ref down to the table name, and default a missing rules list."""
+    """Canonicalize a small-model spec so the pipeline is stable regardless of
+    SLM wobble: lowercase/strip entity + field names, drop the explicit 'id'
+    field (we add the PK), strip a trailing '.<col>' from an fk ref, and DROP
+    malformed rules (empty field, or an fk ref that's a placeholder like
+    'table'/'..'). Entities with a placeholder/empty name are dropped too."""
     for ent in spec.get("entities", []):
-        ent["fields"] = [f for f in ent.get("fields", [])
-                         if f.get("name", "").lower() != "id"]
-        ent.setdefault("rules", [])
-        for r in ent["rules"]:
-            if r.get("type") == "fk" and "." in r.get("ref", ""):
-                r["ref"] = r["ref"].split(".")[0]
+        ent["name"] = (ent.get("name") or "").strip().lower()
+        fields = []
+        for f in ent.get("fields", []) or []:
+            fn = (f.get("name") or "").strip()
+            if fn and fn.lower() != "id":
+                f["name"] = fn
+                fields.append(f)
+        ent["fields"] = fields
+        clean = []
+        for r in ent.get("rules", []) or []:
+            if not (r.get("field") or "").strip():
+                continue
+            if r.get("type") == "fk":
+                ref = (r.get("ref") or "").split(".")[0].strip().lower()
+                if ref in _PLACEHOLDERS:
+                    continue  # drop garbage fk (no real target)
+                r["ref"] = ref
+            clean.append(r)
+        ent["rules"] = clean
+    spec["entities"] = [e for e in spec.get("entities", [])
+                        if e.get("name") and e["name"] not in _PLACEHOLDERS]
     return spec
 
 

--- a/services/prism-service/prism_service/services/magic_app_builder.py
+++ b/services/prism-service/prism_service/services/magic_app_builder.py
@@ -194,3 +194,39 @@ def deploy_app(spec: dict, execute=mc.execute) -> dict:
         endpoints.append(f"POST magic/modules/{mod}/{ent['name']}")
     return {"module": mod, "db": spec["db"], "endpoints": endpoints,
             "file_count": len(app["files"])}
+
+
+# --- deterministic whitespace repair (closes the small-model gap) ------------
+
+
+def normalize_indent(hl: str) -> str:
+    """Rescale a model's indentation to exact 3-space multiples.
+
+    A small model gets Hyperlambda's structure right but often emits a
+    non-3 indent unit (2 or 4 spaces) or drifts — which trips Magic's
+    whitespace-strict parser. If the emitted indentation is internally
+    CONSISTENT (a single unit), its GCD is that unit, and we can map each
+    line to depth = width/unit and re-emit at depth*3. Strips code fences.
+    """
+    lines = [l for l in hl.replace("\t", "   ").splitlines()]
+    lines = [l for l in lines if not l.strip().startswith("```")]
+    widths = {len(l) - len(l.lstrip(" ")) for l in lines if l.strip()}
+    widths.discard(0)
+    unit = 0
+    for w in sorted(widths):
+        unit = w if unit == 0 else _gcd(unit, w)
+    out = []
+    for l in lines:
+        if not l.strip():
+            out.append("")
+            continue
+        w = len(l) - len(l.lstrip(" "))
+        depth = (w // unit) if unit else 0
+        out.append(("   " * depth) + l.lstrip(" "))
+    return "\n".join(out).strip("\n")
+
+
+def _gcd(a: int, b: int) -> int:
+    while b:
+        a, b = b, a % b
+    return a

--- a/services/prism-service/prism_service/services/magic_app_builder.py
+++ b/services/prism-service/prism_service/services/magic_app_builder.py
@@ -1,0 +1,196 @@
+"""Deterministic Magic app renderer — PRISM as the expert user of Magic.
+
+Takes a structured app spec (entities + fields + rules) and emits
+WHITESPACE-PERFECT Hyperlambda: schema DDL + list/add endpoint files
+with rule guards. The idioms here are empirically verified against a
+live servergardens/magic-backend:v22.10.10 tenant (v_shop/orders +
+p_lib/loan_create passed objective rule-probes).
+
+This closes the gap the 7B experiment exposed: a small model reliably
+produces the SPEC but cannot emit precise Hyperlambda. So the division
+of labour is: model -> spec, PRISM -> render. The render is pure code,
+so the whitespace/tree structure is always exact.
+"""
+
+from __future__ import annotations
+
+from prism_service.services import magic_client as mc
+
+# SQLite column type -> Hyperlambda .arguments type
+_ARG_TYPE = {"TEXT": "string", "INTEGER": "long", "REAL": "decimal"}
+
+I = "   "  # one Hyperlambda indent level (exactly 3 spaces)
+
+
+def _arg_type(sql_type: str) -> str:
+    return _ARG_TYPE.get(sql_type.upper(), "string")
+
+
+def _fields_of(entity: dict) -> list[dict]:
+    return entity.get("fields", [])
+
+
+# --- schema -----------------------------------------------------------------
+
+
+def render_schema(spec: dict) -> str:
+    """One execute payload creating every table (id PK + declared fields)."""
+    lines = [f"sqlite.connect:{spec['db']}"]
+    for ent in spec["entities"]:
+        cols = ["id INTEGER PRIMARY KEY"]
+        for f in _fields_of(ent):
+            cols.append(f"{f['name']} {f['type']}")
+        lines.append(f"{I}sqlite.execute:CREATE TABLE IF NOT EXISTS "
+                     f"{ent['name']} ({', '.join(cols)})")
+    for ent in spec["entities"]:
+        for row in ent.get("seed", []):
+            names = ",".join(row.keys())
+            vals = ",".join("'" + str(v).replace("'", "''") + "'"
+                            for v in row.values())
+            lines.append(f"{I}sqlite.execute:INSERT INTO {ent['name']} "
+                         f"({names}) VALUES ({vals})")
+    return "\n".join(lines)
+
+
+# --- endpoint bodies (verified idioms; whitespace is exact) ------------------
+
+
+def render_list_endpoint(entity: dict, db: str) -> str:
+    t = entity["name"]
+    return (f"sqlite.connect:{db}\n"
+            f"{I}sqlite.select:SELECT * FROM {t}\n"
+            f"{I}return-nodes:x:@sqlite.select/*")
+
+
+def _fk_guard(rule: dict) -> list[str]:
+    f, ref = rule["field"], rule["ref"]
+    return [
+        f"{I}sqlite.select:SELECT id FROM {ref} WHERE id = @fk",
+        f"{I*2}@fk:x:@.arguments/*/{f}",
+        f"{I}if",
+        f"{I*2}not",
+        f"{I*3}exists:x:@sqlite.select/*",
+        f"{I*2}.lambda",
+        f"{I*3}response.status.set:400",
+        f"{I*3}return",
+        f"{I*4}error:{f} must reference an existing {ref}",
+    ]
+
+
+def _min_guard(rule: dict) -> list[str]:
+    f, v = rule["field"], rule.get("value", 0)
+    return [
+        f"{I}if",
+        f"{I*2}lt:x:@.arguments/*/{f}",
+        f"{I*3}.:decimal:{v}",
+        f"{I*2}.lambda",
+        f"{I*3}response.status.set:400",
+        f"{I*3}return",
+        f"{I*4}error:{f} must be at least {v}",
+    ]
+
+
+def _enum_checks_inside(rule: dict) -> list[str]:
+    f = rule["field"]
+    flag = f".valid_{f}"
+    out: list[str] = []
+    for val in rule["values"]:
+        out += [
+            f"{I}if",
+            f"{I*2}eq:x:@.arguments/*/{f}",
+            f"{I*3}.:{val}",
+            f"{I*2}.lambda",
+            f"{I*3}set-value:x:@{flag}",
+            f"{I*4}.:bool:true",
+        ]
+    out += [
+        f"{I}if",
+        f"{I*2}not",
+        f"{I*3}get-value:x:@{flag}",
+        f"{I*2}.lambda",
+        f"{I*3}response.status.set:400",
+        f"{I*3}return",
+        f"{I*4}error:{f} must be one of {', '.join(rule['values'])}",
+    ]
+    return out
+
+
+def render_add_endpoint(entity: dict, db: str) -> str:
+    t = entity["name"]
+    rules = entity.get("rules", [])
+    lines = [".arguments"]
+    for fld in _fields_of(entity):
+        lines.append(f"{I}{fld['name']}:{_arg_type(fld['type'])}")
+    # enum flags declared before connect (elder-sibling reachable)
+    for r in rules:
+        if r["type"] == "enum":
+            lines.append(f".valid_{r['field']}:bool:false")
+    lines.append(f"sqlite.connect:{db}")
+    for r in rules:
+        if r["type"] == "fk":
+            lines += _fk_guard(r)
+        elif r["type"] == "min":
+            lines += _min_guard(r)
+        elif r["type"] == "enum":
+            lines += _enum_checks_inside(r)
+    cols = [f["name"] for f in _fields_of(entity)]
+    params = ",".join("@" + c for c in cols)
+    lines.append(f"{I}sqlite.execute:INSERT INTO {t} "
+                 f"({','.join(cols)}) VALUES ({params})")
+    for c in cols:
+        lines.append(f"{I*2}@{c}:x:@.arguments/*/{c}")
+    lines += [f"{I}return", f"{I*2}status:created"]
+    return "\n".join(lines)
+
+
+# --- assembly + deploy ------------------------------------------------------
+
+
+def normalize_spec(spec: dict) -> dict:
+    """Tolerate reasonable variation from a small model: drop any explicit
+    'id' field (we always add the PK), strip a trailing '.<col>' from an fk
+    ref down to the table name, and default a missing rules list."""
+    for ent in spec.get("entities", []):
+        ent["fields"] = [f for f in ent.get("fields", [])
+                         if f.get("name", "").lower() != "id"]
+        ent.setdefault("rules", [])
+        for r in ent["rules"]:
+            if r.get("type") == "fk" and "." in r.get("ref", ""):
+                r["ref"] = r["ref"].split(".")[0]
+    return spec
+
+
+def render_app(spec: dict) -> dict:
+    """Pure render: returns the schema payload + {file_path: hl_content}.
+    No network — unit-testable."""
+    spec = normalize_spec(spec)
+    mod = spec["module"]
+    db = spec["db"]
+    files: dict[str, str] = {}
+    for ent in spec["entities"]:
+        base = f"/modules/{mod}/{ent['name']}"
+        files[f"{base}.get.hl"] = render_list_endpoint(ent, db)
+        files[f"{base}.post.hl"] = render_add_endpoint(ent, db)
+    return {"schema": render_schema(spec), "files": files}
+
+
+def _save_payload(mod: str, path: str, content: str) -> str:
+    body = content.replace('"', '""')
+    return (f"io.folder.create:/modules/{mod}/\n"
+            f'io.file.save:{path}\n{I}.:@"{body}"')
+
+
+def deploy_app(spec: dict, execute=mc.execute) -> dict:
+    """Render + deploy to the connected tenant. `execute` is injectable for
+    tests. Returns the built endpoint list."""
+    app = render_app(spec)
+    execute(app["schema"])
+    mod = spec["module"]
+    for path, content in app["files"].items():
+        execute(_save_payload(mod, path, content))
+    endpoints = []
+    for ent in spec["entities"]:
+        endpoints.append(f"GET magic/modules/{mod}/{ent['name']}")
+        endpoints.append(f"POST magic/modules/{mod}/{ent['name']}")
+    return {"module": mod, "db": spec["db"], "endpoints": endpoints,
+            "file_count": len(app["files"])}

--- a/services/prism-service/prism_service/services/magic_app_builder.py
+++ b/services/prism-service/prism_service/services/magic_app_builder.py
@@ -115,6 +115,28 @@ def _enum_checks_inside(rule: dict) -> list[str]:
     return out
 
 
+def _capacity_guard(rule: dict, child_table: str) -> list[str]:
+    """Count/capacity rule: reject if the referenced parent is missing OR
+    already has >= capacity children. One combined SELECT (verified idiom):
+    it returns a row only when the parent exists AND has room, so a single
+    if/not/exists rejects both cases (R1 missing + R2 full)."""
+    f, ref = rule["field"], rule["ref"]
+    cap = rule.get("capacity_field", "capacity")
+    sql = (f"SELECT id FROM {ref} WHERE id = @cap AND {cap} > "
+           f"(SELECT COUNT(*) FROM {child_table} WHERE {f} = @cap)")
+    return [
+        f"{I}sqlite.select:{sql}",
+        f"{I*2}@cap:x:@.arguments/*/{f}",
+        f"{I}if",
+        f"{I*2}not",
+        f"{I*3}exists:x:@sqlite.select/*",
+        f"{I*2}.lambda",
+        f"{I*3}response.status.set:400",
+        f"{I*3}return",
+        f"{I*4}error:{ref} not found or at capacity",
+    ]
+
+
 def render_add_endpoint(entity: dict, db: str) -> str:
     t = entity["name"]
     rules = entity.get("rules", [])
@@ -133,6 +155,8 @@ def render_add_endpoint(entity: dict, db: str) -> str:
             lines += _min_guard(r)
         elif r["type"] == "enum":
             lines += _enum_checks_inside(r)
+        elif r["type"] == "capacity":
+            lines += _capacity_guard(r, t)
     cols = [f["name"] for f in _fields_of(entity)]
     params = ",".join("@" + c for c in cols)
     lines.append(f"{I}sqlite.execute:INSERT INTO {t} "

--- a/services/prism-service/prism_service/services/magic_client.py
+++ b/services/prism-service/prism_service/services/magic_client.py
@@ -1,0 +1,207 @@
+"""HTTP admin client for a headless Magic Cloud backend.
+
+PRISM's power-user channel to Magic (github.com/polterguy/magic):
+authenticate → JWT, bootstrap a fresh instance (the root/root window →
+config/setup, which PRISM must own — it closes the window permanently),
+execute Hyperlambda, list endpoints, crudify, SQL. Stdlib urllib only
+(house style — no httpx dep). The connection persists as a DATA_DIR
+dotfile with atomic replace; only a user:•••last4 fingerprint ever
+leaves the server.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+
+from prism_service import config
+
+CONN_PATH = config.DATA_DIR / ".magic-connection.json"
+
+_TIMEOUT = 15
+
+
+class MagicError(Exception):
+    """Typed failure from the Magic backend (network or HTTP)."""
+
+    def __init__(self, message: str, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+# --- HTTP core (stdlib, no httpx) ----------------------------------------
+
+
+def _base(url: str) -> str:
+    return url.rstrip("/")
+
+
+def _request(url: str, method: str = "GET", token: str | None = None,
+             payload: dict | None = None):
+    headers = {"Accept": "application/json", "User-Agent": "prism-service"}
+    data = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+        headers["Content-Type"] = "application/json"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=_TIMEOUT) as r:
+            raw = r.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace") if e.fp else ""
+        raise MagicError(f"magic http {e.code}: {body[:200]}", status=e.code) from e
+    except urllib.error.URLError as e:
+        raise MagicError(f"magic network error: {e.reason}") from e
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise MagicError(f"magic returned non-json: {raw[:200]}") from e
+
+
+# --- auth ------------------------------------------------------------------
+
+
+def authenticate(url: str, user: str, password: str) -> str:
+    """GET magic/system/auth/authenticate → JWT ticket."""
+    q = urllib.parse.urlencode({"username": user, "password": password})
+    out = _request(f"{_base(url)}/magic/system/auth/authenticate?{q}")
+    ticket = out.get("ticket") if isinstance(out, dict) else None
+    if not ticket:
+        raise MagicError("magic authenticate returned no ticket")
+    return ticket
+
+
+def verify_ticket(url: str, token: str) -> bool:
+    try:
+        _request(f"{_base(url)}/magic/system/auth/verify-ticket", token=token)
+        return True
+    except MagicError:
+        return False
+
+
+# --- connection store (dotfile + env overrides) -----------------------------
+
+
+def load_connection() -> dict | None:
+    env_url = os.environ.get("PRISM_MAGIC_URL", "")
+    if env_url:
+        return {"url": _base(env_url),
+                "user": os.environ.get("PRISM_MAGIC_USER", "root"),
+                "password": os.environ.get("PRISM_MAGIC_PASSWORD", "")}
+    if not CONN_PATH.is_file():
+        return None
+    try:
+        return json.loads(CONN_PATH.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def save_connection(url: str, user: str, password: str) -> None:
+    if not url.strip() or not password.strip():
+        raise ValueError("url and password are required")
+    payload = {"url": _base(url), "user": user or "root", "password": password}
+    tmp = CONN_PATH.with_name(CONN_PATH.name + ".tmp")
+    tmp.write_text(json.dumps(payload), encoding="utf-8")
+    os.replace(tmp, CONN_PATH)
+
+
+def clear_connection() -> bool:
+    try:
+        CONN_PATH.unlink()
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def is_configured() -> bool:
+    return load_connection() is not None
+
+
+def _fingerprint(user: str, password: str) -> str:
+    tail = password[-4:] if len(password) >= 4 else password
+    return f"{user}:•••{tail}"
+
+
+def status() -> dict:
+    conn = load_connection()
+    if not conn:
+        return {"configured": False, "url": "", "user": "", "fingerprint": ""}
+    return {
+        "configured": True,
+        "url": conn.get("url", ""),
+        "user": conn.get("user", ""),
+        "fingerprint": _fingerprint(conn.get("user", ""), conn.get("password", "")),
+    }
+
+
+# --- authenticated admin operations -----------------------------------------
+
+
+def _conn_or_raise() -> dict:
+    conn = load_connection()
+    if not conn:
+        raise MagicError("no Magic connection configured")
+    return conn
+
+
+def _system(path: str, method: str = "GET", payload: dict | None = None):
+    conn = _conn_or_raise()
+    token = authenticate(conn["url"], conn.get("user", "root"),
+                         conn.get("password", ""))
+    url = f"{_base(conn['url'])}/magic/system/{path}"
+    return _request(url, method=method, token=token, payload=payload)
+
+
+def execute(hyperlambda: str):
+    """Run raw Hyperlambda via the root-only evaluator — the headless
+    admin shell."""
+    return _system("evaluator/evaluate", method="POST",
+                   payload={"hyperlambda": hyperlambda})
+
+
+def endpoints():
+    return _system("endpoints/list")
+
+
+def openapi():
+    return _system("endpoints/openapi")
+
+
+def crudify(payload: dict):
+    return _system("crudifier/crudify", method="POST", payload=payload)
+
+
+def sql(payload: dict):
+    return _system("sql/evaluate", method="POST", payload=payload)
+
+
+# --- bootstrap ---------------------------------------------------------------
+
+
+def bootstrap(url: str, password: str, name: str = "", email: str = "") -> dict:
+    """Own the fresh-instance setup window. root/root only authenticates
+    while the backend's auth secret is unset; config/setup generates the
+    real secret and closes that window permanently, so PRISM must be the
+    one to call it. Idempotent: on an already-configured instance the
+    stored credential is verified instead of bricking auth."""
+    base = _base(url)
+    try:
+        boot = authenticate(base, "root", "root")
+    except MagicError:
+        conn = load_connection()
+        if conn and conn.get("url") == base:
+            authenticate(base, conn.get("user", "root"), conn.get("password", ""))
+            return {"configured": True, "already_configured": True}
+        raise
+    _request(f"{base}/magic/system/config/setup", method="POST", token=boot,
+             payload={"username": "root", "password": password,
+                      "name": name, "email": email, "subscribe": False})
+    save_connection(base, "root", password)
+    return {"configured": True, "already_configured": False}

--- a/services/prism-service/prism_service/services/magic_client.py
+++ b/services/prism-service/prism_service/services/magic_client.py
@@ -61,8 +61,11 @@ def _request(url: str, method: str = "GET", token: str | None = None,
         return {}
     try:
         return json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise MagicError(f"magic returned non-json: {raw[:200]}") from e
+    except json.JSONDecodeError:
+        # The evaluator (and other Hyperlambda endpoints) legitimately
+        # return raw Hyperlambda text — caught against the real v22
+        # backend, invisible to mocks. Non-JSON is a result, not an error.
+        return {"result": raw}
 
 
 # --- auth ------------------------------------------------------------------

--- a/services/prism-service/prism_service/services/magic_interview.py
+++ b/services/prism-service/prism_service/services/magic_interview.py
@@ -177,3 +177,53 @@ def record_facts(project: str, facts: list[dict], data_dir=None) -> str:
         lines.append(f"- {f['text']}")
     p.write_text("\n".join(lines), encoding="utf-8")
     return str(p)
+
+
+def finalize_build(project: str, spec: dict, data_dir=None,
+                   facts: list | None = None) -> dict:
+    """READY -> a real customer app. Renders + deploys the Magic backend,
+    writes the generated Hyperlambda + business facts as the project SOURCE,
+    registers the project's source_path, and ingests the code into the project
+    BRAIN — so the customer sees their code, brain and understand as one system.
+    """
+    from pathlib import Path
+    from prism_service import config
+    from prism_service.services import magic_app_builder as ab
+    dd = Path(data_dir) if data_dir is not None else Path(config.DATA_DIR)
+    src = dd / "projects" / project / "magic_app"
+    src.mkdir(parents=True, exist_ok=True)
+    if facts:  # business knowledge lands with the code so the brain learns it
+        (src / "business-facts.md").write_text(
+            "# Business knowledge\n\n"
+            + "\n".join(f"- {f['text']}" for f in facts), encoding="utf-8")
+    # 1. the generated code (their CODE artifact)
+    app = ab.render_app(spec)
+    for path, content in app["files"].items():
+        (src / Path(path).name).write_text(content, encoding="utf-8")
+    (src / "_schema.hl").write_text(app["schema"], encoding="utf-8")
+    # 2. deploy to the live Magic tenant
+    ab.deploy_app(spec)
+    # 3. register the project source (so /understand shows it)
+    try:
+        from prism_service.services import source_service as ss
+        ss.set_source_path(project, str(src))
+    except Exception:
+        pass
+    # 4. ingest into the project brain (their BRAIN + understand artifact)
+    docs = 0
+    try:
+        from prism_service.engines.brain_engine import Brain
+        base = dd / "projects" / project
+        brain = Brain(brain_db=str(base / "brain.db"),
+                      graph_db=str(base / "graph.db"),
+                      scores_db=str(base / "scores.db"))
+        docs = brain.ingest([str(src)])
+    except Exception:
+        pass
+    mod = spec.get("module", project)
+    endpoints = []
+    for e in spec.get("entities", []) or []:
+        endpoints += [f"GET magic/modules/{mod}/{e['name']}",
+                      f"POST magic/modules/{mod}/{e['name']}"]
+    return {"project": project, "module": mod, "endpoints": endpoints,
+            "source": str(src), "brain_docs": docs}

--- a/services/prism-service/prism_service/services/magic_interview.py
+++ b/services/prism-service/prism_service/services/magic_interview.py
@@ -1,0 +1,105 @@
+"""Reverse-engineering interview — a deterministic state machine.
+
+The small model is stochastic; the interview must not be. SpecInterview
+drives ask -> answer -> refine -> re-check until the spec is STABLE and
+COMPLETE, so we get consistent results regardless of SLM wobble and never
+build on a half-baked spec. Its state is serializable, so a customer's
+interview lives in PRISM's memory/context and can be paused and resumed.
+
+States:
+  clarifying — gaps remain (blocking first); the SLM voices the questions.
+  ready      — no blocking gaps AND the spec has converged; safe to build.
+  exhausted  — hit the round cap with a blocking gap still open; escalate.
+"""
+
+from __future__ import annotations
+
+import json
+
+from prism_service.services import magic_app_builder as ab
+from prism_service.services import magic_spec_gaps as gaps
+
+CLARIFYING, READY, EXHAUSTED = "clarifying", "ready", "exhausted"
+
+
+def _fingerprint(spec: dict) -> str:
+    """Stable signature of the spec's shape — entities, fields, rules —
+    used to detect convergence (the spec stopped changing)."""
+    ents = []
+    for e in sorted(spec.get("entities", []) or [], key=lambda x: x.get("name", "")):
+        fields = sorted((f.get("name", ""), (f.get("type") or "").upper())
+                        for f in e.get("fields", []) or [])
+        rules = sorted((r.get("type", ""), r.get("field", ""),
+                        r.get("ref", ""), tuple(sorted(r.get("values", []))))
+                       for r in e.get("rules", []) or [])
+        ents.append((e.get("name", ""), tuple(fields), tuple(rules)))
+    return json.dumps(ents, sort_keys=True)
+
+
+class SpecInterview:
+    """Deterministic controller for the reverse-engineering interview."""
+
+    def __init__(self, spec: dict, max_rounds: int = 6):
+        self.spec = ab.normalize_spec(spec)
+        self.max_rounds = max_rounds
+        self.round = 0
+        self.answered: list[dict] = []
+        self._prev_fp: str | None = None
+        self.state, self.pending = self._evaluate()
+
+    def _evaluate(self):
+        chk = gaps.check_spec(self.spec)
+        fp = _fingerprint(self.spec)
+        converged = self._prev_fp is not None and self._prev_fp == fp
+        if chk["blocking"]:
+            state = EXHAUSTED if self.round >= self.max_rounds else CLARIFYING
+            return state, chk["blocking"]
+        if chk["clarifying"] and not converged and self.round < self.max_rounds:
+            return CLARIFYING, chk["clarifying"]
+        return READY, []
+
+    # --- interview surface -------------------------------------------------
+    def questions(self) -> list[str]:
+        return [g["question"] for g in self.pending]
+
+    def domain(self):
+        return gaps.match_domain(self.spec)
+
+    def answer(self, qa_pairs: list[dict], refine) -> str:
+        """Fold the customer's answers in, refine the spec (SLM-backed
+        `refine(spec, answered) -> new_spec`), re-check, advance. Returns the
+        new state."""
+        if self.state in (READY, EXHAUSTED):
+            return self.state
+        self.answered.extend(qa_pairs)
+        self._prev_fp = _fingerprint(self.spec)
+        self.spec = ab.normalize_spec(refine(self.spec, self.answered))
+        self.round += 1
+        self.state, self.pending = self._evaluate()
+        return self.state
+
+    # --- persistence (lives in PRISM memory/context) -----------------------
+    def to_dict(self) -> dict:
+        return {"spec": self.spec, "max_rounds": self.max_rounds,
+                "round": self.round, "answered": self.answered,
+                "prev_fp": self._prev_fp, "state": self.state,
+                "pending": self.pending}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SpecInterview":
+        obj = cls.__new__(cls)
+        obj.spec = d["spec"]; obj.max_rounds = d.get("max_rounds", 6)
+        obj.round = d.get("round", 0); obj.answered = d.get("answered", [])
+        obj._prev_fp = d.get("prev_fp")
+        obj.state = d.get("state"); obj.pending = d.get("pending", [])
+        return obj
+
+
+def run(spec: dict, refine, answer_provider, max_rounds: int = 6) -> SpecInterview:
+    """Auto-run the interview to a terminal state (ready/exhausted). Used for
+    automation + tests. answer_provider(questions) -> list[{question,answer}]."""
+    iv = SpecInterview(spec, max_rounds)
+    while iv.state == CLARIFYING:
+        qa = answer_provider(iv.questions())
+        iv.answer(qa, refine)
+    return iv

--- a/services/prism-service/prism_service/services/magic_interview.py
+++ b/services/prism-service/prism_service/services/magic_interview.py
@@ -103,3 +103,77 @@ def run(spec: dict, refine, answer_provider, max_rounds: int = 6) -> SpecIntervi
         qa = answer_provider(iv.questions())
         iv.answer(qa, refine)
     return iv
+
+
+# --- persistence: the interview lives in PRISM's per-project memory ----------
+
+def session_path(project: str, data_dir=None):
+    """Where a customer project's interview session is stored."""
+    from prism_service import config
+    base = data_dir if data_dir is not None else config.DATA_DIR
+    from pathlib import Path
+    return Path(base) / "projects" / project / ".interview.json"
+
+
+def save_session(project: str, session: dict, data_dir=None) -> None:
+    """Persist a serialized interview so it survives restarts + visits."""
+    p = session_path(project, data_dir)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_name(p.name + ".tmp")
+    tmp.write_text(json.dumps(session), encoding="utf-8")
+    import os
+    os.replace(tmp, p)
+
+
+def load_session(project: str, data_dir=None) -> dict | None:
+    """Load a customer's saved interview, or None if they haven't started."""
+    p = session_path(project, data_dir)
+    if not p.is_file():
+        return None
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+
+
+def clear_session(project: str, data_dir=None) -> bool:
+    try:
+        session_path(project, data_dir).unlink()
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def business_facts(iv: "SpecInterview") -> list[dict]:
+    """The durable knowledge PRISM keeps about THIS customer's business, once
+    the interview is READY: the domain, the entities/rules they confirmed, and
+    every Q&A. Recorded as memories so PRISM's brain becomes their expert."""
+    facts: list[dict] = []
+    dom = iv.domain()
+    if dom:
+        facts.append({"name": f"domain-{dom}",
+                      "text": f"This customer's business is a {dom}."})
+    for e in iv.spec.get("entities", []) or []:
+        fields = ", ".join(f.get("name", "") for f in e.get("fields", []) or [])
+        rules = "; ".join(f"{r.get('type')}({r.get('field')})"
+                          for r in e.get("rules", []) or [])
+        facts.append({"name": f"entity-{e.get('name')}",
+                      "text": f"Tracks {e.get('name')} with fields: {fields}."
+                              + (f" Rules: {rules}." if rules else "")})
+    for qa in iv.answered:
+        facts.append({"name": "clarification",
+                      "text": f"Q: {qa.get('question')} A: {qa.get('answer')}"})
+    return facts
+
+
+def record_facts(project: str, facts: list[dict], data_dir=None) -> str:
+    """Write the customer's confirmed business facts as a durable markdown
+    memory under the project, so PRISM's brain ingests it and stays their
+    expert. Returns the path written."""
+    p = session_path(project, data_dir).with_name("business-facts.md")
+    p.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"# Business knowledge — {project}", ""]
+    for f in facts:
+        lines.append(f"- {f['text']}")
+    p.write_text("\n".join(lines), encoding="utf-8")
+    return str(p)

--- a/services/prism-service/prism_service/services/magic_spec_gaps.py
+++ b/services/prism-service/prism_service/services/magic_spec_gaps.py
@@ -35,7 +35,12 @@ def _singular(name: str) -> str:
 def find_gaps(spec: dict) -> list[dict]:
     """Return the ordered list of gaps in a PI-produced spec — structural
     first (blocking), then confidence/clarifying. Each gap carries a
-    plain question for the SLM to voice."""
+    plain question for the SLM to voice. The spec is canonicalized first
+    (names lowercased, malformed/placeholder rules dropped) so a small
+    model's wobble never produces a garbage question."""
+    import copy
+    from prism_service.services.magic_app_builder import normalize_spec
+    spec = normalize_spec(copy.deepcopy(spec))
     gaps: list[dict] = []
     entities = spec.get("entities", []) or []
     if not entities:
@@ -94,9 +99,116 @@ def is_complete(spec: dict) -> bool:
     return not any(g["blocking"] for g in find_gaps(spec))
 
 
-def check_spec(spec: dict) -> dict:
-    gaps = find_gaps(spec)
+def check_spec(spec: dict, archetypes=None) -> dict:
+    """Full completeness check: structural gaps (deterministic) + learned
+    gaps (domain-aware). `complete` is False while a blocking gap remains;
+    clarifying gaps sharpen the build but don't block."""
+    arch = archetypes if archetypes is not None else ARCHETYPES
+    gaps = find_gaps(spec) + learned_gaps(spec, arch)
     return {"complete": not any(g["blocking"] for g in gaps),
+            "domain": match_domain(spec, arch),
             "blocking": [g for g in gaps if g["blocking"]],
             "clarifying": [g for g in gaps if not g["blocking"]],
             "questions": [g["question"] for g in gaps]}
+
+
+# --- learned layer: what apps of THIS business type usually need -------------
+# Seed archetypes; the self-learning hook (learn_from_spec) grows them from
+# real completed builds so the questions get sharper over time.
+ARCHETYPES = {
+    "clinic": {
+        "signals": {"patient", "appointment", "doctor", "visit", "clinic",
+                    "medical", "prescription"},
+        "entities": {"patients": ["name", "phone", "email"],
+                     "appointments": ["patient_id", "date", "status"],
+                     "billing": ["appointment_id", "amount", "paid"]},
+    },
+    "shop": {
+        "signals": {"product", "order", "customer", "cart", "item", "shop",
+                    "store", "supplier", "inventory"},
+        "entities": {"customers": ["name", "email"],
+                     "products": ["name", "price", "stock"],
+                     "orders": ["customer_id", "total", "status"],
+                     "order_items": ["order_id", "product_id", "qty"]},
+    },
+    "crm": {
+        "signals": {"lead", "deal", "contact", "company", "pipeline", "crm",
+                    "opportunity"},
+        "entities": {"contacts": ["name", "email", "company"],
+                     "deals": ["contact_id", "amount", "stage"]},
+    },
+}
+
+
+def _tokens(spec: dict) -> set:
+    toks = set()
+    for e in spec.get("entities", []) or []:
+        toks.add((e.get("name") or "").lower().rstrip("s"))
+        for f in e.get("fields", []) or []:
+            toks.add((f.get("name") or "").lower())
+    return toks
+
+
+def match_domain(spec: dict, archetypes=ARCHETYPES):
+    """Best-matching business archetype by signal overlap, or None."""
+    toks = _tokens(spec)
+    best, score = None, 0
+    for dom, a in archetypes.items():
+        s = sum(1 for sig in a["signals"] if sig in toks or sig + "s" in toks)
+        if s > score:
+            best, score = dom, s
+    return best if score >= 1 else None
+
+
+def learned_gaps(spec: dict, archetypes=ARCHETYPES) -> list[dict]:
+    """Domain-aware gaps: given the matched business type, flag typical-but-
+    missing entities/fields as clarifying questions ('Clinics usually also
+    track billing — do you need that?'). This is the brain asking the RIGHT
+    questions — the thing a generic model can't do without accumulated context."""
+    dom = match_domain(spec, archetypes)
+    if not dom:
+        return []
+    a = archetypes[dom]
+    present = {(e.get("name") or "").lower().rstrip("s")
+               for e in spec.get("entities", []) or []}
+    out: list[dict] = []
+    for ent, typ_fields in a["entities"].items():
+        key = ent.rstrip("s")
+        if key not in present:
+            out.append(_gap("learned_entity", ent, None,
+                            f"{dom} apps usually track '{ent}', which is missing.",
+                            f"{dom.capitalize()} businesses usually also track "
+                            f"{ent} — do you need that?"))
+        else:
+            e = next((x for x in spec["entities"]
+                      if (x.get("name") or "").lower().rstrip("s") == key), None)
+            have = {(f.get("name") or "").lower() for f in (e.get("fields", []) if e else [])}
+            for tf in typ_fields:
+                if tf.lower() not in have and not tf.endswith("_id"):
+                    out.append(_gap("learned_field", ent, tf,
+                                    f"{ent} usually records '{tf}'.",
+                                    f"Should a {_singular(ent)} also record its "
+                                    f"{tf}?"))
+    return out[:6]
+
+
+def learn_from_spec(spec: dict, archetypes=ARCHETYPES, domain=None) -> str | None:
+    """Self-learning hook: fold a COMPLETED build's entities/fields into the
+    matched archetype so future asks of this business type get sharper
+    questions. Returns the domain it enriched (or None)."""
+    dom = domain or match_domain(spec, archetypes)
+    if not dom or dom not in archetypes:
+        return None
+    ents = archetypes[dom]["entities"]
+    for e in spec.get("entities", []) or []:
+        name = (e.get("name") or "").lower()
+        if not name:
+            continue
+        fields = [(f.get("name") or "").lower() for f in e.get("fields", []) or []]
+        if name in ents:
+            for fn in fields:
+                if fn and fn not in ents[name]:
+                    ents[name].append(fn)
+        else:
+            ents[name] = [f for f in fields if f]
+    return dom

--- a/services/prism-service/prism_service/services/magic_spec_gaps.py
+++ b/services/prism-service/prism_service/services/magic_spec_gaps.py
@@ -1,0 +1,102 @@
+"""Completeness / confidence checker — the brain-side gap detector.
+
+Customers never arrive with a complete ruleset. PRISM's job (the middle)
+is to know what a buildable app definition needs, find what's missing or
+ambiguous in the PI-produced spec, and emit a structured list of GAPS —
+each carrying a plain follow-up question the SLM voices on the PI screen.
+
+Detection is PRISM's intelligence (deterministic structural checks now, a
+brain-learned layer later); phrasing the question is the SLM's job. No
+extra inference layer: the same front-door model just voices what PRISM
+decides to ask.
+"""
+
+from __future__ import annotations
+
+# field-name hints (heuristics the learned layer will later refine)
+_ENUM_HINTS = {"status", "state", "type", "kind", "stage", "priority", "role"}
+_MIN_HINTS = {"price", "amount", "total", "cost", "qty", "quantity",
+              "stock", "balance", "salary", "fee", "rate", "count", "age"}
+
+# gaps that BLOCK a build vs ones that merely sharpen it
+_BLOCKING = {"no_entities", "empty_entity", "orphan_fk"}
+
+
+def _gap(kind, entity, field, detail, question):
+    return {"kind": kind, "entity": entity, "field": field,
+            "detail": detail, "question": question,
+            "blocking": kind in _BLOCKING}
+
+
+def _singular(name: str) -> str:
+    return name[:-1] if name.endswith("s") and len(name) > 3 else name
+
+
+def find_gaps(spec: dict) -> list[dict]:
+    """Return the ordered list of gaps in a PI-produced spec — structural
+    first (blocking), then confidence/clarifying. Each gap carries a
+    plain question for the SLM to voice."""
+    gaps: list[dict] = []
+    entities = spec.get("entities", []) or []
+    if not entities:
+        return [_gap("no_entities", None, None, "No entities defined yet.",
+                     "What does your business need to keep track of? "
+                     "(for example: customers, orders, appointments)")]
+    names = {e.get("name", "") for e in entities}
+    for e in entities:
+        en = e.get("name", "")
+        fields = e.get("fields", []) or []
+        rules = e.get("rules", []) or []
+        fk_fields = {r.get("field") for r in rules if r.get("type") == "fk"}
+        enum_fields = {r.get("field") for r in rules if r.get("type") == "enum"}
+        min_fields = {r.get("field") for r in rules if r.get("type") == "min"}
+        if not fields:
+            gaps.append(_gap("empty_entity", en, None,
+                             f"'{en}' has no fields.",
+                             f"What details should each {_singular(en)} record hold?"))
+        for r in rules:
+            if r.get("type") == "fk" and r.get("ref") not in names:
+                ref = r.get("ref")
+                gaps.append(_gap("orphan_fk", en, r.get("field"),
+                                 f"'{en}.{r.get('field')}' references '{ref}', "
+                                 "which isn't defined.",
+                                 f"You linked {en} to {ref}, but there's no {ref} "
+                                 f"yet — should I create a {ref} table, or did you "
+                                 "mean something else?"))
+        for f in fields:
+            fn = f.get("name", "")
+            ft = (f.get("type") or "").upper()
+            low = fn.lower()
+            if fn.endswith("_id") and fn not in fk_fields:
+                target = fn[:-3]
+                gaps.append(_gap("unlinked_fk", en, fn,
+                                 f"'{en}.{fn}' looks like a reference with no target.",
+                                 f"Should {en}.{fn} always point to an existing "
+                                 f"{target}?"))
+            if low in _ENUM_HINTS and ft == "TEXT" and fn not in enum_fields:
+                gaps.append(_gap("missing_enum", en, fn,
+                                 f"'{en}.{fn}' has no allowed values.",
+                                 f"What values can a {_singular(en)}'s {fn} be? "
+                                 "(for example: new, paid, shipped)"))
+            if any(h == low or h in low for h in _MIN_HINTS) and \
+                    ft in ("REAL", "INTEGER") and fn not in min_fields:
+                gaps.append(_gap("maybe_min", en, fn,
+                                 f"'{en}.{fn}' has no bound.",
+                                 f"Can {en}.{fn} be negative, or should it be at "
+                                 "least 0?"))
+    # blocking gaps first
+    gaps.sort(key=lambda g: (not g["blocking"],))
+    return gaps
+
+
+def is_complete(spec: dict) -> bool:
+    """True when no BLOCKING gap remains (clarifying gaps may still exist)."""
+    return not any(g["blocking"] for g in find_gaps(spec))
+
+
+def check_spec(spec: dict) -> dict:
+    gaps = find_gaps(spec)
+    return {"complete": not any(g["blocking"] for g in gaps),
+            "blocking": [g for g in gaps if g["blocking"]],
+            "clarifying": [g for g in gaps if not g["blocking"]],
+            "questions": [g["question"] for g in gaps]}

--- a/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/SettingsPage.tsx
@@ -215,6 +215,10 @@ export default function SettingsPage() {
             <SectionLabel>Claude source</SectionLabel>
             <ClaudeSourceCard project={active} />
           </Card>
+          <Card>
+            <SectionLabel>Magic backend</SectionLabel>
+            <MagicConnectionCard />
+          </Card>
         </div>
       )}
 
@@ -3119,5 +3123,129 @@ function ProjectEditor({
         />
       )}
     </form>
+  );
+}
+
+type MagicStatus = {
+  configured: boolean;
+  url: string;
+  user: string;
+  fingerprint: string;
+};
+
+function MagicConnectionCard() {
+  const [status, setStatus] = useState<MagicStatus | null>(null);
+  const [url, setUrl] = useState("");
+  const [user, setUser] = useState("root");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  const load = useCallback(() => {
+    api.get<MagicStatus>("/api/magic/status")
+      .then(setStatus)
+      .catch(() => setStatus(null));
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  if (!status) {
+    return <div className="text-sm opacity-60">Loading…</div>;
+  }
+
+  const clear = async () => {
+    setBusy(true);
+    try {
+      await api.post<MagicStatus>("/api/magic/clear", {});
+      load();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (status.configured) {
+    return (
+      <div className="space-y-2">
+        <div className="inline-flex items-center gap-2 text-sm">
+          <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-emerald-500/15 text-emerald-200 text-[9px] uppercase tracking-wider">
+            connected
+          </span>
+          <span className="opacity-70 font-mono text-xs">{status.url}</span>
+        </div>
+        <div className="text-[11px] opacity-50 font-mono">
+          credential → {status.fingerprint}
+        </div>
+        <button
+          type="button"
+          onClick={clear}
+          disabled={busy}
+          className="px-3 py-1.5 rounded-md border border-[color:var(--midground-base)]/30 text-[10px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10 disabled:opacity-40"
+        >
+          Disconnect
+        </button>
+      </div>
+    );
+  }
+
+  const connect = async () => {
+    setBusy(true);
+    setError("");
+    try {
+      await api.post<MagicStatus>("/api/magic/configure", { url, user, password });
+      setPassword("");
+      load();
+    } catch (e: any) {
+      setError(String(e?.message ?? e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const inputCls =
+    "w-full px-3 py-2 rounded-md bg-[color:var(--midground-base)]/[0.04] " +
+    "border border-[color:var(--midground-base)]/15 text-xs font-mono " +
+    "focus:outline-none focus:border-[color:var(--midground-base)]/40";
+
+  return (
+    <div className="space-y-3">
+      <div className="inline-flex items-center gap-2 text-sm">
+        <span className="inline-flex items-center px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-200 text-[9px] uppercase tracking-wider">
+          not connected
+        </span>
+        <span className="opacity-70">
+          Point PRISM at a headless Magic backend. Credentials stay on the
+          server — only a fingerprint is shown here.
+        </span>
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
+        <input
+          className={inputCls}
+          placeholder="http://localhost:4444"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <input
+          className={inputCls}
+          placeholder="root"
+          value={user}
+          onChange={(e) => setUser(e.target.value)}
+        />
+        <input
+          className={inputCls}
+          type="password"
+          placeholder="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      {error && <div className="text-[11px] text-red-300">{error}</div>}
+      <button
+        type="button"
+        onClick={connect}
+        disabled={busy || !url.trim() || !password.trim()}
+        className="px-3 py-1.5 rounded-md border border-[color:var(--midground-base)]/30 text-[10px] uppercase tracking-wider hover:bg-[color:var(--midground-base)]/10 disabled:opacity-40"
+      >
+        {busy ? "Connecting…" : "Connect"}
+      </button>
+    </div>
   );
 }

--- a/services/prism-service/tests/unit/test_magic_ai.py
+++ b/services/prism-service/tests/unit/test_magic_ai.py
@@ -1,0 +1,94 @@
+"""Tests for the OpenAI-free Magic AI substrate (services/magic_ai).
+
+PRISM is the memory substrate (retrieve) + a local OpenAI-wire model
+(complete). The invariant these tests pin: no OpenAI, no Anthropic —
+generation runs entirely on injected local pieces.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prism_service.services import magic_ai as ai
+
+
+def test_ai_generate_uses_context_and_is_openai_free():
+    seen = {}
+
+    def retrieve(q, k=5):
+        seen["query"] = q
+        return ["snippet A", "snippet B"]
+
+    def complete(messages):
+        seen["messages"] = messages
+        return "GENERATED", {"total_tokens": 42}
+
+    out = ai.ai_generate("build a list endpoint", retrieve, complete=complete)
+    assert out["answer"] == "GENERATED"
+    assert out["context_used"] == 2
+    assert out["local_tokens"] == 42
+    assert out["openai_tokens"] == 0 and out["anthropic_tokens"] == 0
+    # context actually reached the model
+    user = seen["messages"][-1]["content"]
+    assert "snippet A" in user and "snippet B" in user
+    assert "build a list endpoint" in user
+
+
+def test_ai_generate_with_no_context():
+    out = ai.ai_generate("hi", lambda q, k=5: [],
+                         complete=lambda m: ("ok", {}))
+    assert out["context_used"] == 0
+    assert out["openai_tokens"] == 0
+
+
+def test_make_brain_retriever_extracts_text_fields():
+    def brain_search(q, limit):
+        return [{"text": "T1"}, {"snippet": "S2"},
+                {"description": "D3"}, "raw4"]
+
+    retrieve = ai.make_brain_retriever(brain_search)
+    got = retrieve("q", 5)
+    assert got == ["T1", "S2", "D3", "raw4"]
+
+
+def test_local_complete_parses_openai_shape(monkeypatch):
+    import urllib.request
+
+    class _R:
+        def __init__(self, payload):
+            self._b = json.dumps(payload).encode()
+        def read(self):
+            return self._b
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        return _R({"choices": [{"message": {"content": "hello"}}],
+                   "usage": {"total_tokens": 7}})
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    text, usage = ai.local_complete([{"role": "user", "content": "hi"}])
+    assert text == "hello" and usage["total_tokens"] == 7
+    # hits the OpenAI-compatible path, never api.openai.com
+    assert "/chat/completions" in captured["url"]
+    assert "openai.com" not in captured["url"]
+
+
+def test_local_complete_maps_http_error(monkeypatch):
+    import urllib.error
+    import urllib.request
+
+    def boom(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 500, "err", None, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    with pytest.raises(ai.LocalLLMError):
+        ai.local_complete([{"role": "user", "content": "hi"}])

--- a/services/prism-service/tests/unit/test_magic_ai.py
+++ b/services/prism-service/tests/unit/test_magic_ai.py
@@ -92,3 +92,47 @@ def test_local_complete_maps_http_error(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen", boom)
     with pytest.raises(ai.LocalLLMError):
         ai.local_complete([{"role": "user", "content": "hi"}])
+
+
+def test_generate_verified_repairs_until_ok():
+    from prism_service.services import magic_ai as ai
+    attempts = {"n": 0}
+
+    def complete(messages):
+        attempts["n"] += 1
+        # first try bad, second try good (4-space indent -> normalized)
+        if attempts["n"] == 1:
+            return "```hl\nsqlite.connect:db\n  bad\n```", {"total_tokens": 10}
+        return "```hl\nsqlite.connect:db\n    sqlite.select:SELECT 1\n```", {"total_tokens": 12}
+
+    def verify(hl):
+        # accept once the select is present
+        return ("sqlite.select" in hl, "needs a select")
+
+    out = ai.generate_verified("build it", lambda q, k=5: ["ctx"],
+                               verify=verify, complete=complete, max_rounds=3)
+    assert out["ok"] is True
+    assert out["rounds"] == 2
+    assert out["openai_tokens"] == 0 and out["anthropic_tokens"] == 0
+    # normalized to 3-space multiples
+    assert all((len(l) - len(l.lstrip())) % 3 == 0
+               for l in out["hyperlambda"].splitlines() if l.strip())
+
+
+def test_liberate_training_corpus_writes_and_ingests(tmp_path):
+    from prism_service.services import magic_ai as ai
+    snippets = [{"prompt": "P1", "completion": "C1"},
+                {"prompt": "P2", "completion": "C2", "type": "hl"}]
+    ingested = {}
+
+    def ingest(paths):
+        ingested["paths"] = paths
+        return 2
+
+    out = ai.liberate_training_corpus(lambda: snippets,
+                                      str(tmp_path / "corpus"), ingest)
+    assert out["snippets"] == 2 and out["docs_indexed"] == 2
+    assert out["openai_tokens"] == 0
+    files = list((tmp_path / "corpus").glob("*.md"))
+    assert len(files) == 2
+    assert "P1" in files[0].read_text() or "P1" in files[1].read_text()

--- a/services/prism-service/tests/unit/test_magic_api.py
+++ b/services/prism-service/tests/unit/test_magic_api.py
@@ -34,8 +34,15 @@ def client(tmp_path: Path, monkeypatch):
 
 
 def test_registered_on_shared_api_router():
+    # Probe via the OpenAPI schema — FastAPI >= 0.138 defers
+    # include_router() into _IncludedRouter objects with no .path, so
+    # the schema is the version-agnostic "actually mounted" contract
+    # (same idiom as test_api_agent_runs).
+    from fastapi import FastAPI
     from prism_service.api import api_router
-    paths = {getattr(r, "path", "") for r in api_router.routes}
+    app = FastAPI()
+    app.include_router(api_router)
+    paths = set(app.openapi()["paths"].keys())
     assert "/api/magic/status" in paths
 
 

--- a/services/prism-service/tests/unit/test_magic_api.py
+++ b/services/prism-service/tests/unit/test_magic_api.py
@@ -1,0 +1,133 @@
+"""RED suite for the /api/magic router (task 0a5607a4).
+
+Drives the REAL router through a FastAPI TestClient with the
+magic_client service monkeypatched at its seams. Also pins the
+router's registration on the shared api_router and the
+no-secret-in-any-response contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from prism_service import config
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.delenv("PRISM_MAGIC_URL", raising=False)
+    monkeypatch.delenv("PRISM_MAGIC_USER", raising=False)
+    monkeypatch.delenv("PRISM_MAGIC_PASSWORD", raising=False)
+    import importlib
+    from prism_service.services import magic_client as mc_mod
+    importlib.reload(mc_mod)
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from prism_service.api import magic as magic_api
+    app = FastAPI()
+    app.include_router(magic_api.router, prefix="/api/magic")
+    yield TestClient(app)
+    importlib.reload(mc_mod)
+
+
+def test_registered_on_shared_api_router():
+    from prism_service.api import api_router
+    paths = {getattr(r, "path", "") for r in api_router.routes}
+    assert "/api/magic/status" in paths
+
+
+def test_status_unconfigured(client):
+    r = client.get("/api/magic/status")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["configured"] is False
+    assert body["fingerprint"] == ""
+
+
+def test_configure_validates_then_persists(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+    monkeypatch.setattr(mc, "authenticate", lambda url, user, pw: "jwt-ok")
+    r = client.post("/api/magic/configure", json={
+        "url": "http://magic:4444", "user": "root", "password": "supersecret99"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["configured"] is True
+    assert "•••" in body["fingerprint"]
+    assert "supersecret99" not in r.text
+
+
+def test_configure_rejects_bad_credentials(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+
+    def boom(url, user, pw):
+        raise mc.MagicError("magic http 401: bad credentials", status=401)
+
+    monkeypatch.setattr(mc, "authenticate", boom)
+    r = client.post("/api/magic/configure", json={
+        "url": "http://magic:4444", "user": "root", "password": "bad"})
+    assert r.status_code in (400, 502)
+    assert "401" in str(r.json().get("detail", ""))
+
+
+def test_clear_removes_connection(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+    monkeypatch.setattr(mc, "authenticate", lambda *a: "jwt-ok")
+    client.post("/api/magic/configure", json={
+        "url": "http://magic:4444", "user": "root", "password": "pw"})
+    r = client.post("/api/magic/clear")
+    assert r.status_code == 200
+    assert r.json()["configured"] is False
+    assert client.get("/api/magic/status").json()["configured"] is False
+
+
+def test_execute_proxies_to_client(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+    seen = {}
+
+    def fake_execute(hl):
+        seen["hl"] = hl
+        return {"result": "ok!"}
+
+    monkeypatch.setattr(mc, "execute", fake_execute)
+    r = client.post("/api/magic/execute", json={"hyperlambda": 'log.info:"x"'})
+    assert r.status_code == 200
+    assert r.json() == {"result": "ok!"}
+    assert seen["hl"] == 'log.info:"x"'
+
+
+def test_execute_maps_magic_error_to_502(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+
+    def boom(hl):
+        raise mc.MagicError("magic http 500: kaboom", status=500)
+
+    monkeypatch.setattr(mc, "execute", boom)
+    r = client.post("/api/magic/execute", json={"hyperlambda": "x"})
+    assert r.status_code == 502
+
+
+def test_endpoints_proxies(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+    monkeypatch.setattr(mc, "endpoints", lambda: [{"path": "magic/x", "verb": "get"}])
+    r = client.get("/api/magic/endpoints")
+    assert r.status_code == 200
+    assert r.json()[0]["path"] == "magic/x"
+
+
+def test_setup_bootstraps(client, monkeypatch):
+    from prism_service.services import magic_client as mc
+    seen = {}
+
+    def fake_bootstrap(url, password, name="", email=""):
+        seen.update(url=url, password=password)
+        return {"configured": True, "already_configured": False}
+
+    monkeypatch.setattr(mc, "bootstrap", fake_bootstrap)
+    r = client.post("/api/magic/setup", json={
+        "url": "http://magic:4444", "password": "npw", "name": "op", "email": "e@x.io"})
+    assert r.status_code == 200
+    assert r.json()["configured"] is True
+    assert seen == {"url": "http://magic:4444", "password": "npw"}

--- a/services/prism-service/tests/unit/test_magic_app_builder.py
+++ b/services/prism-service/tests/unit/test_magic_app_builder.py
@@ -100,3 +100,16 @@ def test_deploy_calls_execute_for_schema_and_each_file():
     assert len(calls) == 5
     assert any("CREATE TABLE" in c for c in calls)
     assert sum("io.file.save" in c for c in calls) == 4
+
+
+def test_capacity_rule_emits_combined_count_guard():
+    ent = {"name": "registrations", "fields": [
+        {"name": "event_id", "type": "INTEGER"}, {"name": "who", "type": "TEXT"}],
+        "rules": [{"type": "capacity", "field": "event_id", "ref": "events",
+                   "capacity_field": "capacity"}]}
+    hl = ab.render_add_endpoint(ent, "d")
+    # one combined SELECT rejects both missing-parent and full-parent
+    assert "capacity > (SELECT COUNT(*) FROM registrations WHERE event_id = @cap)" in hl
+    assert "not" in hl and "exists:x:@sqlite.select/*" in hl
+    assert all((len(l) - len(l.lstrip())) % 3 == 0
+               for l in hl.splitlines() if l.strip())

--- a/services/prism-service/tests/unit/test_magic_app_builder.py
+++ b/services/prism-service/tests/unit/test_magic_app_builder.py
@@ -1,0 +1,102 @@
+"""Tests for the deterministic Magic app renderer (services/magic_app_builder).
+
+The load-bearing guarantee: rendered Hyperlambda indentation is ALWAYS a
+multiple of 3 spaces — this is the whole reason PRISM renders instead of
+letting a small model emit raw Hyperlambda (which trips Magic's
+whitespace-strict parser). Rule idioms (fk/min/enum) are the ones verified
+live against magic-backend v22.10.10.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from prism_service.services import magic_app_builder as ab
+
+SPEC = {
+    "db": "shop", "module": "shop",
+    "entities": [
+        {"name": "customers", "fields": [{"name": "name", "type": "TEXT"}]},
+        {"name": "orders", "fields": [
+            {"name": "customer_id", "type": "INTEGER"},
+            {"name": "total", "type": "REAL"},
+            {"name": "status", "type": "TEXT"}],
+         "rules": [
+            {"type": "fk", "field": "customer_id", "ref": "customers"},
+            {"type": "min", "field": "total", "value": 0},
+            {"type": "enum", "field": "status", "values": ["new", "paid"]}]},
+    ],
+}
+
+
+def _all_indents_multiple_of_3(hl: str) -> bool:
+    for line in hl.splitlines():
+        if not line.strip():
+            continue
+        lead = len(line) - len(line.lstrip(" "))
+        if lead % 3 != 0:
+            return False
+    return True
+
+
+def test_indentation_always_multiple_of_3():
+    # The guarantee the 7B could not meet.
+    app = ab.render_app(SPEC)
+    assert _all_indents_multiple_of_3(app["schema"])
+    for content in app["files"].values():
+        assert _all_indents_multiple_of_3(content), content
+
+
+def test_schema_has_pk_and_tables():
+    ddl = ab.render_schema(SPEC)
+    assert "sqlite.connect:shop" in ddl
+    assert "CREATE TABLE IF NOT EXISTS customers (id INTEGER PRIMARY KEY" in ddl
+    assert "CREATE TABLE IF NOT EXISTS orders (id INTEGER PRIMARY KEY" in ddl
+
+
+def test_fk_rule_emits_not_exists_guard():
+    hl = ab.render_add_endpoint(SPEC["entities"][1], "shop")
+    assert "SELECT id FROM customers WHERE id = @fk" in hl
+    assert "not" in hl and "exists:x:@sqlite.select/*" in hl
+    assert "customer_id must reference an existing customers" in hl
+
+
+def test_min_rule_emits_lt_guard():
+    hl = ab.render_add_endpoint(SPEC["entities"][1], "shop")
+    assert "lt:x:@.arguments/*/total" in hl
+    assert ".:decimal:0" in hl
+
+
+def test_enum_rule_emits_flag_and_checks():
+    hl = ab.render_add_endpoint(SPEC["entities"][1], "shop")
+    assert ".valid_status:bool:false" in hl
+    assert "eq:x:@.arguments/*/status" in hl
+    assert "status must be one of new, paid" in hl
+
+
+def test_list_endpoint_returns_nodes_inside_connect():
+    hl = ab.render_list_endpoint(SPEC["entities"][0], "shop")
+    lines = hl.splitlines()
+    # return-nodes must be indented (inside the connect block) — gotcha #2
+    rn = [l for l in lines if "return-nodes" in l][0]
+    assert rn.startswith("   ")
+
+
+def test_normalize_strips_id_field_and_fk_suffix():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "a", "fields": [{"name": "id", "type": "INTEGER"},
+                                 {"name": "n", "type": "TEXT"}],
+         "rules": [{"type": "fk", "field": "n", "ref": "b.id"}]}]}
+    ab.normalize_spec(spec)
+    names = [f["name"] for f in spec["entities"][0]["fields"]]
+    assert "id" not in names and "n" in names
+    assert spec["entities"][0]["rules"][0]["ref"] == "b"
+
+
+def test_deploy_calls_execute_for_schema_and_each_file():
+    calls = []
+    ab.deploy_app(dict(SPEC), execute=lambda hl: calls.append(hl))
+    # 1 schema + 2 files/entity * 2 entities = 5
+    assert len(calls) == 5
+    assert any("CREATE TABLE" in c for c in calls)
+    assert sum("io.file.save" in c for c in calls) == 4

--- a/services/prism-service/tests/unit/test_magic_client.py
+++ b/services/prism-service/tests/unit/test_magic_client.py
@@ -1,0 +1,202 @@
+"""RED suite for prism_service.services.magic_client (task 0a5607a4).
+
+Pins the HTTP admin channel to a headless Magic backend: request
+shaping (URL join + Bearer header + JSON bodies), typed-error mapping,
+credential dotfile round-trip with fingerprint redaction, env
+overrides, and the two bootstrap paths (fresh instance vs already
+configured). urllib is monkeypatched — no real sockets, so this file
+stays OUT of daemon_exclusive.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+from prism_service import config
+
+
+@pytest.fixture
+def isolated_data_dir(tmp_path: Path, monkeypatch):
+    """Point config.DATA_DIR at a tmp dir and reload magic_client so its
+    CONN_PATH re-resolves (same pattern as test_github_auth)."""
+    monkeypatch.setattr(config, "DATA_DIR", tmp_path)
+    monkeypatch.delenv("PRISM_MAGIC_URL", raising=False)
+    monkeypatch.delenv("PRISM_MAGIC_USER", raising=False)
+    monkeypatch.delenv("PRISM_MAGIC_PASSWORD", raising=False)
+    import importlib
+    from prism_service.services import magic_client as mc_mod
+    importlib.reload(mc_mod)
+    yield tmp_path
+    importlib.reload(mc_mod)
+
+
+class _Resp:
+    def __init__(self, payload):
+        self._raw = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _scripted_urlopen(monkeypatch, script, calls):
+    """Replace urllib.request.urlopen with a scripted fake. Each script
+    entry is either a payload (returned as JSON) or an exception to
+    raise. Requests are recorded into `calls`."""
+    import urllib.request as _ur
+
+    def fake(req, timeout=None):
+        assert timeout is not None, "every call must set an explicit timeout"
+        calls.append(req)
+        action = script.pop(0)
+        if isinstance(action, Exception):
+            raise action
+        return _Resp(action)
+
+    monkeypatch.setattr(_ur, "urlopen", fake)
+
+
+def _http_error(code):
+    return urllib.error.HTTPError("http://x", code, "err", None, None)
+
+
+def _configure_env(monkeypatch):
+    monkeypatch.setenv("PRISM_MAGIC_URL", "http://magic:4444")
+    monkeypatch.setenv("PRISM_MAGIC_USER", "root")
+    monkeypatch.setenv("PRISM_MAGIC_PASSWORD", "secretpw99")
+
+
+# --- authenticate --------------------------------------------------------
+
+
+def test_authenticate_builds_url_and_returns_ticket(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    calls, script = [], [{"ticket": "jwt-abc"}]
+    _scripted_urlopen(monkeypatch, script, calls)
+    ticket = mc.authenticate("http://magic:4444/", "alice", "pw1")
+    assert ticket == "jwt-abc"
+    url = calls[0].full_url
+    assert url.startswith("http://magic:4444/magic/system/auth/authenticate")
+    assert "username=alice" in url and "password=pw1" in url
+
+
+def test_authenticate_http_error_maps_to_typed_error(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    calls, script = [], [_http_error(401)]
+    _scripted_urlopen(monkeypatch, script, calls)
+    with pytest.raises(mc.MagicError) as ei:
+        mc.authenticate("http://magic:4444", "root", "bad")
+    assert ei.value.status == 401
+
+
+# --- authenticated operations --------------------------------------------
+
+
+def test_execute_posts_hyperlambda_with_bearer(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    _configure_env(monkeypatch)
+    calls = []
+    script = [{"ticket": "jwt-1"}, {"result": "howdy"}]
+    _scripted_urlopen(monkeypatch, script, calls)
+    out = mc.execute('log.info:"x"')
+    assert out == {"result": "howdy"}
+    req = calls[1]
+    assert req.full_url.endswith("/magic/system/evaluator/evaluate")
+    assert req.get_method() == "POST"
+    assert req.get_header("Authorization") == "Bearer jwt-1"
+    assert json.loads(req.data.decode()) == {"hyperlambda": 'log.info:"x"'}
+
+
+def test_endpoints_lists_with_bearer(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    _configure_env(monkeypatch)
+    calls = []
+    script = [{"ticket": "jwt-1"}, [{"path": "magic/system/version", "verb": "get"}]]
+    _scripted_urlopen(monkeypatch, script, calls)
+    out = mc.endpoints()
+    assert out[0]["path"] == "magic/system/version"
+    req = calls[1]
+    assert req.full_url.endswith("/magic/system/endpoints/list")
+    assert req.get_header("Authorization") == "Bearer jwt-1"
+
+
+def test_crudify_posts_payload(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    _configure_env(monkeypatch)
+    calls = []
+    script = [{"ticket": "jwt-1"}, {"result": "success"}]
+    _scripted_urlopen(monkeypatch, script, calls)
+    payload = {"databaseType": "sqlite", "database": "crm", "table": "customers"}
+    out = mc.crudify(payload)
+    assert out == {"result": "success"}
+    req = calls[1]
+    assert req.full_url.endswith("/magic/system/crudifier/crudify")
+    assert json.loads(req.data.decode()) == payload
+
+
+# --- connection store -----------------------------------------------------
+
+
+def test_connection_roundtrip_and_fingerprint(isolated_data_dir):
+    from prism_service.services import magic_client as mc
+    assert mc.load_connection() is None
+    mc.save_connection("http://magic:4444", "root", "secretpw99")
+    conn = mc.load_connection()
+    assert conn["url"] == "http://magic:4444"
+    assert conn["password"] == "secretpw99"
+    st = mc.status()
+    assert st["configured"] is True
+    assert "•••" in st["fingerprint"] and "pw99" in st["fingerprint"]
+    assert "secretpw99" not in json.dumps(st)
+    assert not list(isolated_data_dir.glob("*.tmp"))
+    assert mc.clear_connection() is True
+    assert mc.load_connection() is None
+
+
+def test_env_overrides_beat_dotfile(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    mc.save_connection("http://file:1", "fileuser", "filepw")
+    _configure_env(monkeypatch)
+    conn = mc.load_connection()
+    assert conn["url"] == "http://magic:4444"
+    assert conn["user"] == "root"
+
+
+# --- bootstrap --------------------------------------------------------------
+
+
+def test_bootstrap_fresh_instance_runs_setup(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    calls = []
+    script = [{"ticket": "boot-jwt"}, {"ticket": "real-jwt"}]
+    _scripted_urlopen(monkeypatch, script, calls)
+    out = mc.bootstrap("http://magic:4444", "newpw1234", name="op", email="op@x.io")
+    assert out["configured"] is True and out["already_configured"] is False
+    setup = calls[1]
+    assert setup.full_url.endswith("/magic/system/config/setup")
+    body = json.loads(setup.data.decode())
+    assert body["password"] == "newpw1234"
+    assert body.get("subscribe") in (False, None)
+    assert setup.get_header("Authorization") == "Bearer boot-jwt"
+    conn = mc.load_connection()
+    assert conn["password"] == "newpw1234" and conn["user"] == "root"
+
+
+def test_bootstrap_already_configured_uses_stored_credential(isolated_data_dir, monkeypatch):
+    from prism_service.services import magic_client as mc
+    mc.save_connection("http://magic:4444", "root", "storedpw")
+    calls = []
+    script = [_http_error(401), {"ticket": "jwt-stored"}]
+    _scripted_urlopen(monkeypatch, script, calls)
+    out = mc.bootstrap("http://magic:4444", "whatever")
+    assert out["already_configured"] is True
+    assert all("config/setup" not in c.full_url for c in calls)

--- a/services/prism-service/tests/unit/test_magic_interview.py
+++ b/services/prism-service/tests/unit/test_magic_interview.py
@@ -112,3 +112,26 @@ def test_record_facts_writes_durable_memory(tmp_path):
     from pathlib import Path
     body = Path(path).read_text(encoding="utf-8")
     assert "Business knowledge" in body and "clinic" in body.lower()
+
+
+def test_finalize_build_writes_code_facts_and_endpoints(tmp_path, monkeypatch):
+    from prism_service.services import magic_app_builder as ab
+    import prism_service.engines.brain_engine as be
+    monkeypatch.setattr(ab, "deploy_app", lambda spec, **k: None)  # no network
+
+    class _FakeBrain:
+        def __init__(self, **k):
+            pass
+        def ingest(self, paths):
+            return 3
+    monkeypatch.setattr(be, "Brain", _FakeBrain)
+
+    spec = {"db": "shop", "module": "shop", "entities": [
+        {"name": "customers", "fields": [{"name": "name", "type": "TEXT"}]}]}
+    r = mi.finalize_build("acme", spec, data_dir=tmp_path,
+                          facts=[{"name": "x", "text": "a shop"}])
+    src = tmp_path / "projects" / "acme" / "magic_app"
+    assert (src / "customers.get.hl").exists()       # their CODE artifact
+    assert (src / "business-facts.md").exists()       # their memory artifact
+    assert r["brain_docs"] == 3                        # ingested into their BRAIN
+    assert any("customers" in e for e in r["endpoints"])

--- a/services/prism-service/tests/unit/test_magic_interview.py
+++ b/services/prism-service/tests/unit/test_magic_interview.py
@@ -1,0 +1,86 @@
+"""Tests for the reverse-engineering interview state machine.
+
+The guarantees: it converges to a stable/complete spec, NEVER reaches
+'ready' with a blocking gap, absorbs a transient dropped rule (re-asks),
+and serializes so the session lives in PRISM memory."""
+
+from __future__ import annotations
+
+import copy
+
+from prism_service.services import magic_interview as mi
+
+THIN = {"db": "clinic", "module": "clinic", "entities": [
+    {"name": "appointments", "fields": [
+        {"name": "patient_id", "type": "INTEGER"},
+        {"name": "status", "type": "TEXT"}],
+     "rules": [{"type": "fk", "field": "patient_id", "ref": "patients"}]}]}
+
+
+def _refine_good(spec, answered):
+    """Deterministic stand-in for the SLM: folds answers into the spec."""
+    s = copy.deepcopy(spec)
+    txt = " ".join(a["answer"] for a in answered).lower()
+    names = {e["name"] for e in s["entities"]}
+    if "patient" in txt and "patients" not in names:
+        s["entities"].append({"name": "patients",
+                              "fields": [{"name": "name", "type": "TEXT"}]})
+    if "scheduled" in txt:
+        for e in s["entities"]:
+            if e["name"] == "appointments" and not any(
+                    r["type"] == "enum" for r in e.get("rules", [])):
+                e.setdefault("rules", []).append(
+                    {"type": "enum", "field": "status",
+                     "values": ["scheduled", "completed", "cancelled"]})
+    return s
+
+
+def _answers(questions):
+    # customer answers: give the patient + status facts, decline the rest
+    return [{"question": q, "answer":
+             ("Patients have a name." if "patient" in q.lower() or "table" in q.lower()
+              else "scheduled, completed, cancelled" if "status" in q.lower()
+              else "no, not needed")} for q in questions]
+
+
+def test_converges_to_ready_no_blocking():
+    iv = mi.run(copy.deepcopy(THIN), _refine_good, _answers, max_rounds=6)
+    assert iv.state == mi.READY
+    # the guarantee: never ready with a blocking gap left
+    from prism_service.services import magic_spec_gaps as g
+    assert not g.check_spec(iv.spec)["blocking"]
+    assert any(e["name"] == "patients" for e in iv.spec["entities"])
+
+
+def test_never_ready_when_blocking_persists():
+    # SLM that NEVER adds the patients entity -> blocking never resolves
+    def refine_broken(spec, answered):
+        return copy.deepcopy(spec)
+    iv = mi.run(copy.deepcopy(THIN), refine_broken, _answers, max_rounds=3)
+    assert iv.state == mi.EXHAUSTED   # escalated, NOT falsely ready
+    assert iv.state != mi.READY
+
+
+def test_absorbs_transient_dropped_rule():
+    # SLM drops patients on round 1, then behaves -> interview re-asks + recovers
+    calls = {"n": 0}
+
+    def refine_flaky(spec, answered):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return copy.deepcopy(spec)          # wobble: adds nothing
+        return _refine_good(spec, answered)     # recovers
+    iv = mi.run(copy.deepcopy(THIN), refine_flaky, _answers, max_rounds=6)
+    assert iv.state == mi.READY
+    assert iv.round >= 2   # it took an extra round to absorb the drop
+
+
+def test_serialize_roundtrip_persists_session():
+    iv = mi.SpecInterview(copy.deepcopy(THIN))
+    d = iv.to_dict()
+    import json
+    d2 = json.loads(json.dumps(d))          # survives a memory round-trip
+    iv2 = mi.SpecInterview.from_dict(d2)
+    assert iv2.state == iv.state
+    assert iv2.questions() == iv.questions()
+    assert iv2.spec == iv.spec

--- a/services/prism-service/tests/unit/test_magic_interview.py
+++ b/services/prism-service/tests/unit/test_magic_interview.py
@@ -84,3 +84,31 @@ def test_serialize_roundtrip_persists_session():
     assert iv2.state == iv.state
     assert iv2.questions() == iv.questions()
     assert iv2.spec == iv.spec
+
+
+def test_save_load_session_roundtrip(tmp_path):
+    iv = mi.SpecInterview(copy.deepcopy(THIN))
+    mi.save_session("acme", iv.to_dict(), data_dir=tmp_path)
+    loaded = mi.load_session("acme", data_dir=tmp_path)
+    assert loaded is not None
+    iv2 = mi.SpecInterview.from_dict(loaded)
+    assert iv2.state == iv.state and iv2.questions() == iv.questions()
+    # a customer who never started has no session
+    assert mi.load_session("nobody", data_dir=tmp_path) is None
+
+
+def test_business_facts_capture_domain_entities_and_qa():
+    iv = mi.run(copy.deepcopy(THIN), _refine_good, _answers, max_rounds=6)
+    facts = mi.business_facts(iv)
+    texts = " ".join(f["text"] for f in facts)
+    assert "clinic" in texts.lower()
+    assert "appointments" in texts and "patients" in texts
+    assert any(f["name"] == "clarification" for f in facts)
+
+
+def test_record_facts_writes_durable_memory(tmp_path):
+    iv = mi.run(copy.deepcopy(THIN), _refine_good, _answers, max_rounds=6)
+    path = mi.record_facts("acme", mi.business_facts(iv), data_dir=tmp_path)
+    from pathlib import Path
+    body = Path(path).read_text(encoding="utf-8")
+    assert "Business knowledge" in body and "clinic" in body.lower()

--- a/services/prism-service/tests/unit/test_magic_spec_gaps.py
+++ b/services/prism-service/tests/unit/test_magic_spec_gaps.py
@@ -1,0 +1,70 @@
+"""Tests for the spec gap detector (services/magic_spec_gaps) — the
+brain-side completeness/confidence checker that drives follow-up questions."""
+
+from __future__ import annotations
+
+from prism_service.services import magic_spec_gaps as g
+
+
+def test_no_entities_is_blocking():
+    r = g.check_spec({"db": "x", "module": "x", "entities": []})
+    assert r["complete"] is False
+    assert r["blocking"][0]["kind"] == "no_entities"
+
+
+def test_orphan_fk_blocks_and_asks():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "orders", "fields": [{"name": "customer_id", "type": "INTEGER"}],
+         "rules": [{"type": "fk", "field": "customer_id", "ref": "customers"}]}]}
+    r = g.check_spec(spec)
+    assert r["complete"] is False
+    kinds = {b["kind"] for b in r["blocking"]}
+    assert "orphan_fk" in kinds
+    assert any("customers" in q for q in r["questions"])
+
+
+def test_unlinked_id_field_is_clarifying_question():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "appointments",
+         "fields": [{"name": "patient_id", "type": "INTEGER"}]}]}
+    r = g.check_spec(spec)
+    # not blocking (it's a suggestion), but a question is raised
+    assert r["complete"] is True
+    assert any(c["kind"] == "unlinked_fk" for c in r["clarifying"])
+    assert any("patient" in q for q in r["questions"])
+
+
+def test_status_field_without_values_asks_enum():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "tickets", "fields": [{"name": "status", "type": "TEXT"}]}]}
+    r = g.check_spec(spec)
+    assert any(c["kind"] == "missing_enum" for c in r["clarifying"])
+
+
+def test_status_with_enum_rule_no_gap():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "tickets", "fields": [{"name": "status", "type": "TEXT"}],
+         "rules": [{"type": "enum", "field": "status",
+                    "values": ["open", "closed"]}]}]}
+    kinds = {gp["kind"] for gp in g.find_gaps(spec)}
+    assert "missing_enum" not in kinds
+
+
+def test_numeric_field_asks_bound():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "products", "fields": [{"name": "price", "type": "REAL"}]}]}
+    assert any(c["kind"] == "maybe_min" for c in g.check_spec(spec)["clarifying"])
+
+
+def test_complete_spec_has_no_blocking_gaps():
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "customers", "fields": [{"name": "name", "type": "TEXT"}]},
+        {"name": "orders", "fields": [
+            {"name": "customer_id", "type": "INTEGER"},
+            {"name": "total", "type": "REAL"},
+            {"name": "status", "type": "TEXT"}],
+         "rules": [{"type": "fk", "field": "customer_id", "ref": "customers"},
+                   {"type": "min", "field": "total", "value": 0},
+                   {"type": "enum", "field": "status", "values": ["new", "paid"]}]}]}
+    assert g.is_complete(spec) is True
+    assert g.check_spec(spec)["complete"] is True

--- a/services/prism-service/tests/unit/test_magic_spec_gaps.py
+++ b/services/prism-service/tests/unit/test_magic_spec_gaps.py
@@ -68,3 +68,57 @@ def test_complete_spec_has_no_blocking_gaps():
                    {"type": "enum", "field": "status", "values": ["new", "paid"]}]}]}
     assert g.is_complete(spec) is True
     assert g.check_spec(spec)["complete"] is True
+
+
+def test_placeholder_fk_produces_no_garbage_question():
+    # a small model emitted a rule referencing a placeholder 'table'
+    spec = {"db": "x", "module": "x", "entities": [
+        {"name": "Appointments", "fields": [{"name": "date", "type": "TEXT"}],
+         "rules": [{"type": "fk", "field": "x", "ref": "table"}]}]}
+    r = g.check_spec(spec)
+    assert all("to table" not in q for q in r["questions"])
+    # entity name canonicalized to lowercase by the normalize pass
+    assert not any(gp["kind"] == "orphan_fk" for gp in r["blocking"])
+
+
+def test_match_domain_detects_clinic_and_shop():
+    clinic = {"entities": [{"name": "appointments", "fields": [
+        {"name": "patient_id", "type": "INTEGER"}]}]}
+    shop = {"entities": [{"name": "orders", "fields": [
+        {"name": "product_id", "type": "INTEGER"}]},
+        {"name": "customers", "fields": []}]}
+    assert g.match_domain(clinic) == "clinic"
+    assert g.match_domain(shop) == "shop"
+    assert g.match_domain({"entities": [{"name": "widgets", "fields": []}]}) is None
+
+
+def test_learned_gaps_flags_typical_missing_entity():
+    # a clinic spec with appointments + patients but no billing
+    spec = {"entities": [
+        {"name": "patients", "fields": [{"name": "name", "type": "TEXT"}]},
+        {"name": "appointments", "fields": [
+            {"name": "patient_id", "type": "INTEGER"},
+            {"name": "date", "type": "TEXT"}]}]}
+    lg = g.learned_gaps(spec)
+    kinds = {x["kind"] for x in lg}
+    assert "learned_entity" in kinds
+    assert any("billing" in x["question"] for x in lg)
+
+
+def test_check_spec_reports_domain_and_learned_questions():
+    spec = {"db": "c", "module": "c", "entities": [
+        {"name": "appointments", "fields": [
+            {"name": "patient_id", "type": "INTEGER"}]}]}
+    r = g.check_spec(spec)
+    assert r["domain"] == "clinic"
+    assert any("usually also track" in q for q in r["questions"])
+
+
+def test_learn_from_spec_enriches_archetype():
+    arch = {"clinic": {"signals": {"appointment", "patient"},
+                       "entities": {"appointments": ["patient_id", "date"]}}}
+    spec = {"entities": [{"name": "appointments", "fields": [
+        {"name": "duration", "type": "INTEGER"}]}]}
+    dom = g.learn_from_spec(spec, arch)
+    assert dom == "clinic"
+    assert "duration" in arch["clinic"]["entities"]["appointments"]


### PR DESCRIPTION
## Magic Cloud admin channel — LOB-factory lane 1

First lane of the "PRISM as a LOB-app factory" epic (`b0723e35`): the PI agent will let customers build business backends on a **headless Magic Cloud** instance (github.com/polterguy/magic, MIT) driven from PRISM — the Magic UI is never deployed. This lane lands the foundation the sibling lanes (MCP bridge, dev rig, LOB driver) build on.

### What's here
- **`services/magic_client.py`** — stdlib-urllib admin channel (house style, no httpx): `authenticate → JWT`, `bootstrap` (owns the root/root setup window; idempotent — won't brick auth on an already-configured instance), `execute` (evaluator), `endpoints`/`openapi`, `crudify`, `sql`. Typed `MagicError`.
- **`api/magic.py`** (registered under `/api/magic`) — `status`/`configure`/`clear`/`setup`/`execute`/`endpoints`. Credentials persist as a redacted `DATA_DIR` dotfile; **the secret never leaves the server** — only a `user:•••last4` fingerprint. Env overrides `PRISM_MAGIC_URL/USER/PASSWORD`.
- **Settings → Connections** — a Magic card (connect / fingerprint / disconnect).
- Pinned backend image **`servergardens/magic-backend:v22.10.10`**. Version bump to **6.7.23**.

### Verification
Driven through the full conductor SDLC (story_gate → plan_gate → red_gate → green_gate), gates cleared by **distinct-actor** verifiers (no self-override).

- **18/18 unit tests** (`test_magic_client.py` + `test_magic_api.py`); 27/27 incl. the sibling github-auth suite (no regression).
- **Live headless container** (`magic-backend:v22.10.10`, no frontend): `/api/magic/setup` bootstraps it and root/root stops authenticating after; idempotent re-run returns `already_configured`; `/api/magic/execute` returns an evaluated result; `/api/magic/endpoints` lists 196 endpoints.
- **UI** verified on a live daemon: Settings → Connections shows the connected card with the redacted fingerprint.

Two fixes came only from the **real backend** (invisible to mocks): the evaluator returns raw Hyperlambda text (now wrapped as `{result}`), and route-registration must probe the OpenAPI schema on FastAPI ≥0.138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
