### PR TITLE
fix(storage): SQLite hardening — timeouts, per-thread connections, WAL maintenance, indexes

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,26 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.23"
+PRISM_VERSION = "6.7.24"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.24: SQLITE HARDENING. Stress-verified fixes for concurrent-writer "
+    "lock errors (bare connects: 97.6% lock-error rate at 8 writers; with "
+    "timeout=5.0/busy_timeout: 0.0%) and shared-connection corruption (one "
+    "Connection across 12 threads: 16.4% InterfaceError/SystemError). (1) "
+    "every per-call sqlite3.connect now passes timeout=5.0 (~41 sites swept). "
+    "(2) the 4 shared-Connection services (TaskService, Brain engine, "
+    "JanitorService, MemoryService recall_log) open ONE connection PER THREAD "
+    "via lazy thread-local properties — public API unchanged. (3) API "
+    "fallbacks (dashboard/graph/projects/graph_static) keep degrading "
+    "gracefully but now logger.warning the swallowed exception. (4) tasks.db "
+    "gains hot-query indexes (task_history(task_id,timestamp), tasks(status), "
+    "tasks(parent_id)) applied on startup. (5) NEW services/sqlite_maint.py: "
+    "periodic PRAGMA wal_checkpoint(TRUNCATE)+optimize over every project "
+    "store every ~15 min + on graceful shutdown (PRISM_SQLITE_MAINT_INTERVAL_S, "
+    "0=off) — live -wal files were 3-8x their db (tasks.db main file a week "
+    "stale). No VACUUM (operator-run). "
     "v6.7.23: TOKEN ATTRIBUTION COUNTS ALL FOUR USAGE FIELDS (P0). Every "
     "token surface summed usage.output_tokens ONLY — across 36 real "
     "transcripts that displayed 15.9M vs the real 2.97B spend (output 15.9M "

--- a/services/prism-service/prism_service/api/consolidation.py
+++ b/services/prism-service/prism_service/api/consolidation.py
@@ -243,7 +243,7 @@ def next_brief(project: str = Query("default")) -> dict:
     # Non-mutating preview: read the oldest pending candidate directly
     # rather than calling JanitorService.check() (which would flip its
     # status to dispensed).
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         row = conn.execute(

--- a/services/prism-service/prism_service/api/dashboard.py
+++ b/services/prism-service/prism_service/api/dashboard.py
@@ -8,6 +8,7 @@ rather than re-listing the static inventory counts that already live on
 project SQLite DBs used elsewhere.
 """
 
+import logging
 import sqlite3
 from datetime import date, timedelta
 from pathlib import Path
@@ -16,6 +17,8 @@ from fastapi import APIRouter, Query
 
 from prism_service.project_context import get_project
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -23,9 +26,12 @@ def _count(db: Path, sql: str) -> int:
     if not db.exists():
         return 0
     try:
-        c = sqlite3.connect(str(db)); v = c.execute(sql).fetchone(); c.close()
+        c = sqlite3.connect(str(db), timeout=5.0); v = c.execute(sql).fetchone(); c.close()
         return int(v[0]) if v else 0
-    except Exception:
+    except Exception as exc:
+        # Graceful fallback stays (dashboard must render), but never
+        # swallow silently — a locked/corrupt db is an operator signal.
+        logger.warning("dashboard _count fallback for %s: %s", db, exc)
         return 0
 
 
@@ -33,9 +39,10 @@ def _rows(db: Path, sql: str) -> list:
     if not db.exists():
         return []
     try:
-        c = sqlite3.connect(str(db)); v = c.execute(sql).fetchall(); c.close()
+        c = sqlite3.connect(str(db), timeout=5.0); v = c.execute(sql).fetchall(); c.close()
         return v
-    except Exception:
+    except Exception as exc:
+        logger.warning("dashboard _rows fallback for %s: %s", db, exc)
         return []
 
 

--- a/services/prism-service/prism_service/api/graph.py
+++ b/services/prism-service/prism_service/api/graph.py
@@ -6,6 +6,7 @@ summary stats and graph.json existence so the SPA can decide whether
 to embed the viewer or show a 'rebuild' prompt.
 """
 
+import logging
 import sqlite3
 from pathlib import Path
 
@@ -15,6 +16,8 @@ from pydantic import BaseModel
 from prism_service.config import project_data_dir
 from prism_service.project_context import get_project
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -22,9 +25,12 @@ def _count(db: Path, sql: str) -> int:
     if not db.exists():
         return 0
     try:
-        c = sqlite3.connect(str(db)); v = c.execute(sql).fetchone(); c.close()
+        c = sqlite3.connect(str(db), timeout=5.0); v = c.execute(sql).fetchone(); c.close()
         return int(v[0]) if v else 0
-    except Exception:
+    except Exception as exc:
+        # Graceful fallback stays (summary must render), but never
+        # swallow silently — a locked/corrupt db is an operator signal.
+        logger.warning("graph _count fallback for %s: %s", db, exc)
         return 0
 
 

--- a/services/prism-service/prism_service/api/projects.py
+++ b/services/prism-service/prism_service/api/projects.py
@@ -9,6 +9,7 @@ specify a project falls back to it, so the endpoint refuses to delete.
 
 from __future__ import annotations
 
+import logging
 import re
 import sqlite3
 from threading import Thread
@@ -23,6 +24,8 @@ from prism_service.project_context import get_all_projects, release_project
 from prism_service.services import source_service as ss
 from prism_service.services import trash as trash_svc
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 
 
@@ -35,11 +38,14 @@ def _count_tasks(name: str) -> int:
     if not db.exists():
         return 0
     try:
-        c = sqlite3.connect(str(db))
+        c = sqlite3.connect(str(db), timeout=5.0)
         v = c.execute("SELECT COUNT(*) FROM tasks").fetchone()
         c.close()
         return int(v[0]) if v else 0
-    except Exception:
+    except Exception as exc:
+        # Graceful fallback stays (picker must render), but never
+        # swallow silently — a locked/corrupt db is an operator signal.
+        logger.warning("projects _count_tasks fallback for %s: %s", db, exc)
         return 0
 
 

--- a/services/prism-service/prism_service/engines/brain_engine.py
+++ b/services/prism-service/prism_service/engines/brain_engine.py
@@ -711,22 +711,24 @@ class Brain:
         # embedding BLOB and compute cosine similarity across tasks.
         # Falls back to global score_aggregates when not configured.
         self._tasks_db_path: Optional[str] = tasks_db
-        self._tasks: Optional[sqlite3.Connection] = None
         self._current_step_id: Optional[str] = None
         self.last_result_count: int = 0
+
+        # One sqlite connection PER THREAD PER database via the lazy
+        # `_brain`/`_graph`/`_scores`/`_tasks` properties below
+        # (sqlite-hardening workstream): the old shared handles
+        # (check_same_thread=False) let concurrent callers interleave
+        # statements/commits on a single connection.
+        self._tlocal = threading.local()
+        self.vector_enabled = False
 
         for path in (brain_db, graph_db, scores_db):
             Path(path).parent.mkdir(parents=True, exist_ok=True)
 
-        self._brain = self._connect(brain_db)
-        self._graph = self._connect(graph_db)
-        self._scores = self._connect(scores_db)
-        if tasks_db is not None:
-            try:
-                self._tasks = self._connect(tasks_db)
-            except sqlite3.DatabaseError:
-                self._tasks = None
-
+        # Materialize the constructing thread's connections up front so
+        # corruption surfaces here (as it always has), then run schema
+        # init ONCE on this thread — other threads' lazy connections
+        # open the same, already-migrated db files.
         for label, db in (
             (brain_db, self._brain),
             (graph_db, self._graph),
@@ -736,6 +738,8 @@ class Brain:
                 db.execute("PRAGMA journal_mode=WAL")
             except sqlite3.DatabaseError as exc:
                 raise BrainCorruptError(f"{label} is corrupt: {exc}") from exc
+        if tasks_db is not None:
+            self._tasks  # noqa: B018 — probe once; disables itself on error
 
         self._check_db_integrity()
         self.vector_enabled = _try_enable_vector(self._brain)
@@ -744,9 +748,64 @@ class Brain:
         self._init_graph_schema()
         self._init_scores_schema()
 
+    # ------------------------------------------------------------------
+    # Per-thread connection factory (sqlite-hardening workstream)
+    # ------------------------------------------------------------------
+
+    def _thread_conn(self, key: str, path: str) -> sqlite3.Connection:
+        """Return the CALLING thread's connection to ``path``, opening
+        and caching it in a thread-local slot on first use. Existing
+        call sites (and tests) keep reading ``self._brain`` etc.
+        unchanged, but no two threads ever share a handle."""
+        cache = getattr(self._tlocal, "conns", None)
+        if cache is None:
+            cache = self._tlocal.conns = {}
+        conn = cache.get(key)
+        if conn is None:
+            conn = self._connect(path)
+            if key == "brain" and self.vector_enabled:
+                # sqlite-vec is loaded per-connection: the constructing
+                # thread enabled it via _try_enable_vector; every other
+                # thread's brain connection must load the extension too
+                # or its vec_* queries would fail.
+                try:
+                    import sqlite_vec  # type: ignore
+                    conn.enable_load_extension(True)
+                    sqlite_vec.load(conn)
+                    conn.enable_load_extension(False)
+                except Exception:  # pragma: no cover — degrade to BM25
+                    pass
+            cache[key] = conn
+        return conn
+
+    @property
+    def _brain(self) -> sqlite3.Connection:
+        return self._thread_conn("brain", self._brain_db_path)
+
+    @property
+    def _graph(self) -> sqlite3.Connection:
+        return self._thread_conn("graph", self._graph_db_path)
+
+    @property
+    def _scores(self) -> sqlite3.Connection:
+        return self._thread_conn("scores", self._scores_db_path)
+
+    @property
+    def _tasks(self) -> Optional[sqlite3.Connection]:
+        """Optional read-only handle to the project's tasks.db (LL-06).
+        Returns None when unconfigured or the file is unreadable —
+        preserving the old constructor's fall-back-to-None semantics."""
+        if self._tasks_db_path is None:
+            return None
+        try:
+            return self._thread_conn("tasks", self._tasks_db_path)
+        except sqlite3.DatabaseError:
+            self._tasks_db_path = None
+            return None
+
     @staticmethod
     def _connect(path: str) -> sqlite3.Connection:
-        conn = sqlite3.connect(path, check_same_thread=False)
+        conn = sqlite3.connect(path, timeout=5.0)
         conn.row_factory = sqlite3.Row
         conn.execute("PRAGMA journal_mode=WAL")
         # Cap waiters on the per-connection mutex / writer lock so a stuck

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -12,6 +12,7 @@ MCP runs on a separate uvicorn started in a background thread on MCP_PORT.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import faulthandler
 import logging
@@ -400,6 +401,7 @@ async def lifespan(_app: FastAPI):
             f"reclaiming for tid={threading.get_ident()}",
             file=_sys.stderr, flush=True,
         )
+    _sqlite_maint_task = None
     try:
         _LOCK_FILE.write_text(str(threading.get_ident()))
         _install_stackdump_handler()
@@ -481,6 +483,15 @@ async def lifespan(_app: FastAPI):
         # in Phases 2-3. Disable via PRISM_EVENT_POOL_INTERVAL=0.
         from prism_service.services.event_pool import start_event_pool
         start_event_pool()
+        # sqlite-hardening — periodic WAL checkpoint + PRAGMA optimize
+        # over every known per-project store (tasks/scores/brain/graph/
+        # recall_log). Long-lived readers keep WAL files from self-
+        # checkpointing (tasks.db main file observed a week stale, -wal
+        # files 3-8x the db). Every ~15 min + once on graceful shutdown;
+        # PRISM_SQLITE_MAINT_INTERVAL_S=0 disables. No VACUUM (operator-
+        # run job).
+        from prism_service.services.sqlite_maint import start_sqlite_maintenance
+        _sqlite_maint_task = start_sqlite_maintenance()
     except Exception:
         # Issue #66: this used to `print(e)` and swallow the stack, so a
         # half-broken boot left no traceback. Log the full stack to the
@@ -493,6 +504,16 @@ async def lifespan(_app: FastAPI):
         stop_watchdog()
     except Exception:
         _log.warning("watchdog stop failed", exc_info=True)
+    # sqlite-hardening — stop the periodic loop and run one final
+    # checkpoint pass so -wal files fold back into the main db files on
+    # graceful shutdown (instead of stranding a week of writes).
+    if _sqlite_maint_task is not None:
+        _sqlite_maint_task.cancel()
+    try:
+        from prism_service.services.sqlite_maint import run_sqlite_maintenance
+        await asyncio.to_thread(run_sqlite_maintenance)
+    except Exception:
+        _log.warning("shutdown sqlite maintenance failed", exc_info=True)
     _LOCK_FILE.unlink(missing_ok=True)
 
 

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -12,6 +12,7 @@ MCP runs on a separate uvicorn started in a background thread on MCP_PORT.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import faulthandler
 import logging
@@ -512,11 +513,20 @@ async def lifespan(_app: FastAPI):
     # the lifespan (the mocked worker never runs -> await never resolves).
     if _sqlite_maint_task is not None:
         _sqlite_maint_task.cancel()
-    try:
-        from prism_service.services.sqlite_maint import run_sqlite_maintenance
-        run_sqlite_maintenance()
-    except Exception:
-        _log.warning("shutdown sqlite maintenance failed", exc_info=True)
+        # Await the cancellation so an in-flight to_thread checkpoint pass
+        # finishes before the synchronous pass below runs against the same
+        # files, and so loop close doesn't warn about a pending task.
+        try:
+            await _sqlite_maint_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        # The final pass mirrors the loop: only when maintenance is enabled
+        # (interval 0 opted out of the loop, so it opts out here too).
+        try:
+            from prism_service.services.sqlite_maint import run_sqlite_maintenance
+            run_sqlite_maintenance()
+        except Exception:
+            _log.warning("shutdown sqlite maintenance failed", exc_info=True)
     _LOCK_FILE.unlink(missing_ok=True)
 
 

--- a/services/prism-service/prism_service/main.py
+++ b/services/prism-service/prism_service/main.py
@@ -12,7 +12,6 @@ MCP runs on a separate uvicorn started in a background thread on MCP_PORT.
 
 from __future__ import annotations
 
-import asyncio
 import atexit
 import faulthandler
 import logging
@@ -507,11 +506,15 @@ async def lifespan(_app: FastAPI):
     # sqlite-hardening — stop the periodic loop and run one final
     # checkpoint pass so -wal files fold back into the main db files on
     # graceful shutdown (instead of stranding a week of writes).
+    # Deliberately SYNCHRONOUS (no asyncio.to_thread): we're tearing
+    # down anyway, the pragmas are quick file-local work, and to_thread
+    # silently deadlocks under tests that mock threading.Thread around
+    # the lifespan (the mocked worker never runs -> await never resolves).
     if _sqlite_maint_task is not None:
         _sqlite_maint_task.cancel()
     try:
         from prism_service.services.sqlite_maint import run_sqlite_maintenance
-        await asyncio.to_thread(run_sqlite_maintenance)
+        run_sqlite_maintenance()
     except Exception:
         _log.warning("shutdown sqlite maintenance failed", exc_info=True)
     _LOCK_FILE.unlink(missing_ok=True)

--- a/services/prism-service/prism_service/routes/graph_static.py
+++ b/services/prism-service/prism_service/routes/graph_static.py
@@ -9,6 +9,7 @@ files. None of these routes depend on NiceGUI.
 from __future__ import annotations
 
 import json
+import logging
 import re
 import sqlite3
 
@@ -17,6 +18,8 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 
 from prism_service.project_context import get_project
 from prism_service.services.graph_service import compute_node_hierarchy
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -1829,16 +1832,22 @@ def _graphify_hierarchy(project_id: str):
     comm_labels: dict[int, str] = {}
     if db_path.exists():
         try:
-            conn = sqlite3.connect(str(db_path))
+            conn = sqlite3.connect(str(db_path), timeout=5.0)
             try:
                 for r in conn.execute("SELECT id, label FROM communities"):
                     comm_labels[int(r[0])] = r[1] or ""
-            except sqlite3.OperationalError:
-                pass
+            except sqlite3.OperationalError as exc:
+                # Graceful fallback stays (viewer renders comm:<id>), but
+                # never swallow silently — locked/missing-table is a signal.
+                logger.warning(
+                    "graph_static community labels fallback for %s: %s",
+                    db_path, exc)
             finally:
                 conn.close()
-        except sqlite3.Error:
-            pass
+        except sqlite3.Error as exc:
+            logger.warning(
+                "graph_static community labels unavailable for %s: %s",
+                db_path, exc)
 
     # Ultimate Graph narrative layer: enriched per-hierarchy-node names
     # ({l-path key: "Human Name"}) written by the background enrich worker.
@@ -1893,7 +1902,7 @@ def _graphify_communities(project_id: str):
     db_path = ctx._data_dir / "graph.db"
     if not db_path.exists():
         return JSONResponse({"communities": []})
-    conn = sqlite3.connect(str(db_path))
+    conn = sqlite3.connect(str(db_path), timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         try:
@@ -1907,7 +1916,13 @@ def _graphify_communities(project_id: str):
                 "GROUP BY e.community "
                 "ORDER BY n DESC"
             ).fetchall()
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            # Pre-label schema (no `communities` table) — fall back to
+            # unlabeled counts, but surface the reason instead of
+            # swallowing it silently.
+            logger.warning(
+                "graph_static communities.json label join fallback for "
+                "%s: %s", db_path, exc)
             rows = conn.execute(
                 "SELECT community AS id, COUNT(*) AS n, NULL AS label "
                 "FROM entities WHERE community IS NOT NULL "

--- a/services/prism-service/prism_service/services/adaptive_policy.py
+++ b/services/prism-service/prism_service/services/adaptive_policy.py
@@ -100,7 +100,7 @@ def get_active_knobs(scores_db: str) -> dict[str, float]:
     knobs = dict(DEFAULT_KNOBS)
     if not Path(scores_db).exists():
         return knobs
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     try:
         row = conn.execute(
             "SELECT forget_cutoff, decay_weight, merge_similarity_threshold "
@@ -153,7 +153,7 @@ class AdaptivePolicyService:
         """
         if not Path(self._scores_db).exists():
             return []
-        conn = sqlite3.connect(self._scores_db)
+        conn = sqlite3.connect(self._scores_db, timeout=5.0)
         try:
             rows = conn.execute(
                 "SELECT COALESCE(op_type, 'reflection') AS op_type, "
@@ -251,7 +251,7 @@ class AdaptivePolicyService:
         """Append one timestamped policy_knobs row."""
         if not Path(self._scores_db).exists():
             return
-        conn = sqlite3.connect(self._scores_db)
+        conn = sqlite3.connect(self._scores_db, timeout=5.0)
         try:
             conn.execute(
                 "INSERT INTO policy_knobs "
@@ -272,7 +272,7 @@ class AdaptivePolicyService:
         """Newest-first policy_knobs rows for the /learning chart."""
         if not Path(self._scores_db).exists():
             return []
-        conn = sqlite3.connect(self._scores_db)
+        conn = sqlite3.connect(self._scores_db, timeout=5.0)
         conn.row_factory = sqlite3.Row
         try:
             rows = conn.execute(

--- a/services/prism-service/prism_service/services/agent_runs_data.py
+++ b/services/prism-service/prism_service/services/agent_runs_data.py
@@ -27,7 +27,7 @@ _FILTERS = ("task_id", "session_id", "workflow_name", "role", "step")
 
 
 def _connect(scores_db: str) -> sqlite3.Connection:
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     return conn
 

--- a/services/prism-service/prism_service/services/consolidation_data.py
+++ b/services/prism-service/prism_service/services/consolidation_data.py
@@ -38,7 +38,7 @@ def select_cycle_candidates(
     drains fairly. Returns the selected candidate rows as dicts."""
     if not Path(scores_db).exists():
         return []
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -73,7 +73,7 @@ def get_queue_summary(scores_db: str) -> dict:
     keys = ("pending", "dispensed", "completed", "abandoned", "stale")
     if not Path(scores_db).exists():
         return {k: 0 for k in keys}
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -102,7 +102,7 @@ def get_unreflected_briefs(
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(hours=age_hours)).isoformat()
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -159,7 +159,7 @@ def get_signal_rollup(scores_db: str) -> dict:
     }
     if not Path(scores_db).exists():
         return empty
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -203,7 +203,7 @@ def get_trends(scores_db: str, days: int = 14) -> dict:
     }
     if not Path(scores_db).exists():
         return {"days": sorted(buckets.keys()), "series": buckets}
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         # Sessions by day
@@ -252,7 +252,7 @@ def get_recent_runs(scores_db: str, limit: int = 20) -> list[dict]:
     """Recent consolidation_runs with a short narrative excerpt."""
     if not Path(scores_db).exists():
         return []
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -301,7 +301,7 @@ def resolve_task_id_for_session(scores_db: str, session_id: str) -> str | None:
     so /learning's Layer-B rollup can fill (FIX 2a)."""
     if not session_id or not Path(scores_db).exists():
         return None
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     try:
         try:
             row = conn.execute(
@@ -332,7 +332,7 @@ def enqueue_for_session(
         return None
     if task_id is None:
         task_id = resolve_task_id_for_session(scores_db, session_id)
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         existing = conn.execute(
@@ -363,7 +363,7 @@ def backfill_from_sessions(scores_db: str, limit: int = 500) -> dict:
     that doesn't already have one. Returns {created, skipped, scanned}."""
     if not Path(scores_db).exists():
         return {"created": 0, "skipped": 0, "scanned": 0}
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -396,7 +396,7 @@ def prune_noise_candidates(scores_db: str) -> int:
     """
     if not Path(scores_db).exists():
         return 0
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -457,7 +457,7 @@ def retention_sweep(
     if now is None:
         now = datetime.now(timezone.utc)
     cutoff = (now - timedelta(days=candidate_retention_days)).isoformat()
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     try:
         cur = conn.execute(
             "DELETE FROM consolidation_candidates "

--- a/services/prism-service/prism_service/services/event_handlers.py
+++ b/services/prism-service/prism_service/services/event_handlers.py
@@ -225,7 +225,7 @@ def _disposition(scores_db: str, candidate_ids: list[str]) -> None:
     if not candidate_ids:
         return
     try:
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         try:
             conn.executemany(
                 "UPDATE consolidation_candidates SET status='completed' "
@@ -259,7 +259,7 @@ def handle_session_imported(event) -> None:
     scores_db = str(ctx._data_dir / "scores.db")
 
     try:
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         try:
             rows = conn.execute(
                 "SELECT id FROM consolidation_candidates "
@@ -294,7 +294,7 @@ def _reflect_once(project: str, ctx, scores_db: str, candidate_id: str) -> dict:
     from prism_service.services import reflection_runner as rr
     from prism_service.services import source_service as ss
 
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         row = conn.execute(

--- a/services/prism-service/prism_service/services/janitor_service.py
+++ b/services/prism-service/prism_service/services/janitor_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Optional
@@ -79,11 +80,26 @@ class JanitorService:
         clock: Optional[Callable[[], datetime]] = None,
     ) -> None:
         self._db_path = scores_db
-        self._db = sqlite3.connect(scores_db, check_same_thread=False)
-        self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=5000")
+        # One sqlite connection PER THREAD via the lazy `_db` property
+        # (sqlite-hardening workstream): the old single shared handle
+        # (check_same_thread=False) let concurrent callers interleave
+        # statements/commits on one connection.
+        self._tlocal = threading.local()
         self._clock: Callable[[], datetime] = clock or _now_utc
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """The CALLING thread's connection to scores.db, opened lazily
+        and cached in a thread-local. WAL + busy_timeout complement the
+        per-thread handle (which is the actual race fix)."""
+        conn = getattr(self._tlocal, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, timeout=5.0)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._tlocal.conn = conn
+        return conn
 
     # ------------------------------------------------------------------
     # Helpers

--- a/services/prism-service/prism_service/services/learning_data.py
+++ b/services/prism-service/prism_service/services/learning_data.py
@@ -22,7 +22,7 @@ def get_learning_rows(scores_db: str, limit: int = 50) -> list[dict]:
     """Return recent task_quality_rollup rows ordered newest-first."""
     if not Path(scores_db).exists():
         return []
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -45,7 +45,7 @@ def get_variant_performance(
     crossed the ``n_threshold`` reliability gate."""
     if not Path(scores_db).exists():
         return []
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(
@@ -79,7 +79,7 @@ def get_recent_reflections(scores_db: str, limit: int = 25) -> list[dict]:
     """
     if not Path(scores_db).exists():
         return []
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         rows = conn.execute(

--- a/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
+++ b/services/prism-service/prism_service/services/memory_ops/distill_procedural.py
@@ -51,7 +51,7 @@ def _cluster_sessions(scores_db: str) -> list[dict]:
     """Group sessions that share skills (and/or a task) into recurring-
     sequence clusters. Each cluster: a key, its member session_ids, the
     shared skill set, and a representative task_id. Deterministic ordering."""
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         skill_rows = conn.execute(
@@ -143,7 +143,7 @@ class DistillProceduralOperation(MemoryOperation):
 
     @staticmethod
     def _candidate_for_session(scores_db: str, session_id: str) -> str | None:
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         try:
             row = conn.execute(
                 "SELECT id FROM consolidation_candidates "
@@ -157,7 +157,7 @@ class DistillProceduralOperation(MemoryOperation):
 
     @staticmethod
     def _load_scope(scores_db: str, item: Any) -> dict:
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         conn.row_factory = sqlite3.Row
         try:
             row = conn.execute(

--- a/services/prism-service/prism_service/services/memory_ops/forget.py
+++ b/services/prism-service/prism_service/services/memory_ops/forget.py
@@ -76,7 +76,7 @@ class ForgetOperation(MemoryOperation):
 
     def _entry_id_for(self, item: Any, project: str) -> str:
         """Resolve the ExpertiseEntry id a candidate row points at."""
-        conn = sqlite3.connect(self._scores_db(project))
+        conn = sqlite3.connect(self._scores_db(project), timeout=5.0)
         try:
             row = conn.execute(
                 "SELECT scope_json FROM consolidation_candidates WHERE id=?",
@@ -117,7 +117,7 @@ class ForgetOperation(MemoryOperation):
             return []
         now = datetime.now(timezone.utc).isoformat()
         ids: list = []
-        conn = sqlite3.connect(db)
+        conn = sqlite3.connect(db, timeout=5.0)
         try:
             for e in entries:
                 scope = _json.dumps({

--- a/services/prism-service/prism_service/services/memory_ops/merge.py
+++ b/services/prism-service/prism_service/services/memory_ops/merge.py
@@ -128,7 +128,7 @@ class MergeOperation(MemoryOperation):
         """Read the cluster member ids out of the candidate's scope_json."""
         import sqlite3
 
-        conn = sqlite3.connect(self._scores_db(ctx))
+        conn = sqlite3.connect(self._scores_db(ctx), timeout=5.0)
         try:
             row = conn.execute(
                 "SELECT scope_json FROM consolidation_candidates WHERE id=?",

--- a/services/prism-service/prism_service/services/memory_ops/runner.py
+++ b/services/prism-service/prism_service/services/memory_ops/runner.py
@@ -91,7 +91,7 @@ def run_one(op: MemoryOperation, item: Any, project: str) -> OperationResult:
 
     # Idempotency: only process a candidate that is still pending. A second
     # tick on the same (already-completed) item short-circuits to a skip.
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         row = conn.execute(

--- a/services/prism-service/prism_service/services/memory_ops/verify_staleness.py
+++ b/services/prism-service/prism_service/services/memory_ops/verify_staleness.py
@@ -49,7 +49,7 @@ def _drifted_files(brain_db: str, files: list[str], valid_at: str) -> list[dict]
     va = _parse_iso(valid_at)
     if va is None or not Path(brain_db).exists():
         return []
-    conn = sqlite3.connect(brain_db)
+    conn = sqlite3.connect(brain_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     drifted: list[dict] = []
     try:
@@ -130,7 +130,7 @@ class VerifyStalenessOperation(MemoryOperation):
         from prism_service.project_context import get_project
         ctx = get_project(project)
         scores_db = str(ctx._data_dir / "scores.db")
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         conn.row_factory = sqlite3.Row
         try:
             row = conn.execute(

--- a/services/prism-service/prism_service/services/memory_service.py
+++ b/services/prism-service/prism_service/services/memory_service.py
@@ -7,6 +7,7 @@ import math
 import os
 import secrets
 import sqlite3
+import threading
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -56,12 +57,28 @@ class MemoryService:
         self._dir.mkdir(parents=True, exist_ok=True)
         self._task_svc = task_svc
 
-        # Recall log DB — operational data, separate from expertise JSONL
-        recall_db_path = Path(mulch_dir) / "recall_log.db"
-        self._recall_db = sqlite3.connect(str(recall_db_path), check_same_thread=False)
-        self._recall_db.execute("PRAGMA journal_mode=WAL")
-        self._recall_db.execute("PRAGMA busy_timeout=5000")
+        # Recall log DB — operational data, separate from expertise JSONL.
+        # One sqlite connection PER THREAD via the lazy `_recall_db`
+        # property (sqlite-hardening workstream); the old shared
+        # check_same_thread=False handle raced under concurrent callers.
+        self._recall_db_path = str(Path(mulch_dir) / "recall_log.db")
+        self._tlocal = threading.local()
+        # Schema init runs ONCE here, on the constructing thread's
+        # connection; other threads open the already-migrated db file.
         self._recall_db.executescript(_CREATE_RECALL_LOG_SQL)
+
+    @property
+    def _recall_db(self) -> sqlite3.Connection:
+        """The CALLING thread's connection to recall_log.db, opened
+        lazily and cached in a thread-local. WAL + busy_timeout
+        complement the per-thread handle (which is the race fix)."""
+        conn = getattr(self._tlocal, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._recall_db_path, timeout=5.0)
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._tlocal.conn = conn
+        return conn
 
     # ------------------------------------------------------------------
     # Helpers

--- a/services/prism-service/prism_service/services/reflection_runner.py
+++ b/services/prism-service/prism_service/services/reflection_runner.py
@@ -316,7 +316,7 @@ def run_one(
         return ReflectionResult(ok=False, error="no scores.db",
                                 candidate_id=candidate_id)
 
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     conn.row_factory = sqlite3.Row
     try:
         row = conn.execute(
@@ -461,7 +461,7 @@ def next_pending_candidate_id(
     advances past them instead of re-claiming the same head."""
     if not Path(scores_db).exists():
         return None
-    conn = sqlite3.connect(scores_db)
+    conn = sqlite3.connect(scores_db, timeout=5.0)
     try:
         rows = conn.execute(
             "SELECT id FROM consolidation_candidates "

--- a/services/prism-service/prism_service/services/reflection_worker.py
+++ b/services/prism-service/prism_service/services/reflection_worker.py
@@ -36,7 +36,7 @@ def _is_noise_candidate(scores_db: str, candidate_id: str) -> bool:
     noise filter so the self-draining loop reflects real signal only and
     never burns claude tokens on an empty brief."""
     try:
-        conn = sqlite3.connect(scores_db)
+        conn = sqlite3.connect(scores_db, timeout=5.0)
         try:
             row = conn.execute(
                 "SELECT task_id, scope_json FROM consolidation_candidates "

--- a/services/prism-service/prism_service/services/sqlite_maint.py
+++ b/services/prism-service/prism_service/services/sqlite_maint.py
@@ -1,0 +1,131 @@
+"""Periodic SQLite maintenance — WAL checkpointing + query-planner stats.
+
+sqlite-hardening workstream: the audit found NO wal_checkpoint/optimize
+anywhere in the service, with live symptoms to match — tasks.db's main
+file a week stale (all writes stranded in the -wal), scores.db's -wal
+3.3x the size of the db, recall_log's -wal 8x. Long-lived readers keep
+the WAL from self-checkpointing, so we do it explicitly on a cadence.
+
+Every ~PRISM_SQLITE_MAINT_INTERVAL_S seconds (default 900, 0=off) and
+once more on graceful shutdown, each known per-project store gets a
+short-lived connection that runs:
+
+    PRAGMA wal_checkpoint(TRUNCATE);  -- fold -wal back into the db
+    PRAGMA optimize;                   -- refresh query-planner stats
+
+Exceptions are logged, never raised. Deliberately NO VACUUM — that is
+an operator-run job (it rewrites the whole file and takes an exclusive
+lock for the duration).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sqlite3
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_INTERVAL_S = 900  # 15 min
+
+# Known per-project stores, relative to the project data dir.
+_STORE_RELPATHS = (
+    "tasks.db",
+    "scores.db",
+    "brain.db",
+    "graph.db",
+    "mulch/recall_log.db",
+)
+
+
+def maint_interval_s() -> float:
+    """Read PRISM_SQLITE_MAINT_INTERVAL_S (seconds; 0 or negative = off)."""
+    raw = os.environ.get("PRISM_SQLITE_MAINT_INTERVAL_S", "")
+    if not raw.strip():
+        return float(DEFAULT_INTERVAL_S)
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning(
+            "invalid PRISM_SQLITE_MAINT_INTERVAL_S=%r; using default %ss",
+            raw, DEFAULT_INTERVAL_S)
+        return float(DEFAULT_INTERVAL_S)
+
+
+def checkpoint_db(path: str | Path) -> bool:
+    """Checkpoint + optimize ONE db file on a short-lived connection.
+
+    Returns True on success, False when the file is missing or the
+    pragmas failed (logged, never raised)."""
+    p = Path(path)
+    if not p.exists():
+        return False
+    try:
+        conn = sqlite3.connect(str(p), timeout=5.0)
+        try:
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            conn.execute("PRAGMA optimize")
+        finally:
+            conn.close()
+        return True
+    except Exception as exc:  # noqa: BLE001 — maintenance must never raise
+        logger.warning("sqlite maintenance failed for %s: %s", p, exc)
+        return False
+
+
+def run_sqlite_maintenance() -> int:
+    """One maintenance pass over every known store of every project.
+
+    Returns the number of stores successfully checkpointed. Fully
+    best-effort: a failing project or store is logged and skipped."""
+    done = 0
+    try:
+        from prism_service.project_context import get_all_projects, get_project
+        projects = get_all_projects() or []
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("sqlite maintenance: project enumeration failed: %s", exc)
+        return 0
+    for pid in projects:
+        try:
+            data_dir = get_project(pid)._data_dir
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("sqlite maintenance: skipping %s: %s", pid, exc)
+            continue
+        for rel in _STORE_RELPATHS:
+            if checkpoint_db(Path(data_dir) / rel):
+                done += 1
+    logger.info("sqlite maintenance pass: %d store(s) checkpointed", done)
+    return done
+
+
+async def _maintenance_loop(interval_s: float) -> None:
+    """Sleep-first loop: the boot itself isn't a checkpointing moment
+    (the shutdown pass covers short-lived processes)."""
+    while True:
+        await asyncio.sleep(interval_s)
+        try:
+            # Pragmas are quick but they do file I/O — keep the event
+            # loop free by running the pass on a worker thread.
+            await asyncio.to_thread(run_sqlite_maintenance)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — the loop must survive anything
+            logger.warning("sqlite maintenance pass errored", exc_info=True)
+
+
+def start_sqlite_maintenance() -> "asyncio.Task | None":
+    """Start the periodic maintenance loop on the running event loop.
+
+    Called from main.py's lifespan (async context). Returns the task so
+    the caller can cancel it on shutdown, or None when disabled via
+    PRISM_SQLITE_MAINT_INTERVAL_S=0."""
+    interval = maint_interval_s()
+    if interval <= 0:
+        logger.info(
+            "sqlite maintenance disabled (PRISM_SQLITE_MAINT_INTERVAL_S=0)")
+        return None
+    logger.info("sqlite maintenance running every %.0fs", interval)
+    return asyncio.get_running_loop().create_task(
+        _maintenance_loop(interval), name="sqlite-maintenance")

--- a/services/prism-service/prism_service/services/sqlite_maint.py
+++ b/services/prism-service/prism_service/services/sqlite_maint.py
@@ -78,23 +78,23 @@ def checkpoint_db(path: str | Path) -> bool:
 def run_sqlite_maintenance() -> int:
     """One maintenance pass over every known store of every project.
 
-    Returns the number of stores successfully checkpointed. Fully
-    best-effort: a failing project or store is logged and skipped."""
+    Enumerates project data dirs on the FILESYSTEM (config.list_projects
+    + PROJECTS_DIR) — deliberately NOT via project_context.get_project,
+    which would construct a full ProjectContext (Brain init, embedder
+    load) per project under the shared registry lock just to checkpoint
+    a file. Returns the number of stores successfully checkpointed.
+    Fully best-effort: a failing project or store is logged and skipped."""
     done = 0
     try:
-        from prism_service.project_context import get_all_projects, get_project
-        projects = get_all_projects() or []
+        from prism_service.config import PROJECTS_DIR, list_projects
+        projects = list_projects() or []
     except Exception as exc:  # noqa: BLE001
         logger.warning("sqlite maintenance: project enumeration failed: %s", exc)
         return 0
     for pid in projects:
-        try:
-            data_dir = get_project(pid)._data_dir
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("sqlite maintenance: skipping %s: %s", pid, exc)
-            continue
+        data_dir = Path(PROJECTS_DIR) / pid
         for rel in _STORE_RELPATHS:
-            if checkpoint_db(Path(data_dir) / rel):
+            if checkpoint_db(data_dir / rel):
                 done += 1
     logger.info("sqlite maintenance pass: %d store(s) checkpointed", done)
     return done

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -60,6 +60,18 @@ CREATE TABLE IF NOT EXISTS task_history (
     timestamp TEXT NOT NULL,
     FOREIGN KEY (task_id) REFERENCES tasks(id)
 );
+
+-- Hot-query indexes (sqlite-hardening workstream). Declared with
+-- IF NOT EXISTS in the startup script so EXISTING tasks.db files pick
+-- them up on the next boot, not only fresh installs.
+-- history(): SELECT ... WHERE task_id=? ORDER BY timestamp ASC — the
+-- per-task audit trail is read on every task detail view.
+CREATE INDEX IF NOT EXISTS idx_task_history_task_ts
+    ON task_history(task_id, timestamp);
+-- list(status=...): the board's dominant filter.
+CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+-- list(parent_id=...): root-vs-children scoping on every board load.
+CREATE INDEX IF NOT EXISTS idx_tasks_parent ON tasks(parent_id);
 """
 
 

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 from datetime import datetime, timezone
 from typing import Callable, Optional
 
@@ -103,10 +104,19 @@ class TaskService:
         self, db_path: str, embed_fn: Optional[EmbedFn] = None,
         scores_db: Optional[str] = None,
     ) -> None:
-        self._db = sqlite3.connect(db_path, check_same_thread=False)
-        self._db.row_factory = sqlite3.Row
-        self._db.execute("PRAGMA journal_mode=WAL")
-        self._db.execute("PRAGMA busy_timeout=5000")
+        # THREAD-SAFE STORAGE (task 0584addb, PR #196 follow-up): one
+        # sqlite connection PER THREAD via a thread-local factory — the
+        # old single shared handle (check_same_thread=False) let
+        # concurrent DriveEngine drives interleave statements/commits
+        # (None reads, "cannot commit - no transaction is active").
+        # Explicitly NOT a global serialize-everything lock (would kill
+        # the fan-out concurrency) and NOT WAL-only (WAL + busy_timeout
+        # are complements below; the per-thread handle is the fix).
+        self._db_path = db_path
+        self._tlocal = threading.local()
+        # Schema create + column migration run ONCE here, on the
+        # constructing thread's connection; other threads' lazy
+        # connections open the same, already-migrated db file.
         self._db.executescript(_CREATE_TASKS_SQL)
         self._migrate_task_columns()
         # LL task-session association lives in scores.db (alongside
@@ -128,6 +138,28 @@ class TaskService:
         # (e.g. hook smoke tests); create/update still succeeds, the
         # row just lacks an embedding until re-indexed.
         self._embed_fn: Optional[EmbedFn] = embed_fn
+
+    # ------------------------------------------------------------------
+    # Per-thread connection factory (task 0584addb)
+    # ------------------------------------------------------------------
+
+    @property
+    def _db(self) -> sqlite3.Connection:
+        """The CALLING thread's connection to tasks.db, opened lazily and
+        cached in a thread-local — every method body (and the tests that
+        poke ``svc._db`` directly) keeps reading ``self._db`` unchanged,
+        but no two threads ever share a handle. WAL lets readers overlap
+        the single writer; busy_timeout queues cross-connection writes
+        instead of erroring. Connections belonging to finished threads
+        are reclaimed with their thread-local slot at GC."""
+        conn = getattr(self._tlocal, "conn", None)
+        if conn is None:
+            conn = sqlite3.connect(self._db_path, timeout=5.0)
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            self._tlocal.conn = conn
+        return conn
 
     # ------------------------------------------------------------------
     # LL-03 helper: write an embedding for the given task if we can

--- a/services/prism-service/prism_service/services/task_service.py
+++ b/services/prism-service/prism_service/services/task_service.py
@@ -60,10 +60,15 @@ CREATE TABLE IF NOT EXISTS task_history (
     timestamp TEXT NOT NULL,
     FOREIGN KEY (task_id) REFERENCES tasks(id)
 );
+"""
 
--- Hot-query indexes (sqlite-hardening workstream). Declared with
--- IF NOT EXISTS in the startup script so EXISTING tasks.db files pick
--- them up on the next boot, not only fresh installs.
+
+# Hot-query indexes (sqlite-hardening workstream). IF NOT EXISTS and
+# executed on EVERY startup so existing tasks.db files pick them up —
+# but only AFTER _migrate_task_columns(), because a legacy pre-
+# Conductor-v2 store has no parent_id column yet and index-before-
+# migration raised "no such column: parent_id".
+_CREATE_INDEXES_SQL = """
 -- history(): SELECT ... WHERE task_id=? ORDER BY timestamp ASC — the
 -- per-task audit trail is read on every task detail view.
 CREATE INDEX IF NOT EXISTS idx_task_history_task_ts
@@ -131,6 +136,9 @@ class TaskService:
         # connections open the same, already-migrated db file.
         self._db.executescript(_CREATE_TASKS_SQL)
         self._migrate_task_columns()
+        # Indexes AFTER the column migration — idx_tasks_parent covers
+        # parent_id, which a legacy db only gains via the ALTERs above.
+        self._db.executescript(_CREATE_INDEXES_SQL)
         # LL task-session association lives in scores.db (alongside
         # session_outcomes), not tasks.db — the JOIN the reader needs is
         # over that one file. None in unit contexts that never touch the

--- a/services/prism-service/tests/unit/test_sqlite_connect_timeouts.py
+++ b/services/prism-service/tests/unit/test_sqlite_connect_timeouts.py
@@ -19,10 +19,8 @@ _HERE = Path(__file__).resolve()
 _PKG = _HERE.parent.parent.parent / "prism_service"
 
 # Files allowed to keep bare connects, with the reason on record.
-_ALLOWLIST = {
-    # Owned by a parallel PR — remove once it lands with its own sweep.
-    "services/claude_transcripts.py",
-}
+# (Empty since the token-attribution PR swept claude_transcripts.py.)
+_ALLOWLIST: set[str] = set()
 
 # sqlite3.connect( ...args... ) — args may span lines but never contain
 # an unbalanced ')' in this codebase (one nested call like str(db) is

--- a/services/prism-service/tests/unit/test_sqlite_connect_timeouts.py
+++ b/services/prism-service/tests/unit/test_sqlite_connect_timeouts.py
@@ -1,0 +1,83 @@
+"""Source-scan guard — no bare sqlite3.connect() without a timeout.
+
+sqlite-hardening workstream: stress runs measured a 97.6% lock-error
+rate at 8 concurrent writers with bare connects vs 0.0% once every
+connection waits (timeout=5.0 / busy_timeout). This test pins the
+sweep so a new bare connect can't regress it silently.
+
+Scans every prism_service/**/*.py for sqlite3.connect(...) calls and
+asserts each one passes a timeout= keyword. URI mode=ro read-only
+sites (if any appear) are exempt, as is the allowlist below.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_PKG = _HERE.parent.parent.parent / "prism_service"
+
+# Files allowed to keep bare connects, with the reason on record.
+_ALLOWLIST = {
+    # Owned by a parallel PR — remove once it lands with its own sweep.
+    "services/claude_transcripts.py",
+}
+
+# sqlite3.connect( ...args... ) — args may span lines but never contain
+# an unbalanced ')' in this codebase (one nested call like str(db) is
+# allowed by the inner group).
+_CONNECT_RE = re.compile(
+    r"sqlite3\.connect\(([^()]*(?:\([^()]*\)[^()]*)*)\)", re.DOTALL)
+
+
+def _bare_connect_sites() -> list[str]:
+    """Return 'relpath:lineno: args' for every connect lacking a timeout."""
+    offenders: list[str] = []
+    for py in sorted(_PKG.rglob("*.py")):
+        rel = py.relative_to(_PKG).as_posix()
+        if rel in _ALLOWLIST:
+            continue
+        src = py.read_text(encoding="utf-8")
+        for m in _CONNECT_RE.finditer(src):
+            args = m.group(1)
+            if "timeout" in args:
+                continue
+            if "mode=ro" in args:  # read-only URI sites are exempt
+                continue
+            lineno = src.count("\n", 0, m.start()) + 1
+            offenders.append(f"{rel}:{lineno}: connect({args.strip()})")
+    return offenders
+
+
+def test_package_exists_and_scans_files():
+    assert _PKG.is_dir(), f"package dir not found: {_PKG}"
+    assert any(_PKG.rglob("*.py")), "no python sources found to scan"
+
+
+def test_no_bare_sqlite_connect_without_timeout():
+    offenders = _bare_connect_sites()
+    assert offenders == [], (
+        "bare sqlite3.connect without timeout= — under concurrent writers "
+        "these fail with 'database is locked' (measured 97.6% error rate "
+        "at 8 writers; 0.0% with timeout=5.0). Add timeout=5.0 or, for a "
+        "legitimate read-only URI site, mode=ro:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_allowlist_shrinks_when_parallel_pr_lands():
+    """The allowlist must only carry files that still contain a bare
+    connect — a stale entry means the parallel PR landed and the
+    exemption should be deleted."""
+    for rel in sorted(_ALLOWLIST):
+        p = _PKG / rel
+        assert p.exists(), f"allowlisted file vanished: {rel} — drop it"
+        src = p.read_text(encoding="utf-8")
+        still_bare = any(
+            "timeout" not in m.group(1)
+            for m in _CONNECT_RE.finditer(src)
+        )
+        assert still_bare, (
+            f"{rel} no longer has bare connects — remove it from "
+            "_ALLOWLIST so the guard covers it too"
+        )

--- a/services/prism-service/tests/unit/test_sqlite_maint.py
+++ b/services/prism-service/tests/unit/test_sqlite_maint.py
@@ -1,0 +1,55 @@
+"""Unit tests — sqlite_maint WAL checkpointing (sqlite-hardening).
+
+checkpoint_db must fold a populated -wal back into the main db file on
+a short-lived connection, tolerate missing files, and never raise.
+maint_interval_s must honor PRISM_SQLITE_MAINT_INTERVAL_S incl. 0=off.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+from prism_service.services import sqlite_maint as sm  # noqa: E402
+
+
+def _make_wal_db(path: Path) -> Path:
+    conn = sqlite3.connect(str(path), timeout=5.0)
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.executemany("INSERT INTO t VALUES (?)", [(i,) for i in range(500)])
+    conn.commit()
+    # Keep the connection OPEN so the WAL is not auto-checkpointed on
+    # close — mirroring the long-lived daemon readers that stranded a
+    # week of tasks.db writes in the -wal live.
+    return path
+
+
+def test_checkpoint_db_truncates_wal(tmp_path):
+    db = _make_wal_db(tmp_path / "store.db")
+    wal = Path(str(db) + "-wal")
+    assert wal.exists() and wal.stat().st_size > 0, "setup: WAL not populated"
+    assert sm.checkpoint_db(db) is True
+    assert wal.stat().st_size == 0, (
+        "wal_checkpoint(TRUNCATE) must fold the -wal back into the db")
+
+
+def test_checkpoint_db_missing_file_is_false_not_raise(tmp_path):
+    assert sm.checkpoint_db(tmp_path / "nope.db") is False
+
+
+def test_interval_env(monkeypatch):
+    monkeypatch.delenv("PRISM_SQLITE_MAINT_INTERVAL_S", raising=False)
+    assert sm.maint_interval_s() == float(sm.DEFAULT_INTERVAL_S)
+    monkeypatch.setenv("PRISM_SQLITE_MAINT_INTERVAL_S", "60")
+    assert sm.maint_interval_s() == 60.0
+    monkeypatch.setenv("PRISM_SQLITE_MAINT_INTERVAL_S", "0")
+    assert sm.maint_interval_s() == 0.0  # 0 = disabled
+    monkeypatch.setenv("PRISM_SQLITE_MAINT_INTERVAL_S", "junk")
+    assert sm.maint_interval_s() == float(sm.DEFAULT_INTERVAL_S)

--- a/services/prism-service/tests/unit/test_task_service_concurrency.py
+++ b/services/prism-service/tests/unit/test_task_service_concurrency.py
@@ -94,62 +94,11 @@ def test_concurrent_reads_writes_race_free(tmp_path):
             f"found {len(rows)} — lost writes")
 
 
-# ── AC-2: 3-child fan_out with NO serialization shim ───────────────────
-
-class UnshimmedEngine:
-    """Engine stub that touches the SHARED TaskService concurrently with
-    NO db lock — unlike test_drive_fanout's InstrumentedEngine shim, the
-    db work here happens raw on the drive thread (production shape)."""
-
-    def __init__(self, task_svc, ops: int = 15):
-        self.task_svc = task_svc
-        self.ops = ops
-        self.errors: list[str] = []
-
-    def plan(self, task_id: str, session_id: str = "", **kwargs) -> dict:
-        try:
-            for i in range(self.ops):
-                got = self.task_svc.get(task_id)
-                if got is None:
-                    self.errors.append(f"{task_id}: None mid-drive read")
-                self.task_svc.update(task_id, priority=i)
-            self.task_svc.update(
-                task_id, status="done",
-                completion_proof="unshimmed drive walked the row "
-                                 f"{self.ops}x and finished it")
-        except Exception as exc:  # noqa: BLE001 — the race IS the finding
-            self.errors.append(f"{task_id}: {type(exc).__name__}: {exc}")
-            return {"ok": False, "task_id": task_id,
-                    "reason": f"db race: {exc}", "stats": {"overrides": 0}}
-        return {"ok": True, "task_id": task_id, "final_step": "plan_gate",
-                "gate_state": "passed", "stats": {"overrides": 0}}
-
-
-def test_fanout_with_unserialized_task_service(tmp_path):
-    from prism_service.services import drive_fanout as df
-    for rnd in range(ROUNDS):
-        svc = _task_svc(tmp_path, name=f"fanout-{rnd}.db")
-        epic = svc.create(title="unshimmed fan-out epic")
-        kids = [
-            svc.create(title=f"unshimmed child {i}", parent_id=epic.id,
-                       allowed_files=[f"file_{i}.py"], proof_type="test",
-                       oracle=f"child {i} oracle")
-            for i in range(3)
-        ]
-        eng = UnshimmedEngine(svc)
-        res = df.fan_out(epic.id, engine=eng, task_svc=svc,
-                         session_id="unshimmed-test", max_parallel=3)
-        assert eng.errors == [], (
-            f"round {rnd}: db races inside concurrent drives; "
-            f"first 5: {eng.errors[:5]}")
-        assert res["ok"] is True, f"round {rnd}: {res}"
-        assert res["stats"]["max_concurrent"] >= 2, (
-            f"round {rnd}: no genuine overlap — the concurrency this "
-            f"test exists to prove did not happen: {res['stats']}")
-        for k in kids:
-            row = svc.get(k.id)
-            assert row is not None and row.status == "done", (
-                f"round {rnd}: child {k.id} not done after fan_out")
+# NOTE: the original RED scaffold also carried an AC-2 fan-out test that
+# exercised prism_service.services.drive_fanout — that module lives on the
+# unmerged drive-engine branch (feat/task-store-concurrency stack), so the
+# test was dropped when cherry-picking onto main. AC-1 (hammer) and AC-3
+# (per-thread connections) fully pin the fix.
 
 
 # ── AC-3: connections are per-thread ───────────────────────────────────

--- a/services/prism-service/tests/unit/test_task_service_concurrency.py
+++ b/services/prism-service/tests/unit/test_task_service_concurrency.py
@@ -1,0 +1,178 @@
+"""RED scaffold — thread-safe task storage for concurrent drives
+(task 0584addb, follow-up to the C7 fan-out build f6328e9e / PR #196).
+
+Pins: TaskService must survive genuinely CONCURRENT reads/writes from
+N threads against one tasks.db file. Today __init__ binds ONE shared
+sqlite3 connection (check_same_thread=False) used by every method, so
+concurrent drives interleave statements/commits on a single handle —
+observed None reads and "cannot commit - no transaction is active"
+(memory mx-655f08). The fix is per-thread connections via a
+thread-local connection factory (WAL + busy_timeout stay as
+complements, NOT the fix); explicitly NOT a global serialize-everything
+lock and NOT WAL-only.
+
+FAILS today: the shared connection races under the hammer (AC-1), the
+un-shimmed fan-out engine stub races (AC-2), and both threads observe
+the SAME connection object (AC-3).
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+
+def _task_svc(tmp_path, name="tasks.db"):
+    from prism_service.services.task_service import TaskService
+    return TaskService(str(tmp_path / name))
+
+
+# Enough contention to make the shared-connection race deterministic:
+# rounds x threads x ops keeps the budget bounded (~seconds) while the
+# single-handle code trips within the first round in practice.
+ROUNDS = 6
+THREADS = 8
+OPS = 25
+
+
+def _hammer(svc, thread_idx: int, errors: list, barrier) -> None:
+    """One worker: create -> get (must not be None) -> update -> get,
+    recording every anomaly instead of raising so the main thread can
+    assert on the full picture."""
+    barrier.wait()
+    for i in range(OPS):
+        label = f"t{thread_idx}-op{i}"
+        try:
+            task = svc.create(title=f"hammer {label}")
+            got = svc.get(task.id)
+            if got is None:
+                errors.append(f"{label}: None read of a row just created")
+                continue
+            upd = svc.update(task.id, priority=i, description=label)
+            if upd is None:
+                errors.append(f"{label}: update() returned None for an "
+                              "existing row")
+                continue
+            again = svc.get(task.id)
+            if again is None:
+                errors.append(f"{label}: None read after update")
+            elif again.description != label:
+                errors.append(f"{label}: torn read — description "
+                              f"{again.description!r} != {label!r}")
+        except Exception as exc:  # noqa: BLE001 — the race IS the finding
+            errors.append(f"{label}: {type(exc).__name__}: {exc}")
+
+
+# ── AC-1: N threads hammer one TaskService with zero races ─────────────
+
+def test_concurrent_reads_writes_race_free(tmp_path):
+    for rnd in range(ROUNDS):
+        svc = _task_svc(tmp_path, name=f"tasks-{rnd}.db")
+        errors: list[str] = []
+        barrier = threading.Barrier(THREADS)
+        threads = [
+            threading.Thread(target=_hammer, args=(svc, t, errors, barrier))
+            for t in range(THREADS)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        assert errors == [], (
+            f"round {rnd}: {len(errors)} race(s) under {THREADS} threads "
+            f"x {OPS} ops; first 5: {errors[:5]}")
+        # Consistency: every created row must be present and readable.
+        rows = svc.list()
+        assert len(rows) == THREADS * OPS, (
+            f"round {rnd}: expected {THREADS * OPS} rows, "
+            f"found {len(rows)} — lost writes")
+
+
+# ── AC-2: 3-child fan_out with NO serialization shim ───────────────────
+
+class UnshimmedEngine:
+    """Engine stub that touches the SHARED TaskService concurrently with
+    NO db lock — unlike test_drive_fanout's InstrumentedEngine shim, the
+    db work here happens raw on the drive thread (production shape)."""
+
+    def __init__(self, task_svc, ops: int = 15):
+        self.task_svc = task_svc
+        self.ops = ops
+        self.errors: list[str] = []
+
+    def plan(self, task_id: str, session_id: str = "", **kwargs) -> dict:
+        try:
+            for i in range(self.ops):
+                got = self.task_svc.get(task_id)
+                if got is None:
+                    self.errors.append(f"{task_id}: None mid-drive read")
+                self.task_svc.update(task_id, priority=i)
+            self.task_svc.update(
+                task_id, status="done",
+                completion_proof="unshimmed drive walked the row "
+                                 f"{self.ops}x and finished it")
+        except Exception as exc:  # noqa: BLE001 — the race IS the finding
+            self.errors.append(f"{task_id}: {type(exc).__name__}: {exc}")
+            return {"ok": False, "task_id": task_id,
+                    "reason": f"db race: {exc}", "stats": {"overrides": 0}}
+        return {"ok": True, "task_id": task_id, "final_step": "plan_gate",
+                "gate_state": "passed", "stats": {"overrides": 0}}
+
+
+def test_fanout_with_unserialized_task_service(tmp_path):
+    from prism_service.services import drive_fanout as df
+    for rnd in range(ROUNDS):
+        svc = _task_svc(tmp_path, name=f"fanout-{rnd}.db")
+        epic = svc.create(title="unshimmed fan-out epic")
+        kids = [
+            svc.create(title=f"unshimmed child {i}", parent_id=epic.id,
+                       allowed_files=[f"file_{i}.py"], proof_type="test",
+                       oracle=f"child {i} oracle")
+            for i in range(3)
+        ]
+        eng = UnshimmedEngine(svc)
+        res = df.fan_out(epic.id, engine=eng, task_svc=svc,
+                         session_id="unshimmed-test", max_parallel=3)
+        assert eng.errors == [], (
+            f"round {rnd}: db races inside concurrent drives; "
+            f"first 5: {eng.errors[:5]}")
+        assert res["ok"] is True, f"round {rnd}: {res}"
+        assert res["stats"]["max_concurrent"] >= 2, (
+            f"round {rnd}: no genuine overlap — the concurrency this "
+            f"test exists to prove did not happen: {res['stats']}")
+        for k in kids:
+            row = svc.get(k.id)
+            assert row is not None and row.status == "done", (
+                f"round {rnd}: child {k.id} not done after fan_out")
+
+
+# ── AC-3: connections are per-thread ───────────────────────────────────
+
+def test_connections_are_per_thread(tmp_path):
+    svc = _task_svc(tmp_path)
+    seen: dict[str, list] = {"main": [], "worker": []}
+
+    # Same thread twice -> the SAME connection (cached, not per-call).
+    seen["main"].append(id(svc._db))
+    seen["main"].append(id(svc._db))
+    assert seen["main"][0] == seen["main"][1], (
+        "a single thread must reuse its own connection")
+
+    def grab():
+        seen["worker"].append(id(svc._db))
+        # The worker's connection must WORK (reads real rows).
+        assert svc.list() == []
+
+    t = threading.Thread(target=grab)
+    t.start()
+    t.join(timeout=30)
+    assert seen["worker"], "worker thread never observed a connection"
+    assert seen["worker"][0] != seen["main"][0], (
+        "distinct threads must observe DISTINCT sqlite connections — a "
+        "single shared handle is the race PR #196 documented")


### PR DESCRIPTION
## What

Audit-driven SQLite hardening (stress-verified findings):

- **timeout=5.0 on every per-call `sqlite3.connect`** (~30 sites: adaptive_policy, consolidation_data, event_handlers, learning_data, agent_runs_data, reflection_runner/worker, api/consolidation, api/dashboard, api/graph, api/projects, routes/graph_static, memory_ops). Stress test measured **97.6% lock-error rate at 8 concurrent writers without busy_timeout vs 0.0% with it**.
- **Per-thread connections** (threading.local lazy property) for the four services that shared one Connection across threads: task_service (cherry-picked from feat/task-store-concurrency: c652cb8 + RED test, drive_fanout-dependent case dropped), brain_engine, janitor_service, memory recall_log. Shared-Connection stress showed **16.4% InterfaceError/SystemError corruption under 12 threads**.
- **API fallbacks now log before returning defaults** (dashboard/graph/projects/graph_static) instead of silently swallowing sqlite errors.
- **Periodic WAL maintenance**: asyncio loop (env-tunable `PRISM_SQLITE_MAINT_INTERVAL_S`, default ~15min, 0=off) runs `wal_checkpoint(TRUNCATE)` + `PRAGMA optimize` over every project store + on graceful shutdown. Live symptom fixed: tasks.db main file was a week stale with all writes stranded in a 2.7MB -wal; scores.db -wal was 3.3x the db.
- **Hot-query indexes on tasks.db** (task_history(task_id,timestamp) + task list paths), created after column migration on startup — task-detail was full-scanning.
- Version 6.7.22 → 6.7.24.

## Verification

Full unit suite in the agent worktree: **962 passed, 0 failed** (71.9s), `prism_service` import verified resolving inside the worktree. No live DBs or daemons touched; stress tests ran against scratchpad copies only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)