### PR TITLE
perf(conductor): incremental transcript tail-parser — stop re-reading the whole file every poll

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,22 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.27"
+PRISM_VERSION = "6.7.28"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.28: conductor live-token reads are now INCREMENTAL. The ~5s poll "
+    "called _sum_billable_tokens / _token_events, which re-read + json.loads "
+    "the ENTIRE transcript on every (mtime,size) cache miss — and an "
+    "in-progress session's file grows every turn, so it missed every tick "
+    "(~10MB/s re-parse per active session, worse since v6.7.23's 4-field "
+    "sums). Now a shared _read_new_lines seeks to the last consumed byte "
+    "offset and folds ONLY appended complete lines into the cached total/"
+    "timeline; truncation/rotation (shrink) forces a full re-parse and a "
+    "partial trailing line is never counted until completed. Totals stay "
+    "byte-identical to a cold parse; benchmark on a 3.8MB/20k-turn transcript: "
+    "per-tick bytes read drop ~19,000x (tail only) and wall-clock ~8x. Nested "
+    "subagent transcripts benefit for free (same summers). "
     "v6.7.27: conductor session gate — a task can no longer be handed to the "
     "conductor without a linked session (sessionless tiles rendered FROZEN: no "
     "transcript, no tokens, no live signals). Sessionless enter_conductor at "

--- a/services/prism-service/prism_service/services/claude_transcripts.py
+++ b/services/prism-service/prism_service/services/claude_transcripts.py
@@ -854,38 +854,81 @@ def _project_source_path(project_id: str) -> str:
 # so the 5s conductor poll never re-reads an unchanged multi-MB transcript.
 # ---------------------------------------------------------------------------
 
-# path -> (mtime, size, total_tokens)
-_TOKEN_CACHE: dict[str, tuple[float, int, int]] = {}
+# path -> (mtime, size, offset, total_tokens). `offset` is the byte position
+# up to the last COMPLETE line already folded into `total`; a growing file is
+# read only from `offset` to EOF each poll (see _read_new_lines).
+_TOKEN_CACHE: dict[str, tuple[float, int, int, int]] = {}
+
+
+def _read_new_lines(
+    path: Path, st: os.stat_result,
+    cached: tuple[float, int, int, object] | None,
+) -> tuple[list[str], int, str]:
+    """Return (complete_lines, new_offset, mode) for an append-mostly JSONL.
+
+    mode is one of:
+      'hit'   file unchanged since the cache — no read, [] lines.
+      'grew'  file strictly larger and clock not rewound — read ONLY the
+              bytes from cached offset to EOF (the appended tail).
+      'reset' shrank / rewritten / no cache — read the whole file from 0.
+
+    Only bytes up to the LAST newline are consumed; a trailing fragment
+    (a partial last line the writer is still appending) is left unconsumed
+    so it is re-read once completed. `new_offset` is the byte position after
+    the last complete line. Raises OSError to the caller on read failure."""
+    size = st.st_size
+    if cached is not None:
+        c_mtime, c_size, c_offset, _ = cached
+        if c_mtime == st.st_mtime and c_size == size:
+            return [], c_offset, "hit"
+        if size > c_size and st.st_mtime >= c_mtime and c_offset <= size:
+            start, mode = c_offset, "grew"
+        else:
+            start, mode = 0, "reset"
+    else:
+        start, mode = 0, "reset"
+    with open(path, "rb") as fh:
+        fh.seek(start)
+        chunk = fh.read()
+    nl = chunk.rfind(b"\n")
+    if nl == -1:
+        # No complete line in the new bytes — consume nothing this poll.
+        return [], start, mode
+    consumed = chunk[: nl + 1]
+    text = consumed.decode("utf-8", errors="replace")
+    return text.splitlines(), start + len(consumed), mode
 
 
 def _sum_billable_tokens(path: Path) -> int:
     """Sum ALL usage token fields (sum_usage: output + input + cache_read +
-    cache_creation) across one transcript JSONL. Cached on
-    (mtime, size) so unchanged files cost nothing on repeat polls."""
+    cache_creation) across one transcript JSONL. Incremental: a growing file
+    is re-read only from the last consumed byte offset, so the ~5s conductor
+    poll never re-parses the whole multi-MB transcript on every tick."""
     try:
         st = path.stat()
     except OSError:
         return 0
     key = str(path)
     cached = _TOKEN_CACHE.get(key)
-    if cached and cached[0] == st.st_mtime and cached[1] == st.st_size:
-        return cached[2]
-    total = 0
     try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                evt = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            usage = (evt.get("message") or {}).get("usage") or {}
-            if usage:
-                total += sum_usage(usage)
+        lines, new_offset, mode = _read_new_lines(path, st, cached)
     except OSError:
-        return cached[2] if cached else 0
-    _TOKEN_CACHE[key] = (st.st_mtime, st.st_size, total)
+        return cached[3] if cached else 0
+    if mode == "hit":
+        return cached[3]  # type: ignore[index]
+    total = cached[3] if (mode == "grew" and cached) else 0
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = (evt.get("message") or {}).get("usage") or {}
+        if usage:
+            total += sum_usage(usage)
+    _TOKEN_CACHE[key] = (st.st_mtime, st.st_size, new_offset, total)
     return total
 
 
@@ -976,12 +1019,13 @@ def live_tokens_for_session(
     return total
 
 
-# path -> (mtime, size, [(epoch_s, tokens), ...]) — tokens per sum_usage (all
-# four usage fields). Same (mtime,size)
-# caching discipline as _sum_billable_tokens, but a KEYED timeline of assistant
-# turns so token spend can be attributed to a wall-clock window (e.g. the
-# turn-to-turn interval on the task-detail timeline).
-_TOKEN_EVENTS_CACHE: dict[str, tuple[float, int, list[tuple[float, int]]]] = {}
+# path -> (mtime, size, offset, [(epoch_s, tokens), ...]) — tokens per
+# sum_usage (all four usage fields). Same incremental discipline as
+# _sum_billable_tokens (offset = last consumed complete-line byte), but a
+# KEYED timeline of assistant turns so token spend can be attributed to a
+# wall-clock window (e.g. the turn-to-turn interval on the task-detail
+# timeline).
+_TOKEN_EVENTS_CACHE: dict[str, tuple[float, int, int, list[tuple[float, int]]]] = {}
 
 
 def _parse_iso_epoch(ts: str) -> float | None:
@@ -996,38 +1040,41 @@ def _parse_iso_epoch(ts: str) -> float | None:
 
 
 def _token_events(path: Path) -> list[tuple[float, int]]:
-    """Per-assistant-turn (timestamp_epoch, output_tokens) for one transcript,
-    sorted ascending. Cached on (mtime, size) so a steady file costs nothing."""
+    """Per-assistant-turn (timestamp_epoch, billable_tokens) for one
+    transcript, sorted ascending. Incremental: a growing file folds only its
+    appended turns into the cached timeline (same offset discipline as
+    _sum_billable_tokens), so a steady file costs nothing on repeat polls."""
     try:
         st = path.stat()
     except OSError:
         return []
     key = str(path)
     cached = _TOKEN_EVENTS_CACHE.get(key)
-    if cached and cached[0] == st.st_mtime and cached[1] == st.st_size:
-        return cached[2]
-    out: list[tuple[float, int]] = []
     try:
-        for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                evt = json.loads(line)
-            except json.JSONDecodeError:
-                continue
-            usage = (evt.get("message") or {}).get("usage") or {}
-            tok = sum_usage(usage)
-            if tok <= 0:
-                continue
-            ep = _parse_iso_epoch(evt.get("timestamp") or "")
-            if ep is None:
-                continue
-            out.append((ep, tok))
+        lines, new_offset, mode = _read_new_lines(path, st, cached)
     except OSError:
-        return cached[2] if cached else []
+        return cached[3] if cached else []
+    if mode == "hit":
+        return cached[3]  # type: ignore[index]
+    out: list[tuple[float, int]] = list(cached[3]) if (mode == "grew" and cached) else []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            evt = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        usage = (evt.get("message") or {}).get("usage") or {}
+        tok = sum_usage(usage)
+        if tok <= 0:
+            continue
+        ep = _parse_iso_epoch(evt.get("timestamp") or "")
+        if ep is None:
+            continue
+        out.append((ep, tok))
     out.sort(key=lambda e: e[0])
-    _TOKEN_EVENTS_CACHE[key] = (st.st_mtime, st.st_size, out)
+    _TOKEN_EVENTS_CACHE[key] = (st.st_mtime, st.st_size, new_offset, out)
     return out
 
 

--- a/services/prism-service/tests/unit/test_transcript_tail_parser.py
+++ b/services/prism-service/tests/unit/test_transcript_tail_parser.py
@@ -1,0 +1,206 @@
+"""RED tests for the incremental transcript tail-parser (task 88a5b228).
+
+Every ~5s conductor poll re-reads and json.loads the ENTIRE transcript
+whenever the (mtime,size) cache key misses -- and an in-progress session's
+file grows every turn, so the cache misses on every poll. These tests pin
+the incremental contract: on growth, only appended bytes are read; totals
+and event lists stay byte-identical to a cold parse; truncation/rotation
+forces a full re-parse; a partial trailing line is never counted until it
+is completed.
+
+The incrementality tests (AC-1, AC-5) FAIL on main because the summers
+full-read the file on every cache miss. The correctness tests (AC-2..AC-4)
+guard the incremental path against regressions.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from prism_service.services import claude_transcripts as ct
+
+
+def _line(out: int, inp: int = 0, cr: int = 0, cc: int = 0, ts: str | None = None) -> str:
+    """One assistant transcript line carrying a usage block.
+    Billable per sum_usage = out + inp + cr + cc."""
+    evt = {"type": "assistant", "message": {"usage": {
+        "output_tokens": out, "input_tokens": inp,
+        "cache_read_input_tokens": cr, "cache_creation_input_tokens": cc,
+    }}}
+    if ts is not None:
+        evt["timestamp"] = ts
+    return json.dumps(evt)
+
+
+def _write(path, lines, *, trailing_newline=True):
+    text = "\n".join(lines)
+    if trailing_newline and lines:
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _bump_mtime(path):
+    """Force a distinct, larger mtime so a same-second append is still seen."""
+    st = path.stat()
+    os.utime(path, (st.st_atime, st.st_mtime + 2))
+
+
+@pytest.fixture(autouse=True)
+def _clear_caches():
+    ct._TOKEN_CACHE.clear()
+    ct._TOKEN_EVENTS_CACHE.clear()
+    yield
+    ct._TOKEN_CACHE.clear()
+    ct._TOKEN_EVENTS_CACHE.clear()
+
+
+class _ByteCounter:
+    """Wrap Path.read_text and builtins.open so a test can measure how many
+    bytes a summer physically pulled from ONE target path during a call.
+    A full re-read counts ~file size; an incremental read counts ~tail size."""
+
+    def __init__(self, monkeypatch, target):
+        self.target = str(target)
+        self.bytes_read = 0
+        real_read_text = ct.Path.read_text
+        real_open = open
+
+        def counting_read_text(path_self, *a, **k):
+            data = real_read_text(path_self, *a, **k)
+            if str(path_self) == self.target:
+                self.bytes_read += len(data.encode("utf-8", "replace"))
+            return data
+
+        def counting_open(file, *a, **k):
+            fh = real_open(file, *a, **k)
+            mode = k.get("mode", a[0] if a else "r")
+            if str(file) == self.target and "b" in mode:
+                return _CountingBinary(fh, self)
+            return fh
+
+        monkeypatch.setattr(ct.Path, "read_text", counting_read_text)
+        monkeypatch.setattr("builtins.open", counting_open)
+
+
+class _CountingBinary:
+    def __init__(self, fh, counter):
+        self._fh = fh
+        self._counter = counter
+
+    def read(self, *a, **k):
+        data = self._fh.read(*a, **k)
+        self._counter.bytes_read += len(data)
+        return data
+
+    def __getattr__(self, name):
+        return getattr(self._fh, name)
+
+    def __enter__(self):
+        self._fh.__enter__()
+        return self
+
+    def __exit__(self, *a):
+        return self._fh.__exit__(*a)
+
+
+# --- AC-1: append re-reads only appended bytes; total == cold parse ---------
+
+def test_append_reads_only_new_bytes_and_total_matches_cold(tmp_path, monkeypatch):
+    p = tmp_path / "s.jsonl"
+    _write(p, [_line(100), _line(50)])
+    assert ct._sum_billable_tokens(p) == 150            # cold parse -> cache
+
+    _write(p, [_line(100), _line(50), _line(7)])        # append one line
+    _bump_mtime(p)
+    counter = _ByteCounter(monkeypatch, p)
+    total = ct._sum_billable_tokens(p)
+
+    assert total == 157, "incremental total must equal a cold full parse"
+    appended = len((_line(7) + "\n").encode("utf-8"))
+    assert counter.bytes_read <= appended * 2, (
+        f"expected to read only the appended tail (~{appended}B), read "
+        f"{counter.bytes_read}B -- summer is not incremental"
+    )
+
+
+# --- AC-2: truncation/rotation forces a full re-parse -----------------------
+
+def test_truncation_triggers_full_reparse(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write(p, [_line(100), _line(100), _line(100)])
+    assert ct._sum_billable_tokens(p) == 300
+
+    _write(p, [_line(5)])                                # smaller -> rotation
+    _bump_mtime(p)
+    assert ct._sum_billable_tokens(p) == 5, (
+        "a shrunk file must be fully re-parsed, not served from a stale offset"
+    )
+
+
+# --- AC-3: partial trailing line not counted until completed ----------------
+
+def test_partial_trailing_line_counted_once_when_completed(tmp_path):
+    p = tmp_path / "s.jsonl"
+    _write(p, [_line(100)])
+    assert ct._sum_billable_tokens(p) == 100
+
+    full = _line(40)
+    half = full[: len(full) // 2]                        # truncated json, no newline
+    p.write_text(_line(100) + "\n" + half, encoding="utf-8")
+    _bump_mtime(p)
+    assert ct._sum_billable_tokens(p) == 100, "a partial last line must not be counted"
+
+    p.write_text(_line(100) + "\n" + full + "\n", encoding="utf-8")
+    _bump_mtime(p)
+    assert ct._sum_billable_tokens(p) == 140, (
+        "completing the line must count it exactly once (not zero, not twice)"
+    )
+
+
+# --- AC-4: _token_events incremental list == cold parse ---------------------
+
+def test_token_events_incremental_matches_cold(tmp_path):
+    p = tmp_path / "s.jsonl"
+    base = [_line(10, ts="2026-07-04T10:00:00Z"),
+            _line(20, ts="2026-07-04T10:00:05Z")]
+    _write(p, base)
+    ct._token_events(p)                                  # warm
+
+    for i, extra in enumerate([
+        _line(30, ts="2026-07-04T10:00:10Z"),
+        _line(40, ts="2026-07-04T10:00:15Z"),
+        _line(50, ts="2026-07-04T10:00:20Z"),
+    ]):
+        base.append(extra)
+        _write(p, base)
+        _bump_mtime(p)
+        incremental = ct._token_events(p)
+
+        ct._TOKEN_EVENTS_CACHE.clear()
+        cold = ct._token_events(p)
+        assert incremental == cold, f"round {i}: incremental events != cold parse"
+
+
+# --- AC-5: per-poll work after append >=10x cheaper on a large transcript ----
+
+def test_large_transcript_incremental_is_10x_cheaper(tmp_path, monkeypatch):
+    p = tmp_path / "big.jsonl"
+    lines = [_line(10, inp=5, cr=1000, ts=f"2026-07-04T{i // 3600:02d}:{(i // 60) % 60:02d}:{i % 60:02d}Z")
+             for i in range(20000)]
+    _write(p, lines)
+    size = p.stat().st_size
+    assert size > 3_000_000, f"fixture should be multi-MB, got {size}B"
+    ct._sum_billable_tokens(p)                           # warm the cache
+
+    lines.append(_line(9))
+    _write(p, lines)
+    _bump_mtime(p)
+    counter = _ByteCounter(monkeypatch, p)
+    ct._sum_billable_tokens(p)
+
+    assert counter.bytes_read <= size / 10, (
+        f"incremental poll read {counter.bytes_read}B of a {size}B file -- "
+        "expected <=10% (appended tail only)"
+    )


### PR DESCRIPTION
## What
Conductor task `88a5b228` (audit-2026-07-03 perf lane), driven through the full PRISM conductor SDLC (story/plan rubric-passed + red/green gates, each independently verified by a distinct actor).

The ~5s conductor poll calls `_sum_billable_tokens` / `_token_events`, which re-read + `json.loads` the ENTIRE transcript on every `(mtime,size)` cache miss. An in-progress session's file grows every turn, so the cache misses on **every** tick — ~10MB/s of continuous re-parse per active session, worse since v6.7.23's 4-field sums.

## Change
A shared `_read_new_lines(path, st, cached)` seeks to the last-consumed byte offset and folds only appended **complete** lines into the cached total / event timeline:
- **hit** — unchanged file, no read
- **grew** — strictly larger + clock not rewound → read only the appended tail
- **reset** — shrink/rotation/no-cache → full re-parse
- a partial trailing line (writer mid-append) is never counted until completed

Both summers widen their cache tuple to `(mtime, size, offset, payload)`. No public API change; nested subagent transcripts benefit via the same summers.

## Proof
- New `tests/unit/test_transcript_tail_parser.py` — 5/5 green (AC-1..AC-5). RED at c695f0f: the 2 incrementality tests failed on main (read whole file); independently re-confirmed non-vacuous (reverting only the source re-fails them).
- Full `pytest tests/unit`: **995 passed, 0 failed**.
- Benchmark, 3.82MB / 20k-turn transcript: per-tick bytes read **~19,000× fewer** (tail only), wall-clock **58ms → 7ms (8×)**, incremental total byte-identical to a cold parse.

Version 6.7.27 → 6.7.28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)