### PR TITLE
feat(task-detail): unified Conductor+Activity Implementation panel + unblock Workflow tool

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,3 +4,8 @@
 .seeds/templates.jsonl merge=union
 .canopy/prompts.jsonl merge=union
 .canopy/schemas.jsonl merge=union
+
+# Workflow scripts are read by the Claude Code harness as the approval
+# "script"; a CR (0x0d) trips its control-character check and blocks the
+# Workflow tool on Windows checkouts. Force LF so autocrlf never re-adds CRs.
+.claude/workflows/*.js text eol=lf

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,23 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.29"
+PRISM_VERSION = "6.7.30"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.30: task-detail Conductor + Activity folded into ONE panel. The "
+    "separate Conductor stepper card and the empty-space Activity Gantt "
+    "(one thin bar + ~3px gate diamonds on a single-session task) are gone; "
+    "the PlanView tab panel gains an Implementation tab (tabs: Prototype · "
+    "Diagram · Proposed change · Implementation). New StepRail.tsx is a "
+    "compact collapsible rail: finished agent steps fold into a "
+    "'✓ N completed steps · show' pill, and each GATE is a one-liner that "
+    "expands in place to its real timeline.gates[] receipt (verified✓ vs "
+    "override! + actor · proof_type · timestamp · reason). The sub-agent "
+    "lock-step Gantt survives behind a Rail/Timeline sub-toggle. No backend "
+    "change; palette stays OKF-single-source. Also ships .gitattributes "
+    "*.js eol=lf so autocrlf can't re-add the CRs that tripped the Workflow "
+    "tool's control-character check on Windows checkouts. "
     "v6.7.29: workflow daemon-IDENTITY preflight. The implement.js pre-flight "
     "proved the conductor daemon on :8888 was reachable but NOT that the "
     "drive's MCP tools pointed at that SAME daemon — a duplicate ~/.claude.json "

--- a/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
@@ -1,0 +1,260 @@
+// Compact, collapsible SDLC rail — the "Implementation" tab's default view.
+// One line per phase down a git-graph spine; each GATE is a one-liner that
+// expands in place to its full receipt (badge · verified/override actor ·
+// proof · reason). Completed agent steps fold into a single pill so the panel
+// stays short on the task screen. Reads REAL data only: workflow_step (current),
+// gate_state (pending gate), and timeline.gates[] (resolved-gate receipts) —
+// nothing per-step is fabricated. Companion to SdlcProgress (minimap) and
+// TaskActivityGantt (the wall-clock Timeline sub-view).
+import { useState } from "react";
+import { motion } from "motion/react";
+import { WORKFLOW_STEPS_ORDERED, stepLabel } from "@/lib/workflowChips";
+import type { PhaseProgress } from "./SdlcProgress";
+import type { GanttGate } from "./TaskActivityGantt";
+
+const PERSONA_TONE: Record<string, string> = { sm: "teal", dev: "amber", qa: "violet" };
+
+function clockHM(ts: number): string {
+  try {
+    return new Date(ts * 1000).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+type GateInfo = { state: "passed" | "override" | "pending" | "future"; g?: GanttGate };
+
+export default function StepRail({
+  step, gateState, phase, status, gates, reduced,
+}: {
+  step?: string;
+  gateState?: string;
+  phase?: PhaseProgress | null;
+  status?: string;
+  gates: GanttGate[];
+  reduced?: boolean | null;
+}) {
+  const steps = WORKFLOW_STEPS_ORDERED;
+  const curIdx = steps.findIndex((s) => s.id === step);
+  const live = (status ?? "").toLowerCase() === "in_progress";
+  const [open, setOpen] = useState<string | null>(null);
+  const [collapseDone, setCollapseDone] = useState(true);
+
+  const gateFor = (id: string) => gates.find((g) => id === `${g.gate}_gate`);
+  const gateInfo = (id: string, i: number): GateInfo => {
+    const g = gateFor(id);
+    if (g) return { state: g.override ? "override" : "passed", g };
+    if (curIdx >= 0 && i < curIdx) return { state: "passed" };
+    if (i === curIdx) return { state: (gateState === "pending" ? "pending" : gateState === "failed" ? "pending" : "future") };
+    return { state: "future" };
+  };
+
+  // Build render items, folding runs of completed AGENT steps into one pill.
+  type Item = { kind: "step"; s: (typeof steps)[number]; i: number } | { kind: "fold"; names: string[]; i: number };
+  const items: Item[] = [];
+  let pend: { s: (typeof steps)[number]; i: number }[] = [];
+  const flush = () => {
+    if (!pend.length) return;
+    items.push({ kind: "fold", names: pend.map((p) => stepLabel(p.s.id)), i: pend[0].i });
+    pend = [];
+  };
+  steps.forEach((s, i) => {
+    const done = curIdx >= 0 && i < curIdx;
+    const isDoneAgent = done && s.type !== "gate";
+    if (collapseDone && isDoneAgent) { pend.push({ s, i }); return; }
+    flush();
+    items.push({ kind: "step", s, i });
+  });
+  flush();
+
+  const railHasCur = curIdx >= 0;
+
+  return (
+    <div className="mt-3 select-none">
+      <div className="flex items-center justify-end mb-1">
+        <button
+          onClick={() => setCollapseDone((v) => !v)}
+          className="text-[10px] uppercase tracking-wider font-mono px-2.5 py-1 rounded border border-[color:var(--border-default)] text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]"
+        >
+          {collapseDone ? "⊞ Expand done" : "⊟ Collapse done"}
+        </button>
+      </div>
+
+      {items.map((it) => {
+        if (it.kind === "fold") {
+          const first = it.i === 0;
+          return (
+            <div key={`fold-${it.i}`} className="flex gap-3">
+              <Spine topHidden={first} filledTop={!first} filledBot />
+              <div className="flex-1 py-1">
+                <button
+                  onClick={() => setCollapseDone(false)}
+                  className="text-[10.5px] font-mono text-[color:var(--text-muted)] hover:text-[color:var(--text-secondary)] border border-dashed border-[color:var(--border-default)] rounded-md px-2.5 py-1.5 inline-flex items-center gap-2"
+                >
+                  <span style={{ color: "var(--accent-emerald-fg)" }}>✓</span>
+                  <span className="text-[color:var(--text-secondary)]">{it.names.length}</span>
+                  completed steps · {it.names.join(" · ")} · show
+                </button>
+              </div>
+            </div>
+          );
+        }
+        const { s, i } = it;
+        const done = curIdx >= 0 && i < curIdx;
+        const cur = i === curIdx;
+        const future = curIdx >= 0 && i > curIdx;
+        const isGate = s.type === "gate";
+        const gi = isGate ? gateInfo(s.id, i) : null;
+        const persona = (s as { persona?: string }).persona || "";
+        const rowOpen = open === s.id;
+
+        return (
+          <div key={s.id} className="flex gap-3">
+            <Spine
+              topHidden={i === 0}
+              filledTop={railHasCur && i <= curIdx}
+              filledBot={railHasCur && i < curIdx}
+              botHidden={i === steps.length - 1}
+              node={<Node isGate={isGate} gi={gi} done={done} cur={cur} live={live} reduced={reduced} />}
+            />
+            <div className="flex-1 min-w-0 py-1.5">
+              {isGate && gi && gi.state !== "future" ? (
+                <GateRow s={s} gi={gi} open={rowOpen} onToggle={() => setOpen(rowOpen ? null : s.id)} />
+              ) : (
+                <div className="flex items-center gap-2 min-h-[22px]">
+                  <Persona persona={persona} isGate={isGate} />
+                  <span className={"text-[13px] " + (future ? "text-[color:var(--text-disabled)]" : "text-[color:var(--text-primary)]")}>
+                    {stepLabel(s.id)}
+                  </span>
+                  {cur && !isGate && (
+                    <span className="ml-auto text-[10px] font-mono tabular-nums flex items-center gap-1.5" style={{ color: "var(--accent-teal-fg)" }}>
+                      <motion.span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: "var(--accent-teal-fg)" }}
+                        animate={!reduced ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
+                        transition={!reduced ? { duration: 1.2, repeat: Infinity } : { duration: 0.2 }} />
+                      {phase?.pct != null ? `${((curIdx >= 0 ? (curIdx + Math.min(1, phase.pct)) / steps.length : 0) * 100).toFixed(0)}%` : "working"}
+                    </span>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function Spine({ topHidden, botHidden, filledTop, filledBot, node }: {
+  topHidden?: boolean; botHidden?: boolean; filledTop?: boolean; filledBot?: boolean;
+  node?: React.ReactNode;
+}) {
+  const line = (fill?: boolean, hide?: boolean) => (
+    <div className="w-[2px] flex-1 min-h-[8px]" style={{
+      background: hide ? "transparent" : fill ? "var(--accent-emerald-ring)" : "var(--border-default)",
+    }} />
+  );
+  return (
+    <div className="w-[18px] flex-none flex flex-col items-center">
+      {line(filledTop, topHidden)}
+      {node ?? <span className="h-2 w-2 rounded-full my-0.5" style={{ background: "var(--accent-emerald-fg)" }} />}
+      {line(filledBot, botHidden)}
+    </div>
+  );
+}
+
+function Node({ isGate, gi, done, cur, live, reduced }: {
+  isGate: boolean; gi: GateInfo | null; done: boolean; cur: boolean; live: boolean; reduced?: boolean | null;
+}) {
+  const pulse = cur && live && !reduced
+    ? { animate: { boxShadow: ["0 0 0 0 rgba(94,234,212,0.5)", "0 0 0 5px rgba(94,234,212,0)"] }, transition: { duration: 1.3, repeat: Infinity } }
+    : {};
+  if (isGate && gi) {
+    const map: Record<string, { bg: string; fg: string; g: string }> = {
+      passed: { bg: "var(--accent-emerald-fg)", fg: "#06281c", g: "✓" },
+      override: { bg: "var(--accent-amber-fg)", fg: "#3a2a04", g: "!" },
+      pending: { bg: "var(--accent-amber-fg)", fg: "#3a2a04", g: "‽" },
+      future: { bg: "transparent", fg: "var(--text-muted)", g: "" },
+    };
+    const m = map[gi.state];
+    if (gi.state === "future") {
+      return <span className="mt-2 h-3 w-3 rotate-45 rounded-[2px] border-2" style={{ borderColor: "var(--accent-slate-ring)" }} />;
+    }
+    return (
+      <motion.span className="mt-2 h-3.5 w-3.5 rotate-45 rounded-[3px] grid place-items-center text-[8px] font-bold"
+        style={{ background: m.bg, color: m.fg }} {...(gi.state === "pending" ? pulse : {})}>
+        <span className="-rotate-45">{m.g}</span>
+      </motion.span>
+    );
+  }
+  if (done) return <span className="mt-2 h-3 w-3 rounded-full grid place-items-center text-[8px] font-bold" style={{ background: "var(--accent-emerald-fg)", color: "#06281c" }}>✓</span>;
+  if (cur) return <motion.span className="mt-2 h-3 w-3 rounded-full" style={{ background: "var(--accent-teal-fg)" }} {...pulse} />;
+  return <span className="mt-2 h-3 w-3 rounded-full border-2" style={{ borderColor: "var(--accent-slate-ring)" }} />;
+}
+
+function Persona({ persona, isGate }: { persona: string; isGate: boolean }) {
+  const tone = isGate ? "slate" : PERSONA_TONE[persona] || "slate";
+  const label = isGate ? "gate" : persona || "sdlc";
+  return (
+    <span className="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded flex-none"
+      style={{ background: `var(--accent-${tone}-bg)`, color: `var(--accent-${tone}-fg)` }}>
+      {label}
+    </span>
+  );
+}
+
+function GateRow({ s, gi, open, onToggle }: {
+  s: { id: string }; gi: GateInfo; open: boolean; onToggle: () => void;
+}) {
+  const [receipt, setReceipt] = useState(false);
+  const g = gi.g;
+  const override = gi.state === "override";
+  const badgeTone = gi.state === "pending" ? "amber" : "emerald";
+  const badgeLabel = gi.state === "pending" ? "pending" : "passed";
+  return (
+    <div>
+      <button onClick={onToggle} className="w-full flex items-center gap-2 min-h-[22px] text-left rounded-md px-1.5 -mx-1.5 hover:bg-[color:var(--surface-2)] transition-colors">
+        <Persona persona="" isGate />
+        <span className="text-[13px] text-[color:var(--text-primary)] whitespace-nowrap">{stepLabel(s.id)}</span>
+        <span className="ml-auto flex items-center gap-2 min-w-0">
+          <span className="text-[9px] font-mono font-bold uppercase tracking-wide px-1.5 py-0.5 rounded flex-none"
+            style={{ background: `var(--accent-${badgeTone}-fg)`, color: badgeTone === "amber" ? "#3a2a04" : "#06281c" }}>
+            {badgeLabel}
+          </span>
+          <span className="text-[11px] font-mono font-bold flex-none" style={{ color: override ? "var(--accent-amber-fg)" : "var(--accent-emerald-fg)" }}>
+            {override ? "!" : "✓"}
+          </span>
+          {g?.reason && <span className="text-[11.5px] text-[color:var(--text-muted)] truncate hidden sm:block">{g.reason}</span>}
+          <span className="text-[10px] font-mono text-[color:var(--text-muted)] flex-none transition-transform" style={{ transform: open ? "rotate(90deg)" : "none" }}>▸</span>
+        </span>
+      </button>
+      {open && g && (
+        <div className="mt-2 rounded-lg p-3 border"
+          style={{
+            borderColor: override ? "var(--accent-amber-ring)" : "var(--accent-emerald-ring)",
+            background: `linear-gradient(0deg, var(--accent-${override ? "amber" : "emerald"}-bg), transparent)`,
+          }}>
+          <div className="flex items-center gap-2 flex-wrap text-[10.5px] font-mono text-[color:var(--text-secondary)]">
+            <span className="font-bold" style={{ color: override ? "var(--accent-amber-fg)" : "var(--accent-emerald-fg)" }}>
+              {override ? "! override" : "✓ verified"}
+            </span>
+            <span>{g.actor || "—"}</span>
+            {g.proof && <span className="px-1.5 py-0.5 rounded text-[9px] uppercase" style={{ background: "var(--accent-violet-bg)", color: "var(--accent-violet-fg)" }}>{g.proof}</span>}
+            <span className="ml-auto text-[color:var(--text-muted)]">{clockHM(g.ts)}</span>
+          </div>
+          <div className="mt-2 text-[12.5px] text-[color:var(--text-secondary)] leading-relaxed">{g.reason}</div>
+          {g.reason && g.reason.length > 120 && (
+            <>
+              {receipt && (
+                <div className="mt-2 border-l-2 pl-2.5 font-mono text-[11px] text-[color:var(--text-muted)] whitespace-pre-wrap leading-relaxed"
+                  style={{ borderColor: "var(--border-strong)" }}>{g.reason}</div>
+              )}
+              <button onClick={() => setReceipt((v) => !v)} className="mt-1.5 text-[10px] font-mono" style={{ color: "var(--accent-teal-fg)" }}>
+                {receipt ? "▾ hide receipt" : "▸ full receipt"}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
+++ b/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
@@ -2,34 +2,73 @@ import { useState } from "react";
 import { Empty } from "@/components/ui";
 import Markdown from "@/components/Markdown";
 import Mermaid from "./Mermaid";
+import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import StepRail from "@/components/conductor/StepRail";
+import TaskActivityGantt, { type Timeline } from "@/components/conductor/TaskActivityGantt";
 
 /**
- * Renders a task plan as TABS in one place — Prototype (the clickable mock,
- * iframed), Diagram (Mermaid), and Proposed change (markdown) share the same
- * slot, toggled by a tab bar. Full-width (max-w-none) so the task page uses
- * the whole screen like /understand. Default tab is the Prototype when present.
+ * The task's work panel, as TABS in one slot — Prototype (clickable mock,
+ * iframed) · Diagram (Mermaid) · Proposed change (markdown) · Implementation
+ * (the conductor drive). The Implementation tab MERGES what used to be the
+ * separate Conductor + Activity cards: an SdlcProgress minimap, a compact
+ * collapsible StepRail (gates expand to their receipts), a Rail/Timeline
+ * sub-toggle onto the retained wall-clock TaskActivityGantt, and the pending-
+ * gate resolve form. "This is how we drive PRISM locally" — not a product tab.
+ * Full-width (max-w-none) so the task page uses the whole screen.
  */
+export type ConductorInfo = {
+  step?: string;
+  gateState?: string;
+  gateReason?: string;
+  phase?: PhaseProgress | null;
+  status?: string;
+  timeline?: Timeline | null;
+};
+export type GateControls = {
+  reason: string;
+  setReason: (s: string) => void;
+  override: boolean;
+  setOverride: (b: boolean) => void;
+  decide: (action: "approve" | "reject") => void;
+  busy: boolean;
+};
+
 export default function PlanView({
   diagram,
   doc,
   prototypeSrc,
+  conductor,
+  reduced,
+  gate,
+  onValidation,
 }: {
   diagram?: string;
   doc?: string;
   prototypeSrc?: string;
+  conductor?: ConductorInfo | null;
+  reduced?: boolean | null;
+  gate?: GateControls | null;
+  onValidation?: () => void;
 }) {
   const hasDiagram = !!diagram?.trim();
   const hasDoc = !!doc?.trim();
   const hasProto = !!prototypeSrc;
+  const hasImpl = !!conductor && !!(conductor.step || (conductor.gateState && conductor.gateState !== "none"));
 
   const tabs: { key: string; label: string }[] = [];
   if (hasProto) tabs.push({ key: "prototype", label: "Prototype" });
   if (hasDiagram) tabs.push({ key: "diagram", label: "Diagram" });
   if (hasDoc) tabs.push({ key: "doc", label: "Proposed change" });
+  if (hasImpl) tabs.push({ key: "implementation", label: "Implementation" });
 
-  const [active, setActive] = useState(tabs[0]?.key ?? "doc");
+  // Default to Implementation when the conductor is engaged (the live status),
+  // else the first available artifact tab.
+  const [active, setActive] = useState(hasImpl ? "implementation" : tabs[0]?.key ?? "doc");
+  const [subView, setSubView] = useState<"rail" | "timeline">("rail");
+
   if (tabs.length === 0) return <Empty>No plan yet.</Empty>;
   const cur = tabs.some((t) => t.key === active) ? active : tabs[0].key;
+  const c = conductor;
 
   return (
     <div className="space-y-3">
@@ -58,6 +97,22 @@ export default function PlanView({
             open full screen ↗
           </a>
         )}
+        {cur === "implementation" && hasImpl && (
+          <div className="ml-auto flex items-center rounded-md bg-[color:var(--surface-2)] border border-[color:var(--border-default)] p-0.5">
+            {(["rail", "timeline"] as const).map((v) => (
+              <button
+                key={v}
+                onClick={() => setSubView(v)}
+                className={
+                  "px-2.5 py-1 text-[10px] uppercase tracking-wider rounded transition-colors " +
+                  (subView === v ? "bg-[color:var(--surface-3)] text-[color:var(--text-primary)]" : "text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)]")
+                }
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
 
       {cur === "prototype" && hasProto && (
@@ -76,8 +131,81 @@ export default function PlanView({
         </div>
       )}
       {cur === "doc" && hasDoc && (
-        // full-width (max-w-none): whole screen like /understand, not 840px.
         <Markdown text={doc!} className="space-y-4 max-w-none" />
+      )}
+
+      {cur === "implementation" && hasImpl && c && (
+        <div>
+          <div className="mt-1 mb-1">
+            <SdlcProgress step={c.step} phase={c.phase} status={c.status} reduced={reduced} />
+          </div>
+
+          {subView === "rail" ? (
+            <StepRail
+              step={c.step}
+              gateState={c.gateState}
+              phase={c.phase}
+              status={c.status}
+              gates={c.timeline?.gates ?? []}
+              reduced={reduced}
+            />
+          ) : c.timeline ? (
+            <TaskActivityGantt timeline={c.timeline} reduced={reduced} />
+          ) : (
+            <Empty>No wall-clock activity recorded yet.</Empty>
+          )}
+
+          {c.gateReason && c.gateState !== "pending" && onValidation && (
+            <button
+              onClick={onValidation}
+              className="mt-3 flex items-center gap-1.5 text-left group"
+            >
+              <span className="text-[11px] uppercase tracking-wider text-[color:var(--text-muted)]">
+                {c.gateState === "failed" ? "failure reason" : "validation"}
+              </span>
+              <span className="text-[12px] leading-snug opacity-80 group-hover:opacity-100 truncate max-w-[520px]">{c.gateReason}</span>
+              <span className="opacity-50 group-hover:opacity-100 shrink-0">→</span>
+            </button>
+          )}
+
+          {c.gateState === "pending" && gate && (
+            <div className="mt-4 pt-4 border-t border-[color:var(--midground-base)]/15">
+              <div className="opacity-50 mb-2 text-[11px] uppercase tracking-wider">Resolve gate</div>
+              <textarea
+                value={gate.reason}
+                onChange={(e) => gate.setReason(e.target.value)}
+                required
+                placeholder="Reason (required) — why approve or reject this gate?"
+                rows={3}
+                className="w-full text-[13px] rounded-md bg-[color:var(--background-base)]/40 border border-[color:var(--midground-base)]/20 p-2 leading-relaxed resize-y"
+              />
+              <label className="flex items-center gap-2 mt-2 text-[12px] opacity-80 cursor-pointer">
+                <input type="checkbox" checked={gate.override} onChange={(e) => gate.setOverride(e.target.checked)} />
+                override (bypass the verifier and release on manual judgment)
+              </label>
+              <div className="flex gap-2 mt-3">
+                <button
+                  type="button"
+                  disabled={gate.busy || !gate.reason.trim()}
+                  onClick={() => gate.decide("approve")}
+                  className="text-[11px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
+                  style={{ background: "var(--accent-emerald-bg)", color: "var(--accent-emerald-fg)" }}
+                >
+                  Approve
+                </button>
+                <button
+                  type="button"
+                  disabled={gate.busy || !gate.reason.trim()}
+                  onClick={() => gate.decide("reject")}
+                  className="text-[11px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
+                  style={{ background: "var(--accent-rose-bg)", color: "var(--accent-rose-fg)" }}
+                >
+                  Reject
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
       )}
     </div>
   );

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -4,13 +4,10 @@ import { motion, AnimatePresence, useReducedMotion } from "motion/react";
 import { api } from "@/lib/api";
 import { useProject } from "@/lib/project";
 import { Page, Card, SectionLabel, Empty, toneFromLabel, type PillTone } from "@/components/ui";
-import {
-  stepChipClass, gateChipClass, gateLabel, stepLabel,
-} from "@/lib/workflowChips";
 import PlanView from "@/components/plan/PlanView";
 import Markdown from "@/components/Markdown";
-import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
-import TaskActivityGantt, { type Timeline } from "@/components/conductor/TaskActivityGantt";
+import { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import { type Timeline } from "@/components/conductor/TaskActivityGantt";
 import { EASE_OUT, DUR, SPRING_SNAPPY, staggerDelay } from "@/lib/motion";
 // "2.9B" / "476.9k" / "512" — compact token count (shared k/M/B formatter).
 import { fmtTokens } from "@/lib/format";
@@ -696,102 +693,37 @@ export default function TaskDetailPage() {
         </Card>
       )}
 
-      {conductorOn && (
+      {(conductorOn || task.plan_doc || task.plan_diagram || task.has_prototype) && (
         <Stagger i={0} reduced={reduced}>
         <Card>
-          <SectionLabel>Conductor</SectionLabel>
-          <div className="mt-3 mb-1">
-            <SdlcProgress step={task.workflow_step} phase={task.phase_progress} status={task.status} reduced={reduced} />
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-3 text-[12px] mt-2 items-start">
-            <div>
-              <div className="opacity-50 mb-1">step</div>
-              {task.workflow_step
-                ? <span className={stepChipClass(task.workflow_step)}>{stepLabel(task.workflow_step)}</span>
-                : <span className="opacity-50">—</span>}
-            </div>
-            <div>
-              <div className="opacity-50 mb-1">gate</div>
-              {task.gate_state && task.gate_state !== "none"
-                ? <span className={gateChipClass(task.gate_state as any)}>{gateLabel(task.gate_state as any)}</span>
-                : <span className="opacity-50">none</span>}
-            </div>
-            <div className="md:col-span-1">
-              <div className="opacity-50 mb-1">
-                {task.gate_state === "passed" ? "validation"
-                  : task.gate_state === "failed" ? "failure reason"
-                  : "reason"}
-              </div>
-              {task.gate_reason
-                ? <button
-                    onClick={() => navigate(`/tasks/${id}/validation`, { state: { from: `/tasks/${id}` } })}
-                    className="flex items-center gap-1.5 text-left w-full group"
-                  >
-                    <span className="text-[12px] leading-snug opacity-80 group-hover:opacity-100 truncate">{oneLine(task.gate_reason)}</span>
-                    <span className="opacity-50 group-hover:opacity-100 shrink-0">→</span>
-                  </button>
-                : <span className="opacity-50">-</span>}
-            </div>
-          </div>
-
-          {task.gate_state === "pending" && (
-            <div className="mt-4 pt-4 border-t border-[color:var(--midground-base)]/15">
-              <div className="opacity-50 mb-2 text-[11px] uppercase tracking-wider">
-                Resolve gate
-              </div>
-              <textarea
-                value={gateReason}
-                onChange={(e) => setGateReason(e.target.value)}
-                required
-                placeholder="Reason (required) — why approve or reject this gate?"
-                rows={3}
-                className="w-full text-[13px] rounded-md bg-[color:var(--background-base)]/40 border border-[color:var(--midground-base)]/20 p-2 leading-relaxed resize-y"
-              />
-              <label className="flex items-center gap-2 mt-2 text-[12px] opacity-80 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={gateOverride}
-                  onChange={(e) => setGateOverride(e.target.checked)}
-                />
-                override (bypass the verifier and release on manual judgment)
-              </label>
-              <div className="flex gap-2 mt-3">
-                <button
-                  type="button"
-                  disabled={busy || !gateReason.trim()}
-                  onClick={() => gateDecide("approve")}
-                  className="text-[11px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
-                  style={{ background: "var(--accent-emerald-bg)", color: "var(--accent-emerald-fg)" }}
-                >
-                  Approve
-                </button>
-                <button
-                  type="button"
-                  disabled={busy || !gateReason.trim()}
-                  onClick={() => gateDecide("reject")}
-                  className="text-[11px] uppercase tracking-wider px-3 py-1.5 rounded disabled:opacity-40"
-                  style={{ background: "var(--accent-rose-bg)", color: "var(--accent-rose-fg)" }}
-                >
-                  Reject
-                </button>
-              </div>
-            </div>
-          )}
+          <PlanView
+            diagram={task.plan_diagram}
+            doc={task.plan_doc}
+            prototypeSrc={task.has_prototype ? `/api/tasks/${id}/prototype` : undefined}
+            reduced={reduced}
+            conductor={conductorOn ? {
+              step: task.workflow_step,
+              gateState: task.gate_state,
+              gateReason: task.gate_reason,
+              phase: task.phase_progress,
+              status: task.status,
+              timeline,
+            } : null}
+            gate={{
+              reason: gateReason,
+              setReason: setGateReason,
+              override: gateOverride,
+              setOverride: setGateOverride,
+              decide: gateDecide,
+              busy,
+            }}
+            onValidation={() => navigate(`/tasks/${id}/validation`, { state: { from: `/tasks/${id}` } })}
+          />
         </Card>
         </Stagger>
       )}
 
-      {(task.plan_doc || task.plan_diagram || task.has_prototype) ? (
-        <Stagger i={1} reduced={reduced}>
-        <Card>
-          <SectionLabel>Plan</SectionLabel>
-          <div className="mt-2">
-            <PlanView diagram={task.plan_diagram} doc={task.plan_doc}
-              prototypeSrc={task.has_prototype ? `/api/tasks/${id}/prototype` : undefined} />
-          </div>
-        </Card>
-        </Stagger>
-      ) : (
+      {!(task.plan_doc || task.plan_diagram || task.has_prototype) && (
         <Stagger i={1} reduced={reduced}>
         <Card>
           <SectionLabel>Description</SectionLabel>
@@ -967,15 +899,6 @@ export default function TaskDetailPage() {
             </div>
           )}
         </div>
-      </Card>
-
-      <Card>
-        <SectionLabel>Activity</SectionLabel>
-        {timeline ? (
-          <TaskActivityGantt timeline={timeline} reduced={reduced} />
-        ) : (
-          <Empty>No activity recorded yet.</Empty>
-        )}
       </Card>
 
       <Card>


### PR DESCRIPTION
## What
Task `b3ec473e`. The task-detail page had three disconnected cards (Conductor stepper / Activity `TaskActivityGantt` / Timeline) and on the common single-session task the Activity Gantt rendered as empty space — one thin bar with ~3px gate diamonds. Owner flagged it as "a mess / empty space."

## Change
- Fold the Conductor card + empty Activity Gantt into the existing PlanView tab panel as an **Implementation** tab (tabs: Prototype · Diagram · Proposed change · Implementation).
- New `components/conductor/StepRail.tsx` — a compact, collapsible rail: finished agent steps fold into a `✓ N completed steps · show` pill (collapse-done default on), and each **gate** is a one-liner that expands in place to its real `timeline.gates[]` receipt (verified✓ vs override! + actor · proof_type chip · timestamp · reason → full receipt). This is where per-gate info now lives — legible instead of a diamond.
- `PlanView.tsx` gains the Implementation tab + `ConductorInfo`/`GateControls` props + a Rail/Timeline sub-toggle; the sub-agent lock-step Gantt survives behind Timeline. `TaskDetailPage.tsx` drops the two cards and routes conductor+gate props through PlanView.
- No backend change; palette stays OKF-single-source.

## Also: unblock the Workflow tool
`.gitattributes` now forces `*.js eol=lf`. The `.claude/workflows/*.js` scripts are read by the Claude Code harness as the approval "script"; a CR (0x0d) trips its control-character check and blocked the `Workflow`/`implement` tool on Windows checkouts (autocrlf kept re-adding CRs). Forcing LF fixes it at the source.

## Proof
- `tsc -b` + `vite build` clean; both workflow scripts `node --check` clean and now LF.
- Full `pytest tests/unit`: **1001 passed, 0 failed** (frontend-only change; suite as regression net).
- Verified live on :8888 on the real task 1e67253c (the empty-mess task) — rail renders real gate data; a gate expands to its verified/override receipt + reason.

Version 6.7.29 → 6.7.30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)