### PR TITLE
feat(v6.7.32): completed tasks get their own /tasks/completed surface

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,27 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.7.31"
+PRISM_VERSION = "6.7.32"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.7.32: COMPLETED WORK GETS ITS OWN SURFACE (task b7c828cc). The Done "
+    "kanban column is GONE from the /tasks board — completed tasks rendered "
+    "as full cards there, same weight as live work, sorted by priority/"
+    "created_at (never completed_at), growing without bound (the standing "
+    "done-tasks-off-board feedback, finally shipped; the v6.5.3 attribution "
+    "was wrong — it never landed). NOW: COLUMNS drops 'done' (board = Pending/"
+    "In Progress/Blocked), and a clickable emerald Completed tile links to a "
+    "new /tasks/completed route (CompletedTasksPage, App.tsx, static segment "
+    "ranked above /tasks/:id). The surface reuses /api/tasks, filters done+"
+    "root, sorts completed_at DESC, and offers TWO views over one dataset: a "
+    "time-grouped Timeline (Today/Yesterday/This week/Last week/Earlier this "
+    "month/Month YYYY, recent buckets open, migration-clustered same-timestamp "
+    "rows fold into one group) and a Search & filter table (title search, "
+    "This-month filter, sortable Task/Completed columns). Hermes primitives "
+    "throughout; no tokens/in-memory columns (not on the list payload — "
+    "deferred, not faked). Prototyped + confirmed in-app on the task's "
+    "Prototype tab before build. "
     "v6.7.31: UNIFY domain color-coding on ONE palette resolver (task 3df51df3). "
     "The seven Hermes tones (--accent-{teal,sage,amber,rose,violet,emerald,slate}-"
     "{bg,ring,fg} in web/src/index.css) were the intended single source, but two "

--- a/services/prism-service/prism_service/web/src/App.tsx
+++ b/services/prism-service/prism_service/web/src/App.tsx
@@ -16,6 +16,7 @@ import LiveStatusStrip from "@/components/LiveStatusStrip";
 import DashboardPage from "@/pages/DashboardPage";
 const ExplorePage = lazy(() => import("@/pages/ExplorePage"));
 const TasksPage = lazy(() => import("@/pages/TasksPage"));
+const CompletedTasksPage = lazy(() => import("@/pages/CompletedTasksPage"));
 const TaskDetailPage = lazy(() => import("@/pages/TaskDetailPage"));
 const TaskTextPage = lazy(() => import("@/pages/TaskTextPage"));
 const ConductorPage = lazy(() => import("@/pages/ConductorPage"));
@@ -68,6 +69,10 @@ export default function App() {
             />
             <Route path="/okf" element={<Navigate to="/understand" replace />} />
             <Route path="/tasks" element={<TasksPage />} />
+            {/* Completed work lives on its own surface, off the active board
+                (feedback: done-tasks-off-board). Static segment ranks above
+                /tasks/:id so it never resolves as a task detail. */}
+            <Route path="/tasks/completed" element={<CompletedTasksPage />} />
             <Route path="/tasks/:id" element={<TaskDetailPage />} />
             <Route path="/tasks/:id/:section" element={<TaskTextPage />} />
             <Route path="/conductor" element={<ConductorPage />} />

--- a/services/prism-service/prism_service/web/src/pages/CompletedTasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/CompletedTasksPage.tsx
@@ -1,0 +1,317 @@
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { api } from "@/lib/api";
+import { useProject } from "@/lib/project";
+import { Page, Card, Empty, Pill, toneFromLabel } from "@/components/ui";
+
+// Completed work lives on its OWN surface — off the active /tasks board so
+// finished tasks can never pile up in a Done column again (feedback:
+// done-tasks-off-board). Two views over the same data: a time-grouped
+// Timeline (glance at what shipped lately) and a Search & filter table
+// (look something specific up). Ordered by completed_at — the board's
+// priority/created_at sort is exactly why "done" never read as recent.
+
+type Task = {
+  id?: string;
+  title?: string;
+  status?: string;
+  priority?: number | string;
+  tags?: string[];
+  completed_at?: string;
+  created_at?: string;
+  parent_id?: string;
+};
+
+type Row = Task & { when: Date | null };
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+function parseWhen(t: Task): Date | null {
+  const s = t.completed_at || "";
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function fmtDay(d: Date): string {
+  return `${MONTHS[d.getMonth()]} ${d.getDate()}`;
+}
+function fmtISO(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+function dayDiff(d: Date, now: Date): number {
+  return Math.floor((now.getTime() - d.getTime()) / 86_400_000);
+}
+
+// Relative-time bucket for the Timeline view. Recent work gets named
+// buckets; older work falls back to "Month YYYY" so a decade of done
+// tasks still groups cleanly instead of scrolling forever.
+const RECENT_ORDER = ["Today", "Yesterday", "This week", "Last week", "Earlier this month"];
+function bucketOf(d: Date | null, now: Date): string {
+  if (!d) return "Undated";
+  const diff = dayDiff(d, now);
+  if (diff <= 0) return "Today";
+  if (diff === 1) return "Yesterday";
+  if (diff <= 7) return "This week";
+  if (diff <= 14) return "Last week";
+  if (d.getFullYear() === now.getFullYear() && d.getMonth() === now.getMonth()) return "Earlier this month";
+  return `${MONTHS[d.getMonth()]} ${d.getFullYear()}`;
+}
+
+export default function CompletedTasksPage() {
+  const [project] = useProject();
+  const navigate = useNavigate();
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [view, setView] = useState<"timeline" | "search">("timeline");
+  const [query, setQuery] = useState("");
+  const [monthOnly, setMonthOnly] = useState(false);
+  const [sortKey, setSortKey] = useState<"when" | "title">("when");
+  const [sortDir, setSortDir] = useState<1 | -1>(-1);
+
+  const load = useCallback(() => {
+    api
+      .get<{ tasks: Task[] }>(`/api/tasks?project=${project}`)
+      .then((d) => setTasks(d.tasks ?? []))
+      .catch(() => setTasks([]))
+      .finally(() => setLoaded(true));
+  }, [project]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const now = useMemo(() => new Date(), [tasks]);
+
+  // Only DONE root tasks, newest completion first.
+  const rows: Row[] = useMemo(() => {
+    return tasks
+      .filter((t) => (t.status ?? "") === "done" && !t.parent_id)
+      .map((t) => ({ ...t, when: parseWhen(t) }))
+      .sort((a, b) => (b.when?.getTime() ?? 0) - (a.when?.getTime() ?? 0));
+  }, [tasks]);
+
+  const weekCount = useMemo(
+    () => rows.filter((r) => r.when && dayDiff(r.when, now) <= 7).length,
+    [rows, now],
+  );
+
+  const open = (id?: string) => id && navigate(`/tasks/${id}`, { state: { from: "/tasks/completed" } });
+
+  return (
+    <Page>
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate("/tasks")}
+          className="text-xs text-[color:var(--text-muted)] hover:text-[color:var(--text-primary)] transition-colors"
+        >
+          ← Back to board
+        </button>
+      </div>
+
+      <div className="flex items-end justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-semibold text-[color:var(--text-primary)]">Completed</h1>
+          <p className="text-sm text-[color:var(--text-secondary)] mt-1 max-w-[60ch]">
+            Finished work, off the active board and ordered by when it actually completed.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Pill active={view === "timeline"} onClick={() => setView("timeline")} tone="teal">Timeline</Pill>
+          <Pill active={view === "search"} onClick={() => setView("search")} tone="teal">Search &amp; filter</Pill>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-2">
+        <SummaryChip label="total" value={rows.length} />
+        <SummaryChip label="this week" value={weekCount} tone="emerald" />
+      </div>
+
+      {!loaded ? (
+        <Empty>Loading…</Empty>
+      ) : rows.length === 0 ? (
+        <Empty>No completed tasks yet.</Empty>
+      ) : view === "timeline" ? (
+        <TimelineView rows={rows} now={now} onOpen={open} />
+      ) : (
+        <SearchView
+          rows={rows}
+          query={query}
+          setQuery={setQuery}
+          monthOnly={monthOnly}
+          setMonthOnly={setMonthOnly}
+          now={now}
+          sortKey={sortKey}
+          sortDir={sortDir}
+          onSort={(k) => {
+            if (k === sortKey) setSortDir((d) => (d === 1 ? -1 : 1));
+            else { setSortKey(k); setSortDir(-1); }
+          }}
+          onOpen={open}
+        />
+      )}
+    </Page>
+  );
+}
+
+function SummaryChip({ label, value, tone }: { label: string; value: number; tone?: "emerald" }) {
+  const fg = tone ? "var(--accent-emerald-fg)" : "var(--text-primary)";
+  return (
+    <div className="rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-2)] px-3 py-1.5 text-xs text-[color:var(--text-muted)]">
+      <span className="font-semibold tabular-nums" style={{ color: fg }}>{value}</span> {label}
+    </div>
+  );
+}
+
+function Chip({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="shrink-0 text-[11px] font-mono text-[color:var(--text-muted)] tabular-nums">{children}</span>
+  );
+}
+
+function Row({ r, onOpen }: { r: Row; onOpen: (id?: string) => void }) {
+  return (
+    <button
+      onClick={() => onOpen(r.id)}
+      className="w-full flex items-center gap-3 py-2 px-1 text-left border-b border-[color:var(--border-subtle)] last:border-0 group"
+    >
+      <span
+        className="shrink-0 grid place-items-center w-[18px] h-[18px] rounded-full text-[11px]"
+        style={{
+          background: "var(--accent-sage-bg)",
+          color: "var(--accent-sage-fg)",
+          boxShadow: "inset 0 0 0 1px var(--accent-sage-ring)",
+        }}
+      >✓</span>
+      <span className="flex-1 min-w-0 truncate text-sm text-[color:var(--text-secondary)] group-hover:text-[color:var(--text-primary)]">
+        {r.title ?? "—"}
+      </span>
+      {(r.tags ?? []).slice(0, 2).map((tag) => (
+        <span
+          key={tag}
+          className="shrink-0 text-[10px] font-mono px-1.5 py-0.5 rounded"
+          style={{ background: `var(--accent-${toneFromLabel(tag)}-bg)`, color: `var(--accent-${toneFromLabel(tag)}-fg)` }}
+        >#{tag}</span>
+      ))}
+      <Chip>{r.when ? fmtDay(r.when) : "—"}</Chip>
+    </button>
+  );
+}
+
+function TimelineView({ rows, now, onOpen }: { rows: Row[]; now: Date; onOpen: (id?: string) => void }) {
+  // Group into ordered buckets. Named recent buckets first (in RECENT_ORDER),
+  // then month buckets newest-first, Undated last.
+  const groups = new Map<string, Row[]>();
+  for (const r of rows) {
+    const b = bucketOf(r.when, now);
+    (groups.get(b) ?? groups.set(b, []).get(b)!).push(r);
+  }
+  const keys = [...groups.keys()].sort((a, b) => {
+    if (a === "Undated") return 1;
+    if (b === "Undated") return -1;
+    const ia = RECENT_ORDER.indexOf(a), ib = RECENT_ORDER.indexOf(b);
+    if (ia >= 0 || ib >= 0) return (ia < 0 ? 99 : ia) - (ib < 0 ? 99 : ib);
+    return (groups.get(b)![0].when?.getTime() ?? 0) - (groups.get(a)![0].when?.getTime() ?? 0);
+  });
+
+  return (
+    <div className="space-y-3">
+      {keys.map((k, idx) => {
+        const list = groups.get(k)!;
+        return (
+          <Card key={k} className="!p-0 overflow-hidden">
+            <details open={idx < 2}>
+              <summary className="flex items-center gap-3 px-4 py-3 cursor-pointer select-none hover:bg-[color:var(--surface-2)] list-none">
+                <span className="text-[color:var(--text-muted)] text-xs transition-transform [details[open]_&]:rotate-90">▶</span>
+                <span className="font-medium text-sm text-[color:var(--text-primary)]">{k}</span>
+                <span className="ml-auto text-xs text-[color:var(--text-muted)] tabular-nums">{list.length} done</span>
+              </summary>
+              <div className="px-4 pb-2 border-t border-[color:var(--border-subtle)]">
+                {list.map((r) => <Row key={r.id} r={r} onOpen={onOpen} />)}
+              </div>
+            </details>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}
+
+function SearchView({
+  rows, query, setQuery, monthOnly, setMonthOnly, now, sortKey, sortDir, onSort, onOpen,
+}: {
+  rows: Row[];
+  query: string; setQuery: (s: string) => void;
+  monthOnly: boolean; setMonthOnly: (b: boolean) => void;
+  now: Date;
+  sortKey: "when" | "title"; sortDir: 1 | -1;
+  onSort: (k: "when" | "title") => void;
+  onOpen: (id?: string) => void;
+}) {
+  const q = query.trim().toLowerCase();
+  let filtered = rows.filter((r) => {
+    if (q && !(r.title ?? "").toLowerCase().includes(q)) return false;
+    if (monthOnly && !(r.when && dayDiff(r.when, now) <= 30)) return false;
+    return true;
+  });
+  filtered = [...filtered].sort((a, b) => {
+    let v = 0;
+    if (sortKey === "when") v = (a.when?.getTime() ?? 0) - (b.when?.getTime() ?? 0);
+    else v = (a.title ?? "").localeCompare(b.title ?? "");
+    return v * sortDir;
+  });
+  const arrow = (k: "when" | "title") => (sortKey === k ? (sortDir < 0 ? " ↓" : " ↑") : "");
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex-1 min-w-[220px] flex items-center gap-2 rounded-md border border-[color:var(--border-default)] bg-[color:var(--surface-1)] px-3 py-2">
+          <span className="text-[color:var(--text-muted)]">⌕</span>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${rows.length} completed tasks…`}
+            className="flex-1 bg-transparent outline-none text-sm text-[color:var(--text-primary)] placeholder:text-[color:var(--text-disabled)]"
+          />
+        </div>
+        <Pill active={monthOnly} onClick={() => setMonthOnly(!monthOnly)} tone="teal">This month</Pill>
+      </div>
+
+      <Card className="!p-0 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr>
+                <th
+                  onClick={() => onSort("title")}
+                  className="text-left text-[10px] uppercase tracking-wider text-[color:var(--text-label)] font-semibold px-4 py-2.5 border-b border-[color:var(--border-default)] cursor-pointer hover:text-[color:var(--text-secondary)] select-none"
+                >Task{arrow("title")}</th>
+                <th
+                  onClick={() => onSort("when")}
+                  className="text-left text-[10px] uppercase tracking-wider text-[color:var(--text-label)] font-semibold px-4 py-2.5 border-b border-[color:var(--border-default)] cursor-pointer hover:text-[color:var(--text-secondary)] select-none whitespace-nowrap w-px"
+                >Completed{arrow("when")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.length === 0 ? (
+                <tr><td colSpan={2} className="px-4 py-8 text-center text-sm text-[color:var(--text-muted)]">No completed tasks match.</td></tr>
+              ) : (
+                filtered.map((r) => (
+                  <tr
+                    key={r.id}
+                    onClick={() => onOpen(r.id)}
+                    className="cursor-pointer hover:bg-[color:var(--surface-2)]"
+                  >
+                    <td className="px-4 py-2 border-b border-[color:var(--border-subtle)] text-[color:var(--text-primary)] max-w-0 truncate">{r.title ?? "—"}</td>
+                    <td className="px-4 py-2 border-b border-[color:var(--border-subtle)] font-mono text-[color:var(--text-muted)] tabular-nums whitespace-nowrap">{r.when ? fmtISO(r.when) : "—"}</td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+      <div className="text-xs text-[color:var(--text-muted)] tabular-nums">
+        Showing {filtered.length} of {rows.length} completed
+      </div>
+    </div>
+  );
+}

--- a/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TasksPage.tsx
@@ -30,12 +30,14 @@ type Task = {
 //   pending      → amber  (waiting for attention)
 //   in_progress  → teal   (actively being worked)
 //   blocked      → rose   (problem, stop)
-//   done         → emerald (complete)
+// NOTE: there is deliberately no "done" column. Completed work leaves the
+// active board entirely (feedback: done-tasks-off-board) so it can never
+// pile up here — it lives on the dedicated /tasks/completed surface,
+// reached via the clickable Completed tile below.
 const COLUMNS: { key: string; label: string }[] = [
   { key: "pending", label: "Pending" },
   { key: "in_progress", label: "In Progress" },
   { key: "blocked", label: "Blocked" },
-  { key: "done", label: "Done" },
 ];
 
 export default function TasksPage() {
@@ -69,6 +71,19 @@ export default function TasksPage() {
         {COLUMNS.map((c) => (
           <Kpi key={c.key} label={c.label} value={roots.filter((t) => (t.status ?? "pending") === c.key).length} />
         ))}
+        {/* Completed is a TILE, not a column — click through to the dedicated
+            surface so finished work never occupies the active board. */}
+        <button
+          onClick={() => navigate("/tasks/completed")}
+          className="flex-1 min-w-[150px] text-left rounded-md border border-[color:var(--accent-emerald-ring)] bg-[color:var(--surface-1)] p-4 hover:bg-[color:var(--surface-2)] transition-colors cursor-pointer relative"
+          style={{ backgroundImage: "linear-gradient(180deg, var(--accent-emerald-bg), transparent)" }}
+        >
+          <span className="absolute top-3 right-4 text-[color:var(--accent-emerald-fg)] text-sm">→</span>
+          <div className="text-[10px] uppercase tracking-wider text-[color:var(--accent-emerald-fg)] mb-2">Completed</div>
+          <div className="text-2xl font-semibold leading-none text-[color:var(--accent-emerald-fg)] tabular-nums">
+            {roots.filter((t) => (t.status ?? "") === "done").length}
+          </div>
+        </button>
       </section>
 
       <Card>
@@ -86,7 +101,7 @@ export default function TasksPage() {
         )}
       </Card>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
         {COLUMNS.map((col) => {
           const items = roots.filter((t) => (t.status ?? "pending") === col.key);
           const colTone = domainTone("taskStatus", col.key) ?? "slate";


### PR DESCRIPTION
Completed work leaves the active board entirely (feedback: done-tasks-off-board).

- **TasksPage**: `COLUMNS` drops `done` (board = Pending / In Progress / Blocked); a clickable emerald **Completed** tile links to the new surface.
- **App.tsx**: new `/tasks/completed` route (static segment ranked above `/tasks/:id`).
- **CompletedTasksPage**: reuses `/api/tasks`, filters `done`+root, sorts `completed_at` DESC. Two views over one dataset — a time-grouped **Timeline** (Today … Month YYYY; recent buckets open; same-timestamp migration rows fold into one group) and a **Search & filter** table (title search, This-month filter, sortable Task/Completed). Hermes primitives; no faked columns.

Patch-bump 6.7.31 → 6.7.32.

Gates: `tsc -b` 0 · `vite build` 0 · `pytest tests/unit` 1001 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)