### PR TITLE
Conductor tiles: completion ring + labeled phase timeline (on the honest-activity base)

### DIFF
--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,12 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.14"
+PRISM_VERSION = "6.8.15"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.15: CONDUCTOR TILE wider/landscape — auto-fill grid min-width 380px->520px "
+    "so each tile reads wide-screen instead of portrait. "
     "v6.8.14: HONEST ETA — the tile's '~N left' chip + countdown bar now show ONLY "
     "when the tile is actually WORKING and has work left (children_done<total). A "
     "paused/adrift/done epic no longer shows a frozen 'ETA 4:58 left' lie on a "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,18 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.12"
+PRISM_VERSION = "6.8.14"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.14: HONEST ETA — the tile's '~N left' chip + countdown bar now show ONLY "
+    "when the tile is actually WORKING and has work left (children_done<total). A "
+    "paused/adrift/done epic no longer shows a frozen 'ETA 4:58 left' lie on a "
+    "4/4-done feature. "
+    "v6.8.13: JIRA SLICE D — bidirectional task<->Jira sync. services/jira_client.py "
+    "(stdlib urllib) + services/jira_sync.py (receipts + outbound_create on task "
+    "create/update + inbound reconcile + env-gated poller, OFF by default) + main.py "
+    "lifespan spawn + GET /api/jira/sync/receipts. Epic 4/4 — all slices done. "
     "v6.8.12: CONDUCTOR TILE — FOCUSED SLICE. The epic tile no longer lists all N "
     "slice chips; it shows just the ONE being worked (or 'next: …') + the stage: "
     "'Slice 3/4 · ▶ Bidirectional Jira sync · implement'. Less noise, the current "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.9"
+PRISM_VERSION = "6.8.11"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.11: CONDUCTOR TILE LIVENESS — a card that isn't being driven still "
+    "VISIBLY ticks so it's never mistaken for frozen: a heartbeat ('live Ns' + "
+    "pulsing dot) counts 0..5 and resets each 5s poll, and the idle clock on "
+    "paused/adrift/stalled tiles now ticks up every second (server snapshot + "
+    "seconds-since-poll) instead of freezing between refreshes. "
+    "v6.8.10: JIRA SLICE C COMPLETE — users API (/api/users {,/status,/link-jira,"
+    "/unlink}) surfaces the auto-provisioned single-operator PRISM User + links the "
+    "authenticated Jira account (email/masked fingerprint, never a token); "
+    "PrismRequestContext.principal populated from operator().id at the MCP seam "
+    "(try/except, can't reject); Settings 'Identity & Users' panel (PRISM-owned "
+    "user + OAuth-auto-matched Jira link). Epic 3/4. "
     "v6.8.9: CONDUCTOR FANOUT SUBDIVISION — the tile's SDLC stepper now SUBDIVIDES "
     "the current step's node into one cell per dispatched sub-agent (returned "
     "filled teal + 'R/D' count) when that step is in fanout mode, so a fan-out reads "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,25 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.2"
+PRISM_VERSION = "6.8.4"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.4: HONEST CONDUCTOR ACTIVITY STATES — a task no longer claims 'in "
+    "progress' + a live burn when nothing is driving it. New activity classifier "
+    "(working / awaiting_gate / adrift / stalled) from REAL Claude-Code-integration "
+    "signals: task_motion_s (last conductor transition in task_history) + "
+    "session_quiet_s (linked-session live-transcript recency). The pulse/shimmer + "
+    "burn graph only read as 'work' when working; a gate reads 'awaiting review', a "
+    "live-session-but-idle-task reads 'session busy · task idle Nm', a dead one "
+    "'stalled · idle Nm'. Under-claims when uncertain. "
+    "v6.8.3: JIRA SLICE A — OAuth-first credential connect. New /api/jira/* "
+    "(status/authorize/callback/configure/clear) backed by services/jira_auth.py "
+    "(server-side store: atomic write + chmod 600, env-override precedence, "
+    "fingerprint-only echo — raw token never crosses the API) + services/"
+    "jira_oauth.py (stdlib Atlassian 3LO seam). OAuth is the PRIMARY path, "
+    "email+API-token the fallback. 8/8 red use-cases now green. UI Settings "
+    "panel + slices B/C/D still pending. "
     "v6.8.2: CONDUCTOR PER-STEP FANOUT TELEMETRY — the conductor now visualizes, "
     "for the current workflow step, how many sub-agents were dispatched vs how "
     "many have returned (e.g. write_failing_tests: '8/8 agents back'), plus a "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,16 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.6"
+PRISM_VERSION = "6.8.7"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.7: CONDUCTOR TILE — SLICES are now the visual HERO. An epic's tile shows "
+    "a labeled chip per sub-task (SLICES 1/4: Slice A emerald-✓, rest muted) right "
+    "under the title, so real feature progress is legible at a glance instead of a "
+    "tiny text pill. The borrowed-token burn graph is DIMMED + shrunk + honestly "
+    "labeled ('linked session · not this task') on every non-working state so it no "
+    "longer visually dominates/lies on a paused tile. New tile.subtasks payload. "
     "v6.8.6: CONDUCTOR ACTIVITY now EPIC-AWARE — a parent/epic's activity reflects "
     "its SUB-TASKS: a slice actively moving => working, some slices done but none "
     "active => 'paused · N/M done' (real progress between bursts, NOT the alarming "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,21 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.7"
+PRISM_VERSION = "6.8.9"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.9: CONDUCTOR FANOUT SUBDIVISION — the tile's SDLC stepper now SUBDIVIDES "
+    "the current step's node into one cell per dispatched sub-agent (returned "
+    "filled teal + 'R/D' count) when that step is in fanout mode, so a fan-out reads "
+    "'5 of 8 back' inline instead of a single opaque dot. Plus JIRA SLICE C CORE: "
+    "first-class User store (users.db) + User model + principal field on "
+    "PrismRequestContext (foundation; UI + principal-population still pending). "
+    "v6.8.8: JIRA SLICE B — task<->Jira issue mapping. Additive 1:1 jira_issue_key "
+    "TEXT column threaded through models/task.py + task_service (create/update/"
+    "_row_to_task + idempotent ALTER migration) + api/tasks.py + mcp/tools.py; "
+    "GET /api/tasks now returns jira_issue_key and it round-trips create/update. "
+    "11/11 test-first green. Epic now 2/4 slices. "
     "v6.8.7: CONDUCTOR TILE — SLICES are now the visual HERO. An epic's tile shows "
     "a labeled chip per sub-task (SLICES 1/4: Slice A emerald-✓, rest muted) right "
     "under the title, so real feature progress is legible at a glance instead of a "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,20 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.15"
+PRISM_VERSION = "6.8.18"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.18: CONDUCTOR CARD SHIPPED TO PRODUCTION (task 696cacf5) — the approved "
+    "Timeline-D design is now the REAL ConductorPage TaskTile, combined onto the "
+    "honest-activity conductor (working/awaiting_gate/adrift/stalled pill, fanout "
+    "subdivision, focused-slice hero, live idle clock, honest ETA). The tile leads "
+    "with a completion RING (done SDLC steps/total over WORKFLOW_STEPS_ORDERED) + a "
+    "2x2 LIVE metric grid, then a LABELED phase timeline (real steps, stepLabel "
+    "caption, current node pulses only when working + subdivides in fanout) "
+    "replacing the abstract SdlcDots; TokenTurns keeps its marked peak bar. Version "
+    "reconciled past the stranded 6.8.1-6.8.17 range. Pure SPA change on the unified "
+    "conductor base. "
     "v6.8.15: CONDUCTOR TILE wider/landscape — auto-fill grid min-width 380px->520px "
     "so each tile reads wide-screen instead of portrait. "
     "v6.8.14: HONEST ETA — the tile's '~N left' chip + countdown bar now show ONLY "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,23 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.4"
+PRISM_VERSION = "6.8.6"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.6: CONDUCTOR ACTIVITY now EPIC-AWARE — a parent/epic's activity reflects "
+    "its SUB-TASKS: a slice actively moving => working, some slices done but none "
+    "active => 'paused · N/M done' (real progress between bursts, NOT the alarming "
+    "'stalled'), nothing done+nothing active => stalled. _task_motion_s now counts "
+    "sub-task completion as parent motion (an epic no longer reads stalled for hours "
+    "while its slices get done underneath it). "
+    "v6.8.5: JIRA SLICE A UI (Settings→Connections Jira sub-panel, OAuth-first, "
+    "flips to Connected w/ masked fingerprint + Disconnect; ?jira= callback) + "
+    "CONDUCTOR DRIVER CONTRACT documented (mcp/instructions.py taught at connect, "
+    "implement.js/prototype.js headers, Brain mx-85c9c1): the daemon never self-"
+    "advances — a task moves only while a driver drives it, so keep the session "
+    "linked, advance/gate every step, fan-in+advance on fanout completion, report "
+    "activity, and never leave a task un-driven. A stall is a DRIVER bug. "
     "v6.8.4: HONEST CONDUCTOR ACTIVITY STATES — a task no longer claims 'in "
     "progress' + a live burn when nothing is driving it. New activity classifier "
     "(working / awaiting_gate / adrift / stalled) from REAL Claude-Code-integration "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,17 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.0"
+PRISM_VERSION = "6.8.2"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.2: CONDUCTOR PER-STEP FANOUT TELEMETRY — the conductor now visualizes, "
+    "for the current workflow step, how many sub-agents were dispatched vs how "
+    "many have returned (e.g. write_failing_tests: '8/8 agents back'), plus a "
+    "'verified by <Role>' tag naming the reviewer of the upcoming gate. New "
+    "step_fanout store + POST /api/conductor/fanout; phase_progress gains "
+    "basis='fanout' (pct=returned/dispatched) + fanout_dispatched/returned; "
+    "SdlcProgress caption + StepRail current-step chip render it. "
     "v6.8.0: LEARNING PAGE THAT SHOWS WHAT PRISM LEARNED (task 62674246, MINOR "
     "cap on the role/tier + learning-loop work). The /learning surface was six "
     "stacked mono-font telemetry tables, most broken or empty: Scored-tasks "

--- a/services/prism-service/prism_service/__version__.py
+++ b/services/prism-service/prism_service/__version__.py
@@ -13,10 +13,14 @@ live. Bump MINOR for backward-compatible feature work, MAJOR for
 distribution-shape changes like the docker→native pivot v6 marks.
 """
 
-PRISM_VERSION = "6.8.11"
+PRISM_VERSION = "6.8.12"
 
 # Changelog-ish notes (free-form; keep short)
 PRISM_VERSION_NOTES = (
+    "v6.8.12: CONDUCTOR TILE — FOCUSED SLICE. The epic tile no longer lists all N "
+    "slice chips; it shows just the ONE being worked (or 'next: …') + the stage: "
+    "'Slice 3/4 · ▶ Bidirectional Jira sync · implement'. Less noise, the current "
+    "work + where it's at. "
     "v6.8.11: CONDUCTOR TILE LIVENESS — a card that isn't being driven still "
     "VISIBLY ticks so it's never mistaken for frozen: a heartbeat ('live Ns' + "
     "pulsing dot) counts 0..5 and resets each 5s poll, and the idle clock on "

--- a/services/prism-service/prism_service/api/conductor.py
+++ b/services/prism-service/prism_service/api/conductor.py
@@ -1,6 +1,7 @@
 """Conductor API — prompt variants, scores, session outcomes, and SDLC state."""
 
 from fastapi import APIRouter, Body, HTTPException, Query
+from pydantic import BaseModel
 
 from prism_service.project_context import get_project
 from prism_service.services.conductor_service import board_health
@@ -70,6 +71,25 @@ def gate(project: str = Query("default"), body: dict = Body(...)) -> dict:
         # NO-SELF-OVERRIDE actor (task 3826dac3): defaults to the session.
         actor=body.get("actor") or body.get("session_id"),
     )
+
+
+class FanoutBody(BaseModel):
+    task_id: str
+    step: str
+    dispatched: int = 0
+    returned: int = 0
+
+
+@router.post("/fanout")
+def fanout(project: str = Query("default"), body: FanoutBody = Body(...)) -> dict:
+    """Record per-step sub-agent fanout (dispatched vs returned) for the SPA.
+
+    Ephemeral units — e.g. "8 test-writers handed out, 8 back" — for the
+    CURRENT workflow step; distinct from phase_progress' CHILD-TASK basis.
+    UPSERTs on (task_id, step) and returns the stored row.
+    """
+    s = _svc(project)
+    return s.set_step_fanout(body.task_id, body.step, body.dispatched, body.returned)
 
 
 @router.post("/advance")

--- a/services/prism-service/prism_service/api/tasks.py
+++ b/services/prism-service/prism_service/api/tasks.py
@@ -304,7 +304,12 @@ def get_task(task_id: str, project: str = Query("default")) -> dict:
     try:
         cond = get_project(project).conductor_svc
         if cond is not None and hasattr(cond, "phase_progress"):
-            out["phase_progress"] = cond.phase_progress(task_id)
+            pp = cond.phase_progress(task_id)
+            out["phase_progress"] = pp
+            # Honest work state (working/adrift/stalled/…) rides the detail
+            # route alongside phase_progress so the header pill can't lie.
+            if hasattr(cond, "activity_for"):
+                out["activity"] = cond.activity_for(t, pp)
     except Exception:
         pass
     # has_prototype: a clickable MOCK prototype HTML the /prototype workflow

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -655,6 +655,55 @@ class ConductorService:
             return []
 
     # ------------------------------------------------------------------
+    # Per-step fanout telemetry — ephemeral sub-agent dispatch/return counts
+    # for the CURRENT workflow step (e.g. "8 test-writers handed out, 8 back").
+    # Distinct from phase_progress' children basis, which counts CHILD TASKS.
+    # ------------------------------------------------------------------
+
+    def set_step_fanout(
+        self, task_id: str, step: str, dispatched: int, returned: int
+    ) -> dict:
+        """UPSERT the fanout row for (task_id, step) and return it."""
+        from datetime import datetime, timezone
+
+        self._ensure_meta_schema()
+        now = datetime.now(timezone.utc).isoformat()
+        conn = self._scores_conn()
+        conn.execute(
+            "INSERT INTO step_fanout (task_id, step, dispatched, returned, updated_at) "
+            "VALUES (?, ?, ?, ?, ?) "
+            "ON CONFLICT(task_id, step) DO UPDATE SET "
+            "dispatched=excluded.dispatched, returned=excluded.returned, "
+            "updated_at=excluded.updated_at",
+            (task_id, step, int(dispatched), int(returned), now),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT * FROM step_fanout WHERE task_id = ? AND step = ?",
+            (task_id, step),
+        ).fetchone()
+        conn.close()
+        return dict(row) if row else {}
+
+    def _step_fanout(self, task_id: str, step: str) -> tuple[int, int]:
+        """Return (dispatched, returned) for a step, or (0, 0) if none."""
+        if not step:
+            return (0, 0)
+        try:
+            conn = self._scores_conn()
+            row = conn.execute(
+                "SELECT dispatched, returned FROM step_fanout "
+                "WHERE task_id = ? AND step = ?",
+                (task_id, step),
+            ).fetchone()
+            conn.close()
+            if row:
+                return (int(row["dispatched"]), int(row["returned"]))
+        except Exception:
+            pass
+        return (0, 0)
+
+    # ------------------------------------------------------------------
     # Meta-Conductor: offline prompt-variant candidate loop
     # ------------------------------------------------------------------
 
@@ -733,6 +782,14 @@ class ConductorService:
                 reason TEXT,
                 metrics_json TEXT,
                 evaluated_at TEXT DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS step_fanout (
+                task_id TEXT NOT NULL,
+                step TEXT NOT NULL,
+                dispatched INTEGER NOT NULL DEFAULT 0,
+                returned INTEGER NOT NULL DEFAULT 0,
+                updated_at TEXT,
+                PRIMARY KEY (task_id, step)
             );
             """
         )
@@ -2677,6 +2734,10 @@ class ConductorService:
             except Exception:
                 children_total = 0
 
+        # Per-step ephemeral fanout (test-writers etc.) for the CURRENT step —
+        # a real returned/dispatched signal that beats the wall-clock estimate.
+        fanout_dispatched, fanout_returned = self._step_fanout(task_id, cur_step)
+
         # A finished task is 100%, period — never a stale children/time ratio.
         if task_status == "done":
             pct = 1.0
@@ -2684,6 +2745,10 @@ class ConductorService:
         elif children_total > 0:
             pct = children_done / children_total
             basis = "children"
+        elif fanout_dispatched > 0:
+            # write_failing_tests has no child tasks, so fanout wins over time.
+            pct = fanout_returned / fanout_dispatched
+            basis = "fanout"
         else:
             ratio = in_step_s / typical_s if typical_s > 0 else 0.0
             pct = min(0.95, ratio)
@@ -2775,6 +2840,10 @@ class ConductorService:
             "eta_total_s": round(eta_total, 1) if eta_total is not None else None,
             "children_done": children_done,
             "children_total": children_total,
+            # Ephemeral per-step sub-agent fanout (0/0 when the step dispatched
+            # no disposable units) — powers the "N/M agents back" chip.
+            "fanout_dispatched": fanout_dispatched,
+            "fanout_returned": fanout_returned,
             # Task-total linked-session tokens (see note above).
             "tokens_since_step": tokens,
             # Per-turn burn rate series + honest total turn count.

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2402,6 +2402,20 @@ class ConductorService:
                 else:
                     continue
             pp = self.phase_progress(t.id)
+            # Compact ordered slice list for the tile: done first (by
+            # completed_at) then the rest by created_at, so the slice bar reads
+            # left-to-right as progress. Only title/status/id — keep it small.
+            kids = self._children(t)
+            subtasks = [
+                {"id": c.id, "title": c.title, "status": getattr(c, "status", "") or ""}
+                for c in sorted(
+                    kids,
+                    key=lambda c: (
+                        0 if (getattr(c, "status", "") or "") == "done" else 1,
+                        getattr(c, "completed_at", "") or getattr(c, "created_at", "") or "",
+                    ),
+                )
+            ]
             out.append({
                 "id": t.id,
                 "title": t.title,
@@ -2423,6 +2437,10 @@ class ConductorService:
                 # Honest work state (working/adrift/stalled/awaiting_gate/…) —
                 # the tile pill + live pulse read this, NOT the raw status.
                 "activity": self.activity_for(t, pp),
+                # Real progress: the epic's non-cancelled slices, done-first.
+                # Omitted (empty) for leaf tasks — the tile only renders a slice
+                # bar when this is non-empty.
+                "subtasks": subtasks,
             })
         return out
 

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2889,11 +2889,37 @@ class ConductorService:
                             latest = ts
             except Exception:
                 latest = None
+        # A SUB-TASK completing/moving IS the parent moving, even though the
+        # parent's own step didn't transition — otherwise an epic reads "stalled"
+        # for hours while its slices are actively getting done underneath it.
+        if self._task_svc is not None and tid:
+            try:
+                for c in self._task_svc.list():
+                    if (getattr(c, "parent_id", "") or "") != tid:
+                        continue
+                    for fld in ("completed_at", "updated_at"):
+                        ts = self._parse_iso(getattr(c, fld, "") or "")
+                        if ts is not None and (latest is None or ts > latest):
+                            latest = ts
+            except Exception:
+                pass
         if latest is None:
             latest = self._parse_iso(getattr(task, "updated_at", "") or "")
         if latest is None:
             return None
         return max(0.0, self._now_epoch() - latest)
+
+    def _children(self, task) -> list:
+        """Non-cancelled child tasks of this task (parent_id == task.id)."""
+        tid = getattr(task, "id", "") or ""
+        if self._task_svc is None or not tid:
+            return []
+        try:
+            return [c for c in self._task_svc.list()
+                    if (getattr(c, "parent_id", "") or "") == tid
+                    and (getattr(c, "status", "") or "") != "cancelled"]
+        except Exception:
+            return []
 
     def activity_for(self, task, phase_progress: dict) -> dict:
         """Honest {state, task_motion_s, session_quiet_s} for a task. 'working'
@@ -2913,7 +2939,22 @@ class ConductorService:
         elif status == "pending":
             state = "pending"
         elif status == "in_progress":
-            if step.endswith("_gate") and gate in ("pending", "failed"):
+            kids = self._children(task)
+            if kids:
+                # An EPIC's activity is its slices': a slice actively moving =>
+                # working; some slices done but none active => paused (real
+                # progress, between bursts — NOT the alarming "stalled");
+                # nothing done and nothing active => stalled.
+                active = any((getattr(k, "status", "") or "") == "in_progress"
+                             and (self._task_motion_s(k) or 1e9) <= 120 for k in kids)
+                done = sum(1 for k in kids if (getattr(k, "status", "") or "") == "done")
+                if active:
+                    state = "working"
+                elif done > 0:
+                    state = "paused"         # progress made, idle between slices
+                else:
+                    state = "stalled"
+            elif step.endswith("_gate") and gate in ("pending", "failed"):
                 state = "awaiting_gate"      # a WAIT for review, not work
             elif motion is not None and motion <= 120:
                 state = "working"            # a real recent transition on THIS task

--- a/services/prism-service/prism_service/services/conductor_service.py
+++ b/services/prism-service/prism_service/services/conductor_service.py
@@ -2401,6 +2401,7 @@ class ConductorService:
                     step = self.INTAKE_STEP
                 else:
                     continue
+            pp = self.phase_progress(t.id)
             out.append({
                 "id": t.id,
                 "title": t.title,
@@ -2418,7 +2419,10 @@ class ConductorService:
                 "tags": list(getattr(t, "tags", []) or []),
                 # Animated SDLC progress bar (a5e0d9f5): blended current-step
                 # fill so the tile bar tweens between polls.
-                "phase_progress": self.phase_progress(t.id),
+                "phase_progress": pp,
+                # Honest work state (working/adrift/stalled/awaiting_gate/…) —
+                # the tile pill + live pulse read this, NOT the raw status.
+                "activity": self.activity_for(t, pp),
             })
         return out
 
@@ -2767,6 +2771,12 @@ class ConductorService:
         # duplication). Empty for a task with no on-disk transcript yet.
         token_turns: list[dict] = []
         total_turns = 0
+        # Recency of the linked session's live transcript: server-now minus the
+        # newest token event across the task's sessions. Powers activity_for's
+        # 'adrift' vs 'stalled' split (session alive but task idle). None when
+        # there is no on-disk transcript. Server-side now() is fine here — this
+        # is the daemon reading its own clock, not a workflow script.
+        session_quiet_s: Optional[float] = None
         # 'linked' = series came from authoritative per-session live events (or
         # is honestly empty); 'wallclock' = the project-wide fallback supplied
         # it. The SPA dims/labels the 'wallclock' case as approximate.
@@ -2810,6 +2820,8 @@ class ConductorService:
                         except Exception:
                             pass
                 live_events.sort(key=lambda e: e[0])
+                if live_events:
+                    session_quiet_s = max(0.0, self._now_epoch() - live_events[-1][0])
                 # PER-TASK-EXCLUSIVE (owner decision, task 5ecbbfb8): the tile
                 # shows ONLY this task's authoritative linked-session activity.
                 # The old #134/#137 project-WIDE wall-clock fallback (bucket the
@@ -2852,4 +2864,67 @@ class ConductorService:
             # 'linked' (authoritative/empty) | 'wallclock' (project-wide
             # approximate fallback — the SPA dims + labels it).
             "tokens_source": tokens_source,
+            # Recency of the linked session's live transcript (s). None when no
+            # transcript. activity_for reads this for the adrift/stalled split.
+            "session_quiet_s": round(session_quiet_s, 3) if session_quiet_s is not None else None,
+        }
+
+    # ------------------------------------------------------------------
+    # activity — the HONEST per-task work state (not the raw status)
+    # ------------------------------------------------------------------
+    def _task_motion_s(self, task) -> Optional[float]:
+        """Seconds since the last CONDUCTOR TRANSITION on this task: the newest
+        advance_task/gate_decide row in task_history (both written by
+        advance_task/gate_decide via TaskService.record_history). Falls back to
+        task.updated_at ONLY when the task has no transition history. None when
+        neither resolves."""
+        latest: Optional[float] = None
+        tid = getattr(task, "id", "") or ""
+        if self._task_svc is not None and tid:
+            try:
+                for r in self._task_svc.history(tid):
+                    if getattr(r, "action", "") in ("advance_task", "gate_decide"):
+                        ts = self._parse_iso(getattr(r, "timestamp", "") or "")
+                        if ts is not None and (latest is None or ts > latest):
+                            latest = ts
+            except Exception:
+                latest = None
+        if latest is None:
+            latest = self._parse_iso(getattr(task, "updated_at", "") or "")
+        if latest is None:
+            return None
+        return max(0.0, self._now_epoch() - latest)
+
+    def activity_for(self, task, phase_progress: dict) -> dict:
+        """Honest {state, task_motion_s, session_quiet_s} for a task. 'working'
+        means a REAL recent conductor transition on THIS task (<=120s); when
+        uncertain we UNDER-claim (stalled/adrift over working). session_quiet_s
+        rides in on the already-computed phase_progress dict (transcript recency)
+        so we don't re-read the transcript."""
+        status = (getattr(task, "status", "") or "")
+        step = (getattr(task, "workflow_step", "") or "")
+        gate = (getattr(task, "gate_state", "none") or "none")
+        motion = self._task_motion_s(task)
+        quiet = phase_progress.get("session_quiet_s") if isinstance(phase_progress, dict) else None
+        if status == "done":
+            state = "done"
+        elif status == "blocked":
+            state = "blocked"
+        elif status == "pending":
+            state = "pending"
+        elif status == "in_progress":
+            if step.endswith("_gate") and gate in ("pending", "failed"):
+                state = "awaiting_gate"      # a WAIT for review, not work
+            elif motion is not None and motion <= 120:
+                state = "working"            # a real recent transition on THIS task
+            elif quiet is not None and quiet <= 90:
+                state = "adrift"             # session alive but busy elsewhere
+            else:
+                state = "stalled"            # nothing is driving it
+        else:
+            state = status or "pending"
+        return {
+            "state": state,
+            "task_motion_s": round(motion, 3) if motion is not None else None,
+            "session_quiet_s": round(quiet, 3) if isinstance(quiet, (int, float)) else None,
         }

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -77,6 +77,7 @@ function fmtEta(s: number): string {
 // teal "in progress" lie. adrift/stalled append a mm:ss idle clock (see below).
 const ACTIVITY_META: Record<string, { label: string; tone: string }> = {
   working: { label: "in progress", tone: "teal" },
+  paused: { label: "paused", tone: "teal" },   // epic between slices — progress, NOT stalled
   awaiting_gate: { label: "awaiting review", tone: "amber" },
   adrift: { label: "session busy · task idle", tone: "slate" },
   stalled: { label: "stalled · idle", tone: "rose" },
@@ -131,6 +132,7 @@ export default function SdlcProgress({
   const stateLabel =
     state === "adrift" ? `session busy · task idle${idleClock ? ` ${idleClock}` : ""}`
     : state === "stalled" ? `stalled · idle${idleClock ? ` ${idleClock}` : ""}`
+    : state === "paused" ? `paused · ${phase?.children_done ?? 0}/${phase?.children_total ?? 0} done`
     : meta.label;
   // "live" = the task is genuinely being DRIVEN right now — ONLY the "working"
   // state (a real recent conductor transition on THIS task), NEVER raw

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -29,6 +29,11 @@ export type PhaseProgress = {
   typical_s?: number;
   children_done?: number;
   children_total?: number;
+  // Ephemeral per-step sub-agent fanout for the CURRENT step: how many
+  // disposable units (e.g. test-writers) were dispatched vs returned. 0/0
+  // when the step handed out none. basis==="fanout" ⇒ pct = returned/dispatched.
+  fanout_dispatched?: number;
+  fanout_returned?: number;
   tokens_since_step?: number;
   // Per-turn burn series (oldest..newest) + honest total turn count — drives
   // the live TokenTurns graph beside each conductor tile.
@@ -195,6 +200,9 @@ export default function SdlcProgress({
             <span className="uppercase tracking-wider truncate">
               {stepLabel(steps[curIdx].id)} · {liveLabel.toFixed(2)}%
               {basis === "children" && phase?.children_total ? ` · ${phase.children_done}/${phase.children_total}` : ""}
+              {(basis === "fanout" || (phase?.fanout_dispatched ?? 0) > 0)
+                ? ` · ${phase?.fanout_returned ?? 0}/${phase?.fanout_dispatched ?? 0} back`
+                : ""}
             </span>
             <span className="flex items-center gap-1.5 shrink-0 tabular-nums">
               <motion.span

--- a/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/SdlcProgress.tsx
@@ -50,6 +50,15 @@ export type PhaseProgress = {
   eta_total_s?: number | null;
 };
 
+// Honest per-task work state (server: conductor_service.activity_for). The
+// tile pill + live pulse read THIS, not the raw status — "working" is the ONLY
+// state that means the task is actively being driven right now.
+export type Activity = {
+  state?: string;             // working|adrift|stalled|awaiting_gate|done|blocked|pending
+  task_motion_s?: number | null;   // s since the last conductor transition on THIS task
+  session_quiet_s?: number | null; // s since the linked session's transcript moved
+};
+
 function fmtClock(s: number): string {
   const m = Math.floor(s / 60);
   const sec = Math.floor(s % 60);
@@ -63,9 +72,15 @@ function fmtEta(s: number): string {
   return `${Math.round(s)}s`;
 }
 
-// Real task status → label + accent tone (honest; no guessed "idle").
-const STATUS_META: Record<string, { label: string; tone: string }> = {
-  in_progress: { label: "in progress", tone: "teal" },
+// Honest activity STATE → label + accent tone. Keyed by activity.state (not the
+// raw status) so a task the conductor isn't driving reads as slate/rose, not a
+// teal "in progress" lie. adrift/stalled append a mm:ss idle clock (see below).
+const ACTIVITY_META: Record<string, { label: string; tone: string }> = {
+  working: { label: "in progress", tone: "teal" },
+  awaiting_gate: { label: "awaiting review", tone: "amber" },
+  adrift: { label: "session busy · task idle", tone: "slate" },
+  stalled: { label: "stalled · idle", tone: "rose" },
+  in_progress: { label: "in progress", tone: "teal" },  // pre-activity fallback
   done: { label: "done", tone: "emerald" },
   blocked: { label: "blocked", tone: "rose" },
   pending: { label: "pending", tone: "slate" },
@@ -84,6 +99,7 @@ export default function SdlcProgress({
   step,
   phase,
   status,
+  activity,
   reduced,
   showCaption = true,
   hideTokens = false,
@@ -91,6 +107,9 @@ export default function SdlcProgress({
   step?: string;
   phase?: PhaseProgress | null;
   status?: string;
+  // Honest work state — drives the pill + pulse. When omitted we fall back to
+  // the raw status (legacy callers) so nothing regresses to a blank pill.
+  activity?: Activity | null;
   reduced?: boolean | null;
   showCaption?: boolean;
   // When the tile renders a dedicated TokenTurns graph, suppress the caption's
@@ -104,10 +123,20 @@ export default function SdlcProgress({
   const tokFrac = Math.max(0, Math.min(1, tokens / 500_000));
   const seed = Math.max(0, Math.min(1, phase?.pct ?? 0));
 
-  const meta = STATUS_META[(status ?? "").toLowerCase()] ?? { label: status || "", tone: "slate" };
-  // "live" = the task is genuinely being worked (status in_progress) — the
-  // honest basis for the shimmer + pulse, instead of a laggy token delta.
-  const live = (status ?? "").toLowerCase() === "in_progress";
+  // The honest state: prefer activity.state, fall back to raw status.
+  const state = (activity?.state ?? status ?? "").toLowerCase();
+  const meta = ACTIVITY_META[state] ?? { label: state || "", tone: "slate" };
+  // adrift/stalled surface HOW LONG the task has been idle (from task_motion_s).
+  const idleClock = activity?.task_motion_s != null ? fmtClock(activity.task_motion_s) : "";
+  const stateLabel =
+    state === "adrift" ? `session busy · task idle${idleClock ? ` ${idleClock}` : ""}`
+    : state === "stalled" ? `stalled · idle${idleClock ? ` ${idleClock}` : ""}`
+    : meta.label;
+  // "live" = the task is genuinely being DRIVEN right now — ONLY the "working"
+  // state (a real recent conductor transition on THIS task), NEVER raw
+  // in_progress. This is the honest basis for the shimmer + pulse; an adrift or
+  // stalled tile must read as still, not animated.
+  const live = state === "working";
 
   // Overall task progress toward DONE: completed steps + current phase fraction.
   const overallSeed = curIdx >= 0 ? (curIdx + seed) / steps.length : seed;
@@ -222,7 +251,7 @@ export default function SdlcProgress({
                 </span>
               )}
               {!hideTokens && <span className="opacity-70">· {fmtTokens(tokens)} tok</span>}
-              {meta.label && <span style={{ color: `var(--accent-${meta.tone}-fg)` }}>· {meta.label}</span>}
+              {stateLabel && <span style={{ color: `var(--accent-${meta.tone}-fg)` }}>· {stateLabel}</span>}
             </span>
           </div>
           {!hideTokens && tokens > 0 && (

--- a/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
@@ -67,6 +67,11 @@ export default function StepRail({
   flush();
 
   const railHasCur = curIdx >= 0;
+  // The VERIFIER for the upcoming gate — persona of the next gate step ahead of
+  // the current one (honest: omitted when no gate remains). Surfaced on the
+  // current step so you can see WHO signs off before you get there.
+  const nextGate = curIdx >= 0 ? steps.slice(curIdx + 1).find((s) => s.type === "gate") : undefined;
+  const verifierPersona = nextGate?.persona || "";
 
   return (
     <div className="mt-3 select-none">
@@ -126,12 +131,27 @@ export default function StepRail({
                     {stepLabel(s.id)}
                   </span>
                   {cur && !isGate && (
-                    <span className="ml-auto text-[10px] font-mono tabular-nums flex items-center gap-1.5" style={{ color: "var(--accent-teal-fg)" }}>
-                      <motion.span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: "var(--accent-teal-fg)" }}
-                        animate={!reduced ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
-                        transition={!reduced ? { duration: 1.2, repeat: Infinity } : { duration: 0.2 }} />
-                      {phase?.pct != null ? `${((curIdx >= 0 ? (curIdx + Math.min(1, phase.pct)) / steps.length : 0) * 100).toFixed(0)}%` : "working"}
-                    </span>
+                    <div className="ml-auto flex items-center gap-2 min-w-0">
+                      {verifierPersona && <VerifiedBy persona={verifierPersona} />}
+                      {(phase?.fanout_dispatched ?? 0) > 0 && (
+                        <span className="flex items-center gap-1 text-[10px] font-mono tabular-nums flex-none" style={{ color: "var(--accent-teal-fg)" }}
+                          title="ephemeral sub-agents dispatched vs returned for this step">
+                          <span>{phase?.fanout_returned ?? 0}/{phase?.fanout_dispatched ?? 0} agents back</span>
+                          <span className="h-[3px] w-8 rounded-full overflow-hidden" style={{ background: "var(--surface-2)" }}>
+                            <span className="block h-full rounded-full" style={{
+                              width: `${Math.min(1, (phase?.fanout_returned ?? 0) / Math.max(1, phase?.fanout_dispatched ?? 1)) * 100}%`,
+                              background: "var(--accent-teal-bg)",
+                            }} />
+                          </span>
+                        </span>
+                      )}
+                      <span className="text-[10px] font-mono tabular-nums flex items-center gap-1.5 flex-none" style={{ color: "var(--accent-teal-fg)" }}>
+                        <motion.span className="inline-block h-1.5 w-1.5 rounded-full" style={{ background: "var(--accent-teal-fg)" }}
+                          animate={!reduced ? { opacity: [1, 0.3, 1] } : { opacity: 1 }}
+                          transition={!reduced ? { duration: 1.2, repeat: Infinity } : { duration: 0.2 }} />
+                        {phase?.pct != null ? `${((curIdx >= 0 ? (curIdx + Math.min(1, phase.pct)) / steps.length : 0) * 100).toFixed(0)}%` : "working"}
+                      </span>
+                    </div>
                   )}
                 </div>
               )}
@@ -205,6 +225,23 @@ function Persona({ persona, isGate }: { persona: string; isGate: boolean }) {
       style={{ background: `var(--accent-${tone}-bg)`, color: `var(--accent-${tone}-fg)` }}>
       {isGate && persona && <span aria-hidden>◇</span>}
       {label}
+    </span>
+  );
+}
+
+// "verified by {Role}" — the persona that reviews the UPCOMING gate, shown on
+// the current step so the reviewer is legible before the gate is reached. Same
+// domainTone("role") palette + ◇ marker as the gate Persona tag (subtle: the
+// tag is outlined, not filled, so it reads as a forward-looking hint).
+function VerifiedBy({ persona }: { persona: string }) {
+  const tone = domainTone("role", persona) ?? "slate";
+  return (
+    <span
+      title={`${personaLabel(persona)} verifies the next gate`}
+      className="text-[9px] font-mono uppercase tracking-wide px-1.5 py-0.5 rounded flex-none inline-flex items-center gap-1"
+      style={{ color: `var(--accent-${tone}-fg)`, boxShadow: `inset 0 0 0 1px var(--accent-${tone}-ring)` }}>
+      <span aria-hidden>◇</span>
+      verified by {personaLabel(persona)}
     </span>
   );
 }

--- a/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/StepRail.tsx
@@ -10,7 +10,7 @@ import { useState } from "react";
 import { motion } from "motion/react";
 import { WORKFLOW_STEPS_ORDERED, stepLabel, personaLabel } from "@/lib/workflowChips";
 import { domainTone } from "@/lib/domainTone";
-import type { PhaseProgress } from "./SdlcProgress";
+import type { PhaseProgress, Activity } from "./SdlcProgress";
 import type { GanttGate } from "./TaskActivityGantt";
 
 function clockHM(ts: number): string {
@@ -24,18 +24,22 @@ function clockHM(ts: number): string {
 type GateInfo = { state: "passed" | "override" | "pending" | "future"; g?: GanttGate };
 
 export default function StepRail({
-  step, gateState, phase, status, gates, reduced,
+  step, gateState, phase, status, activity, gates, reduced,
 }: {
   step?: string;
   gateState?: string;
   phase?: PhaseProgress | null;
   status?: string;
+  // Honest work state — the current-step node/% only pulses when "working".
+  activity?: Activity | null;
   gates: GanttGate[];
   reduced?: boolean | null;
 }) {
   const steps = WORKFLOW_STEPS_ORDERED;
   const curIdx = steps.findIndex((s) => s.id === step);
-  const live = (status ?? "").toLowerCase() === "in_progress";
+  // Pulse ONLY when genuinely being driven now (a real recent conductor
+  // transition on THIS task), never merely because status is in_progress.
+  const live = (activity?.state ?? status ?? "").toLowerCase() === "working";
   const [open, setOpen] = useState<string | null>(null);
   const [collapseDone, setCollapseDone] = useState(true);
 

--- a/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
@@ -52,21 +52,27 @@ export default function TokenTurns({
   const peak = series.reduce((m, t) => Math.max(m, t.tok_s), 0) || 1;
   const latest = series.length ? series[series.length - 1] : null;
   const approximate = tokens_source === "wallclock";
-  // The burn belongs to THIS task only while working; adrift/stalled ⇒ dim it
-  // and say so honestly instead of presenting it as task progress.
+  // The burn belongs to THIS task only while working. EVERY other state
+  // (paused/adrift/stalled/awaiting_gate) is real spend but NOT this task's
+  // progress ⇒ dim + shrink it and say so honestly, so a borrowed orchestrator
+  // burn can't masquerade as work getting done on this tile.
   const st = (state ?? "").toLowerCase();
+  const working = st === "working";
   const quietClock = session_quiet_s != null ? mmss(session_quiet_s) : "";
   const heading =
-    st === "adrift" ? "linked session busy — not this task"
+    st === "paused" ? "linked session · not this task"
+    : st === "adrift" ? "linked session busy — not this task"
     : st === "stalled" ? `no active driver${quietClock ? ` · quiet ${quietClock}` : ""}`
+    : st === "awaiting_gate" ? "awaiting review · paused here"
     : approximate ? "project activity (approximate)"
     : "burn · tok/s by turn";
-  const dimmed = approximate || st === "adrift" || st === "stalled";
+  // Only a task actively being WORKED gets the full-strength graph.
+  const dimmed = approximate || (st !== "" && !working);
 
   return (
     <div
       className="flex flex-col gap-1.5 h-full"
-      style={dimmed ? { opacity: 0.5 } : undefined}
+      style={dimmed ? { opacity: 0.4 } : undefined}
       title={heading}
     >
       <div className="flex items-baseline justify-between gap-2">
@@ -88,7 +94,7 @@ export default function TokenTurns({
 
       {/* Bar field — flex row, newest on the right. Each bar tweens its height
           between polls so the field flows as the live tail advances. */}
-      <div className="relative flex-1 min-h-[56px] flex items-end gap-[2px] rounded bg-[color:var(--surface-2)]/40 px-1.5 pt-1.5 pb-1 overflow-hidden">
+      <div className={`relative flex-1 ${working ? "min-h-[56px]" : "min-h-[30px]"} flex items-end gap-[2px] rounded bg-[color:var(--surface-2)]/40 px-1.5 pt-1.5 pb-1 overflow-hidden`}>
         {series.length === 0 ? (
           <span className="absolute inset-0 grid place-items-center text-[10px] font-mono opacity-30 italic">
             awaiting first turn…

--- a/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
@@ -50,6 +50,11 @@ export default function TokenTurns({
   const series = turns ?? [];
   const count = total ?? series.length;
   const peak = series.reduce((m, t) => Math.max(m, t.tok_s), 0) || 1;
+  // Index of the window-peak bar so it can be visually MARKED (not just a
+  // scalar readout) — a teal cap makes the burst legible at a glance.
+  const peakIdx = series.length
+    ? series.reduce((mi, t, i) => (t.tok_s > series[mi].tok_s ? i : mi), 0)
+    : -1;
   const latest = series.length ? series[series.length - 1] : null;
   const approximate = tokens_source === "wallclock";
   // The burn belongs to THIS task only while working. EVERY other state
@@ -102,6 +107,7 @@ export default function TokenTurns({
         ) : (
           series.map((t, i) => {
             const isLast = i === series.length - 1;
+            const isPeak = i === peakIdx;
             // Log-scale height: with all four usage fields counted, a
             // cache-heavy turn can run ~1000x a plain generation turn — a
             // linear tok_s/peak normalization pins peak and flattens every
@@ -115,10 +121,16 @@ export default function TokenTurns({
                 style={{
                   transformOrigin: "bottom",
                   background: isLast ? "var(--accent-amber-fg)" : "var(--accent-amber-bg)",
-                  boxShadow: isLast ? "0 0 6px var(--accent-amber-fg)" : "inset 0 0 0 1px var(--accent-amber-ring)",
+                  // Peak bar gets a teal cap so the window maximum is MARKED,
+                  // not merely printed as a scalar in the readout below.
+                  boxShadow: isPeak
+                    ? "inset 0 3px 0 var(--accent-teal-fg), inset 0 0 0 1px var(--accent-teal-ring)"
+                    : isLast
+                    ? "0 0 6px var(--accent-amber-fg)"
+                    : "inset 0 0 0 1px var(--accent-amber-ring)",
                   opacity: isLast ? 1 : 0.55 + 0.4 * (i / series.length),
                 }}
-                title={`${fmtRate(t.tok_s)} tok/s · ${fmtTokens(t.out)} tok / ${t.dt_s}s`}
+                title={`${fmtRate(t.tok_s)} tok/s · ${fmtTokens(t.out)} tok / ${t.dt_s}s${isPeak ? " · window peak" : ""}`}
                 initial={false}
                 animate={{ height: `${h * 100}%` }}
                 transition={{ duration: reduced ? 0 : 0.4, ease: [0.16, 1, 0.3, 1] }}

--- a/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
+++ b/services/prism-service/prism_service/web/src/components/conductor/TokenTurns.tsx
@@ -19,12 +19,19 @@ function fmtRate(n: number): string {
   return `${Math.round(n)}`;
 }
 
+function mmss(s: number): string {
+  const m = Math.floor(s / 60);
+  return `${m}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
+}
+
 export default function TokenTurns({
   turns,
   total,
   live,
   reduced,
   tokens_source,
+  state,
+  session_quiet_s,
 }: {
   turns?: TokenTurn[];
   total?: number;
@@ -34,22 +41,37 @@ export default function TokenTurns({
   // approximate fallback — render dimmed + labelled so the number is never
   // presented as authoritative per-task truth.
   tokens_source?: "linked" | "wallclock";
+  // Honest work state (conductor_service.activity_for). When NOT "working" the
+  // burn is real spend but NOT this task's progress — dim it + relabel so it
+  // can't masquerade as work getting done here.
+  state?: string;
+  session_quiet_s?: number | null;
 }) {
   const series = turns ?? [];
   const count = total ?? series.length;
   const peak = series.reduce((m, t) => Math.max(m, t.tok_s), 0) || 1;
   const latest = series.length ? series[series.length - 1] : null;
   const approximate = tokens_source === "wallclock";
+  // The burn belongs to THIS task only while working; adrift/stalled ⇒ dim it
+  // and say so honestly instead of presenting it as task progress.
+  const st = (state ?? "").toLowerCase();
+  const quietClock = session_quiet_s != null ? mmss(session_quiet_s) : "";
+  const heading =
+    st === "adrift" ? "linked session busy — not this task"
+    : st === "stalled" ? `no active driver${quietClock ? ` · quiet ${quietClock}` : ""}`
+    : approximate ? "project activity (approximate)"
+    : "burn · tok/s by turn";
+  const dimmed = approximate || st === "adrift" || st === "stalled";
 
   return (
     <div
       className="flex flex-col gap-1.5 h-full"
-      style={approximate ? { opacity: 0.55 } : undefined}
-      title={approximate ? "project activity (approximate)" : undefined}
+      style={dimmed ? { opacity: 0.5 } : undefined}
+      title={heading}
     >
       <div className="flex items-baseline justify-between gap-2">
         <span className="text-[9px] uppercase tracking-[0.12em] font-mono text-[color:var(--text-muted)] opacity-70">
-          {approximate ? "project activity (approximate)" : "burn · tok/s by turn"}
+          {heading}
         </span>
         <span className="flex items-center gap-1 text-[10px] font-mono tabular-nums text-[color:var(--text-muted)]">
           {live && (

--- a/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
+++ b/services/prism-service/prism_service/web/src/components/plan/PlanView.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Empty } from "@/components/ui";
 import Markdown from "@/components/Markdown";
 import Mermaid from "./Mermaid";
-import SdlcProgress, { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import SdlcProgress, { type PhaseProgress, type Activity } from "@/components/conductor/SdlcProgress";
 import StepRail from "@/components/conductor/StepRail";
 import TaskActivityGantt, { type Timeline } from "@/components/conductor/TaskActivityGantt";
 
@@ -22,6 +22,8 @@ export type ConductorInfo = {
   gateReason?: string;
   phase?: PhaseProgress | null;
   status?: string;
+  // Honest work state — drives the pulse/pill (only "working" animates).
+  activity?: Activity | null;
   timeline?: Timeline | null;
 };
 export type GateControls = {
@@ -137,7 +139,7 @@ export default function PlanView({
       {cur === "implementation" && hasImpl && c && (
         <div>
           <div className="mt-1 mb-1">
-            <SdlcProgress step={c.step} phase={c.phase} status={c.status} reduced={reduced} />
+            <SdlcProgress step={c.step} phase={c.phase} status={c.status} activity={c.activity} reduced={reduced} />
           </div>
 
           {subView === "rail" ? (
@@ -146,6 +148,7 @@ export default function PlanView({
               gateState={c.gateState}
               phase={c.phase}
               status={c.status}
+              activity={c.activity}
               gates={c.timeline?.gates ?? []}
               reduced={reduced}
             />

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -30,7 +30,18 @@ type ManagedTask = {
   // + burn graph read THIS, not the raw status — a task nobody is driving must
   // NOT read as a teal "in progress".
   activity?: Activity | null;
+  // Epic slices (server: managed_tasks). Done-first ordered non-cancelled
+  // children; drives the SLICES hero bar. Empty/absent for leaf tasks.
+  subtasks?: { id: string; title: string; status: string }[];
 };
+
+// Strip a leading "Slice X · " / "Slice X: " prefix and truncate so a slice
+// chip reads at tile width. Falls back to the short id when a title is empty.
+function sliceLabel(s: { id: string; title: string }): string {
+  let t = (s.title || "").replace(/^\s*slice\s+\S+\s*[·:\-]\s*/i, "").trim();
+  if (!t) t = s.id.slice(0, 6);
+  return t.length > 22 ? t.slice(0, 21) + "…" : t;
+}
 
 // Honest activity STATE → tile pill label + tone. adrift/stalled append an idle
 // mm:ss (from task_motion_s) so the pill says how long it's been dark.
@@ -176,7 +187,13 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
           {phaseLabel}
         </span>
       </div>
-      {/* Animated SDLC stepper — dots fill to the current phase as the task advances. */}
+      {/* Real progress HERO: the epic's slices, done-first, one chip each.
+          Rendered ABOVE the abstract SDLC stepper so "1 of 4 done, here's
+          which" is the first thing read on the tile. */}
+      {(task.subtasks?.length ?? 0) > 0 && (
+        <SlicesBar subtasks={task.subtasks!} reduced={reduced} />
+      )}
+      {/* Animated SDLC stepper — now SECONDARY to the slice bar above. */}
       <SdlcDots step={stepId} reduced={reduced} />
       <div className="flex flex-wrap items-center gap-1">
         <TileBadge tone={actTone}>{actLabel}</TileBadge>
@@ -321,6 +338,55 @@ function TileBadge({ tone, children }: { tone: PillTone; children: ReactNode }) 
     >
       {children}
     </span>
+  );
+}
+
+// SlicesBar — the REAL-progress hero for an epic tile. One chip per slice,
+// done-first (server-ordered), so the row reads left-to-right as progress:
+// filled emerald + ✓ = done, teal (subtle pulse) = in progress, muted outline
+// = pending. Uses the shared Hermes accent vars — no per-surface palette.
+function SlicesBar({ subtasks, reduced }: {
+  subtasks: { id: string; title: string; status: string }[];
+  reduced: boolean | null;
+}) {
+  const done = subtasks.filter((s) => (s.status || "").toLowerCase() === "done").length;
+  return (
+    <div className="flex flex-col gap-1" title={`${done} of ${subtasks.length} slices done`}>
+      <span className="text-[10px] uppercase tracking-[0.14em] font-mono text-[color:var(--text-secondary)]">
+        Slices <span className="text-[color:var(--accent-emerald-fg)]">{done}</span>/{subtasks.length}
+      </span>
+      <div className="flex flex-wrap gap-1">
+        {subtasks.map((s) => {
+          const st = (s.status || "").toLowerCase();
+          const isDone = st === "done";
+          const isActive = st === "in_progress";
+          const tone = isDone ? "emerald" : isActive ? "teal" : null;
+          const chip = (
+            <span
+              key={s.id}
+              className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded-sm max-w-[11rem] truncate"
+              style={tone ? {
+                background: `var(--accent-${tone}-bg)`,
+                color: `var(--accent-${tone}-fg)`,
+                boxShadow: `inset 0 0 0 1px var(--accent-${tone}-ring)`,
+              } : {
+                color: "var(--text-muted)",
+                boxShadow: "inset 0 0 0 1px var(--border-default)",
+              }}
+              title={`${s.title} · ${st || "pending"}`}
+            >
+              {isDone && <span aria-hidden>✓</span>}
+              <span className="truncate">{sliceLabel(s)}</span>
+            </span>
+          );
+          return isActive && !reduced ? (
+            <motion.span key={s.id} animate={{ opacity: [1, 0.55, 1] }}
+              transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
+              className="inline-flex">{chip}</motion.span>
+          ) : chip;
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/workflowChips";
 import { relativeTime } from "@/lib/relativeTime";
 import { motion, useReducedMotion } from "motion/react";
-import { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import { type PhaseProgress, type Activity } from "@/components/conductor/SdlcProgress";
 import TokenTurns from "@/components/conductor/TokenTurns";
 
 type ManagedTask = {
@@ -26,7 +26,29 @@ type ManagedTask = {
   updated_at?: string;
   tags?: string[];
   phase_progress?: PhaseProgress | null;
+  // Honest work state (server: conductor_service.activity_for). The tile pill
+  // + burn graph read THIS, not the raw status — a task nobody is driving must
+  // NOT read as a teal "in progress".
+  activity?: Activity | null;
 };
+
+// Honest activity STATE → tile pill label + tone. adrift/stalled append an idle
+// mm:ss (from task_motion_s) so the pill says how long it's been dark.
+const ACT_TILE: Record<string, { label: string; tone: PillTone }> = {
+  working: { label: "working", tone: "teal" },
+  awaiting_gate: { label: "awaiting review", tone: "amber" },
+  adrift: { label: "session busy", tone: "slate" },
+  stalled: { label: "stalled", tone: "rose" },
+  done: { label: "done", tone: "emerald" },
+  blocked: { label: "blocked", tone: "rose" },
+  pending: { label: "pending", tone: "amber" },
+};
+
+function fmtIdle(s?: number | null): string {
+  if (s == null) return "";
+  const m = Math.floor(s / 60);
+  return `${m}:${String(Math.floor(s % 60)).padStart(2, "0")}`;
+}
 
 type BoardHealth = {
   consecutive_low_value?: number;
@@ -111,6 +133,15 @@ export default function ConductorPage() {
 function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: boolean | null; onClick: () => void }) {
   const status = (task.status ?? "").toLowerCase();
   const statusTone: PillTone = domainTone("taskStatus", status) ?? "slate";
+  // Honest state drives the pill (fall back to raw status pre-activity).
+  const actState = (task.activity?.state ?? status).toLowerCase();
+  const actTone: PillTone = ACT_TILE[actState]?.tone ?? statusTone;
+  const actWorking = actState === "working";
+  const idle = fmtIdle(task.activity?.task_motion_s);
+  const actLabel =
+    actState === "adrift" ? `session busy${idle ? ` · idle ${idle}` : ""}`
+    : actState === "stalled" ? `stalled${idle ? ` · idle ${idle}` : ""}`
+    : (ACT_TILE[actState]?.label ?? (status || "—"));
   const gate = task.gate_state ?? "none";
   const showGate = gate !== "none";
   const gateTone: PillTone = domainTone("gate", gate) ?? "slate";
@@ -146,7 +177,7 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
       {/* Animated SDLC stepper — dots fill to the current phase as the task advances. */}
       <SdlcDots step={stepId} reduced={reduced} />
       <div className="flex flex-wrap items-center gap-1">
-        <TileBadge tone={statusTone}>{status || "—"}</TileBadge>
+        <TileBadge tone={actTone}>{actLabel}</TileBadge>
         {showGate && (
           <TileBadge tone={gateTone}>{gateLabel(gate as any)}</TileBadge>
         )}
@@ -206,9 +237,11 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
           <TokenTurns
             turns={task.phase_progress?.token_turns}
             total={task.phase_progress?.turns}
-            live={status === "in_progress"}
+            live={actWorking}
             reduced={reduced}
             tokens_source={task.phase_progress?.tokens_source}
+            state={actState}
+            session_quiet_s={task.activity?.session_quiet_s}
           />
         </div>
       </div>

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -79,12 +79,24 @@ export default function ConductorPage() {
   const navigate = useNavigate();
   const reduced = useReducedMotion();
   const [data, setData] = useState<State | null>(null);
+  // Liveness: a card that isn't being driven still must VISIBLY tick, or it's
+  // indistinguishable from frozen. fetchedAt marks the last successful poll;
+  // sinceFetchS counts up every second and RESETS each 5s poll — a heartbeat the
+  // eye can see. It also drives the per-second idle clock on paused/adrift tiles.
+  const fetchedAt = useRef(0);
+  const [sinceFetchS, setSinceFetchS] = useState(0);
 
   const load = useCallback(() => {
-    api.get<State>(`/api/conductor/state?project=${project}`).then(setData).catch(() => setData(null));
+    api.get<State>(`/api/conductor/state?project=${project}`)
+      .then((d) => { setData(d); fetchedAt.current = performance.now(); setSinceFetchS(0); })
+      .catch(() => setData(null));
   }, [project]);
 
   useEffect(() => { load(); const t = setInterval(load, 5000); return () => clearInterval(t); }, [load]);
+  useEffect(() => {
+    const t = setInterval(() => setSinceFetchS(Math.max(0, (performance.now() - fetchedAt.current) / 1000)), 1000);
+    return () => clearInterval(t);
+  }, []);
 
   const managed = data?.managed_tasks ?? [];
   const boardHealth = data?.board_health;
@@ -118,7 +130,7 @@ export default function ConductorPage() {
         ) : (
           <div className="grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-3">
             {managed.map((t) => (
-              <TaskTile key={t.id} task={t} reduced={reduced} onClick={() =>
+              <TaskTile key={t.id} task={t} reduced={reduced} sinceFetchS={sinceFetchS} onClick={() =>
                 navigate(`/tasks/${t.id}`, { state: { from: "/conductor" } })
               } />
             ))}
@@ -142,18 +154,22 @@ export default function ConductorPage() {
 //   - owner: {assigned_agent or 'unassigned'}
 //   - up to 3 tag chips
 // ---------------------------------------------------------------------------
-function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: boolean | null; onClick: () => void }) {
+function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; reduced: boolean | null; sinceFetchS: number; onClick: () => void }) {
   const status = (task.status ?? "").toLowerCase();
   const statusTone: PillTone = domainTone("taskStatus", status) ?? "slate";
   // Honest state drives the pill (fall back to raw status pre-activity).
   const actState = (task.activity?.state ?? status).toLowerCase();
   const actTone: PillTone = ACT_TILE[actState]?.tone ?? statusTone;
   const actWorking = actState === "working";
-  const idle = fmtIdle(task.activity?.task_motion_s);
+  // LIVE idle clock: server snapshot + seconds since the last poll, so it ticks
+  // up every second instead of freezing between the 5s data refreshes.
+  const liveMotionS = task.activity?.task_motion_s != null ? task.activity.task_motion_s + sinceFetchS : null;
+  const idle = fmtIdle(liveMotionS);
+  const kids = `${task.phase_progress?.children_done ?? 0}/${task.phase_progress?.children_total ?? 0}`;
   const actLabel =
     actState === "adrift" ? `session busy${idle ? ` · idle ${idle}` : ""}`
     : actState === "stalled" ? `stalled${idle ? ` · idle ${idle}` : ""}`
-    : actState === "paused" ? `paused · ${task.phase_progress?.children_done ?? 0}/${task.phase_progress?.children_total ?? 0} done`
+    : actState === "paused" ? `paused · ${kids} done${idle ? ` · idle ${idle}` : ""}`
     : (ACT_TILE[actState]?.label ?? (status || "—"));
   const gate = task.gate_state ?? "none";
   const showGate = gate !== "none";
@@ -209,6 +225,21 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
             ~{fmtEtaTile(task.phase_progress!.eta_s!)} left{(task.phase_progress?.eta_sample_n ?? 0) < 2 ? " ~rough" : ""}
           </span>
         )}
+        {/* Liveness heartbeat: pulses + counts 0..5s and RESETS each 5s poll, so
+            the card visibly proves it is live-polling — even a paused/idle tile
+            is never mistaken for frozen. */}
+        <span
+          className="ml-auto inline-flex items-center gap-1 text-[9px] font-mono text-[color:var(--text-muted)] tabular-nums"
+          title={`live — data refreshed ${Math.floor(sinceFetchS)}s ago (auto-polls every 5s)`}
+        >
+          <motion.span
+            className="inline-block h-1.5 w-1.5 rounded-full"
+            style={{ background: "var(--accent-emerald-fg)" }}
+            animate={reduced ? { opacity: 1 } : { opacity: [1, 0.2, 1] }}
+            transition={reduced ? { duration: 0.2 } : { duration: 1, repeat: Infinity, ease: "easeInOut" }}
+          />
+          live {Math.floor(sinceFetchS)}s
+        </span>
       </div>
       {gateReason && (
         <div className="text-[11px] text-[color:var(--text-muted)]">

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -194,7 +194,7 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
         <SlicesBar subtasks={task.subtasks!} reduced={reduced} />
       )}
       {/* Animated SDLC stepper — now SECONDARY to the slice bar above. */}
-      <SdlcDots step={stepId} reduced={reduced} />
+      <SdlcDots step={stepId} phase={task.phase_progress} reduced={reduced} />
       <div className="flex flex-wrap items-center gap-1">
         <TileBadge tone={actTone}>{actLabel}</TileBadge>
         {showGate && (
@@ -395,9 +395,13 @@ function SlicesBar({ subtasks, reduced }: {
 // before the current step read "done" (emerald), the current node pulses
 // teal with a ring, later nodes are muted. Color/size transition on advance
 // so a task visibly moves between phases (motion suppressed under reduced).
-function SdlcDots({ step, reduced }: { step?: string; reduced: boolean | null }) {
+function SdlcDots({ step, phase, reduced }: { step?: string; phase?: PhaseProgress | null; reduced: boolean | null }) {
   const steps = WORKFLOW_STEPS_ORDERED;
   const curIdx = steps.findIndex((s) => s.id === (step ?? ""));
+  // Fanout mode: when the CURRENT step dispatched sub-agents, subdivide its node
+  // into one cell per unit (returned filled) so "5 of 8 back" is visible inline.
+  const fd = phase?.fanout_dispatched ?? 0;
+  const fr = phase?.fanout_returned ?? 0;
   return (
     <div
       className="flex items-center"
@@ -417,17 +421,30 @@ function SdlcDots({ step, reduced }: { step?: string; reduced: boolean | null })
                 style={{ height: "1px", width: "0.55rem", background: reached ? "var(--accent-emerald-fg)" : "var(--border-default)" }}
               />
             )}
-            <span
-              className={[
-                isGate ? "rounded-[2px]" : "rounded-full",
-                current ? "w-2.5 h-2.5" : "w-2 h-2",
-                reduced ? "" : "transition-all duration-500",
-              ].join(" ")}
-              style={{
-                background: current ? "var(--accent-teal-fg)" : done ? "var(--accent-emerald-fg)" : "var(--surface-3)",
-                boxShadow: current ? "0 0 0 2px var(--accent-teal-ring)" : "none",
-              }}
-            />
+            {current && fd > 0 ? (
+              <span className="inline-flex items-center gap-[1.5px] mx-0.5" title={`fanout: ${fr}/${fd} sub-agents back`}>
+                {Array.from({ length: Math.min(fd, 12) }).map((_, k) => (
+                  <span key={k} style={{
+                    width: "3px", height: "10px", borderRadius: "1px",
+                    background: k < fr ? "var(--accent-teal-fg)" : "var(--surface-3)",
+                    boxShadow: k < fr ? "none" : "inset 0 0 0 1px var(--border-default)",
+                  }} />
+                ))}
+                <span className="ml-0.5 text-[8px] font-mono tabular-nums" style={{ color: "var(--accent-teal-fg)" }}>{fr}/{fd}</span>
+              </span>
+            ) : (
+              <span
+                className={[
+                  isGate ? "rounded-[2px]" : "rounded-full",
+                  current ? "w-2.5 h-2.5" : "w-2 h-2",
+                  reduced ? "" : "transition-all duration-500",
+                ].join(" ")}
+                style={{
+                  background: current ? "var(--accent-teal-fg)" : done ? "var(--accent-emerald-fg)" : "var(--surface-3)",
+                  boxShadow: current ? "0 0 0 2px var(--accent-teal-ring)" : "none",
+                }}
+              />
+            )}
           </div>
         );
       })}

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -161,6 +161,11 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
   const actState = (task.activity?.state ?? status).toLowerCase();
   const actTone: PillTone = ACT_TILE[actState]?.tone ?? statusTone;
   const actWorking = actState === "working";
+  // An ETA/countdown is only honest while the tile is ACTUALLY being driven and
+  // has work left. A paused/done tile must NOT show "N left" (a frozen lie).
+  const _ct = task.phase_progress?.children_total ?? 0;
+  const workLeft = _ct === 0 || (task.phase_progress?.children_done ?? 0) < _ct;
+  const showEta = actWorking && workLeft;
   // LIVE idle clock: server snapshot + seconds since the last poll, so it ticks
   // up every second instead of freezing between the 5s data refreshes.
   const liveMotionS = task.activity?.task_motion_s != null ? task.activity.task_motion_s + sinceFetchS : null;
@@ -216,7 +221,7 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
         {showGate && (
           <TileBadge tone={gateTone}>{gateLabel(gate as any)}</TileBadge>
         )}
-        {status === "in_progress" && (task.phase_progress?.eta_s ?? 0) > 5 && (
+        {showEta && (task.phase_progress?.eta_s ?? 0) > 5 && (
           <span
             className="text-[10px] uppercase tracking-wider font-mono px-1.5 py-0.5 rounded ring-1"
             style={{ background: "var(--accent-teal-bg)", color: "var(--accent-teal-fg)", boxShadow: "inset 0 0 0 1px var(--accent-teal-ring)" }}
@@ -295,7 +300,7 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
           />
         </div>
       </div>
-      {status === "in_progress" && (task.phase_progress?.eta_s ?? 0) > 5 && (task.phase_progress?.eta_total_s ?? 0) > 0 && (
+      {showEta && (task.phase_progress?.eta_s ?? 0) > 5 && (task.phase_progress?.eta_total_s ?? 0) > 0 && (
         <EtaCountdownBar
           etaS={task.phase_progress!.eta_s!}
           totalS={task.phase_progress!.eta_total_s!}

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -128,7 +128,7 @@ export default function ConductorPage() {
         {managed.length === 0 ? (
           <Empty>No tasks under conductor management. Call conductor_advance on a task to start one.</Empty>
         ) : (
-          <div className="grid grid-cols-[repeat(auto-fill,minmax(380px,1fr))] gap-3">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(520px,1fr))] gap-3">
             {managed.map((t) => (
               <TaskTile key={t.id} task={t} reduced={reduced} sinceFetchS={sinceFetchS} onClick={() =>
                 navigate(`/tasks/${t.id}`, { state: { from: "/conductor" } })

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -36,6 +36,7 @@ type ManagedTask = {
 // mm:ss (from task_motion_s) so the pill says how long it's been dark.
 const ACT_TILE: Record<string, { label: string; tone: PillTone }> = {
   working: { label: "working", tone: "teal" },
+  paused: { label: "paused", tone: "teal" },   // epic between slices — progress, NOT stalled
   awaiting_gate: { label: "awaiting review", tone: "amber" },
   adrift: { label: "session busy", tone: "slate" },
   stalled: { label: "stalled", tone: "rose" },
@@ -141,6 +142,7 @@ function TaskTile({ task, reduced, onClick }: { task: ManagedTask; reduced: bool
   const actLabel =
     actState === "adrift" ? `session busy${idle ? ` · idle ${idle}` : ""}`
     : actState === "stalled" ? `stalled${idle ? ` · idle ${idle}` : ""}`
+    : actState === "paused" ? `paused · ${task.phase_progress?.children_done ?? 0}/${task.phase_progress?.children_total ?? 0} done`
     : (ACT_TILE[actState]?.label ?? (status || "—"));
   const gate = task.gate_state ?? "none";
   const showGate = gate !== "none";

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -207,7 +207,7 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
           Rendered ABOVE the abstract SDLC stepper so "1 of 4 done, here's
           which" is the first thing read on the tile. */}
       {(task.subtasks?.length ?? 0) > 0 && (
-        <SlicesBar subtasks={task.subtasks!} reduced={reduced} />
+        <SlicesBar subtasks={task.subtasks!} stage={phaseLabel} reduced={reduced} />
       )}
       {/* Animated SDLC stepper — now SECONDARY to the slice bar above. */}
       <SdlcDots step={stepId} phase={task.phase_progress} reduced={reduced} />
@@ -376,47 +376,45 @@ function TileBadge({ tone, children }: { tone: PillTone; children: ReactNode }) 
 // done-first (server-ordered), so the row reads left-to-right as progress:
 // filled emerald + ✓ = done, teal (subtle pulse) = in progress, muted outline
 // = pending. Uses the shared Hermes accent vars — no per-surface palette.
-function SlicesBar({ subtasks, reduced }: {
+// Focused slice line: shows ONLY the slice we're working on (or the next up) +
+// the stage — not all N chips. "Slice 3/4 · ▶ Bidirectional Jira sync · implement".
+function SlicesBar({ subtasks, stage, reduced }: {
   subtasks: { id: string; title: string; status: string }[];
+  stage?: string;
   reduced: boolean | null;
 }) {
   const done = subtasks.filter((s) => (s.status || "").toLowerCase() === "done").length;
+  const active = subtasks.find((s) => (s.status || "").toLowerCase() === "in_progress");
+  const next = subtasks.find((s) => (s.status || "").toLowerCase() === "pending");
+  const focus = active ?? next;
+  const allDone = done === subtasks.length && subtasks.length > 0;
   return (
-    <div className="flex flex-col gap-1" title={`${done} of ${subtasks.length} slices done`}>
-      <span className="text-[10px] uppercase tracking-[0.14em] font-mono text-[color:var(--text-secondary)]">
-        Slices <span className="text-[color:var(--accent-emerald-fg)]">{done}</span>/{subtasks.length}
+    <div className="flex items-center gap-2 flex-wrap" title={`${done} of ${subtasks.length} slices done`}>
+      <span className="text-[10px] uppercase tracking-[0.14em] font-mono text-[color:var(--text-secondary)] shrink-0">
+        Slice <span className="text-[color:var(--accent-emerald-fg)]">{done}</span>/{subtasks.length}
       </span>
-      <div className="flex flex-wrap gap-1">
-        {subtasks.map((s) => {
-          const st = (s.status || "").toLowerCase();
-          const isDone = st === "done";
-          const isActive = st === "in_progress";
-          const tone = isDone ? "emerald" : isActive ? "teal" : null;
-          const chip = (
-            <span
-              key={s.id}
-              className="inline-flex items-center gap-1 text-[10px] font-mono px-1.5 py-0.5 rounded-sm max-w-[11rem] truncate"
-              style={tone ? {
-                background: `var(--accent-${tone}-bg)`,
-                color: `var(--accent-${tone}-fg)`,
-                boxShadow: `inset 0 0 0 1px var(--accent-${tone}-ring)`,
-              } : {
-                color: "var(--text-muted)",
-                boxShadow: "inset 0 0 0 1px var(--border-default)",
-              }}
-              title={`${s.title} · ${st || "pending"}`}
-            >
-              {isDone && <span aria-hidden>✓</span>}
-              <span className="truncate">{sliceLabel(s)}</span>
+      {allDone ? (
+        <span className="text-[11px] font-mono" style={{ color: "var(--accent-emerald-fg)" }}>✓ all slices done</span>
+      ) : focus ? (
+        <span className="inline-flex items-center gap-1.5 min-w-0">
+          {active ? (
+            <motion.span className="inline-block h-1.5 w-1.5 rounded-full shrink-0" style={{ background: "var(--accent-teal-fg)" }}
+              animate={reduced ? { opacity: 1 } : { opacity: [1, 0.3, 1] }}
+              transition={reduced ? { duration: 0.2 } : { duration: 1.2, repeat: Infinity, ease: "easeInOut" }} />
+          ) : (
+            <span className="text-[9px] font-mono uppercase tracking-wide text-[color:var(--text-muted)] shrink-0">next</span>
+          )}
+          <span className="text-[12px] font-medium truncate max-w-[13rem] text-[color:var(--text-primary)]" title={focus.title}>
+            {sliceLabel(focus)}
+          </span>
+          {active && stage && (
+            <span className="text-[9px] font-mono px-1.5 py-0.5 rounded-sm shrink-0"
+              style={{ background: "var(--accent-teal-bg)", color: "var(--accent-teal-fg)", boxShadow: "inset 0 0 0 1px var(--accent-teal-ring)" }}>
+              {stage}
             </span>
-          );
-          return isActive && !reduced ? (
-            <motion.span key={s.id} animate={{ opacity: [1, 0.55, 1] }}
-              transition={{ duration: 1.4, repeat: Infinity, ease: "easeInOut" }}
-              className="inline-flex">{chip}</motion.span>
-          ) : chip;
-        })}
-      </div>
+          )}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/ConductorPage.tsx
@@ -121,9 +121,9 @@ export default function ConductorPage() {
       <Card>
         <SectionLabel>Under conductor</SectionLabel>
         <p className="text-[11px] opacity-60 mt-1 mb-3">
-          Workflow-claimed tasks moving through the 8-step SDLC. Each tile's stepper fills to the
-          task's current phase (shown top-right) and advances automatically as the conductor drives
-          it. Tasks worked without conductor (status flips only) don't appear here. Click a tile to open it.
+          Workflow-claimed tasks moving through the SDLC. Each tile leads with a completion ring and a
+          labeled phase timeline (the task's current phase shown top-right) that advance automatically as the
+          conductor drives it. Tasks worked without conductor (status flips only) don't appear here. Click a tile to open it.
         </p>
         {managed.length === 0 ? (
           <Empty>No tasks under conductor management. Call conductor_advance on a task to start one.</Empty>
@@ -142,17 +142,15 @@ export default function ConductorPage() {
 }
 
 // ---------------------------------------------------------------------------
-// TaskTile — uniform-sized swimlane tile (v6.0.43)
+// TaskTile — uniform-sized swimlane tile.
 //
-// Replaces the variable-width truncated pill that used to render each task
-// inside its lane. Sized by the parent's auto-fill CSS grid (minmax 220px)
-// so the lane reads as a row of equal cards; each tile then exposes the
-// SDLC signal the swimlanes are trying to communicate at a glance:
-//   - title (2-line clamp, font-medium)
-//   - status badge + gate badge (when gate_state != 'none')
-//   - p{priority} . {relative_age} . id {short_id}
-//   - owner: {assigned_agent or 'unassigned'}
-//   - up to 3 tag chips
+// Leads with the approved ring+timeline design (variant C hero: completion
+// ring + 2×2 live metric grid; variant D: a labeled phase timeline over the
+// REAL WORKFLOW_STEPS_ORDERED) while preserving the honest-activity signals:
+// the pill reads task.activity.state (working/awaiting_gate/adrift/stalled),
+// the current timeline node pulses only when working and subdivides in fanout,
+// the idle clock ticks only when paused/adrift, and the burn graph + ETA are
+// gated on real motion so a paused tile never shows a frozen "N left" lie.
 // ---------------------------------------------------------------------------
 function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; reduced: boolean | null; sinceFetchS: number; onClick: () => void }) {
   const status = (task.status ?? "").toLowerCase();
@@ -208,14 +206,16 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
           {phaseLabel}
         </span>
       </div>
-      {/* Real progress HERO: the epic's slices, done-first, one chip each.
-          Rendered ABOVE the abstract SDLC stepper so "1 of 4 done, here's
-          which" is the first thing read on the tile. */}
+      {/* Real-progress hero for epics: the focused slice + stage, above the
+          at-a-glance ring so "which slice" reads first on an epic tile. */}
       {(task.subtasks?.length ?? 0) > 0 && (
         <SlicesBar subtasks={task.subtasks!} stage={phaseLabel} reduced={reduced} />
       )}
-      {/* Animated SDLC stepper — now SECONDARY to the slice bar above. */}
-      <SdlcDots step={stepId} phase={task.phase_progress} reduced={reduced} />
+      {/* Hero (variant C): completion ring + 2×2 live metric grid. */}
+      <TileHero task={task} sinceFetchS={sinceFetchS} />
+      {/* Labeled phase timeline (variant D) — replaces the abstract SdlcDots,
+          keeping the fanout subdivision + working-only pulse on the current step. */}
+      <LabeledTimeline step={stepId} phase={task.phase_progress} reduced={reduced} live={actWorking} />
       <div className="flex flex-wrap items-center gap-1">
         <TileBadge tone={actTone}>{actLabel}</TileBadge>
         {showGate && (
@@ -263,9 +263,9 @@ function TaskTile({ task, reduced, sinceFetchS, onClick }: { task: ManagedTask; 
         </div>
       )}
 
-      {/* Two-column body: identity/meta + SDLC phase on the LEFT, the live
-          per-turn burn graph on the RIGHT. The graph is the only token surface
-          on the tile (rate), the left is the only meta surface — no overlap. */}
+      {/* Two-column body: identity/meta on the LEFT, the live per-turn burn
+          graph on the RIGHT. The graph is the only token surface on the tile
+          (rate), the left is the only meta surface — no overlap. */}
       <div className="mt-1 grid grid-cols-[1fr_44%] gap-3 items-stretch">
         <div className="flex flex-col gap-1.5 min-w-0">
           <div className="text-[11px] font-mono text-[color:var(--text-muted)] truncate">
@@ -377,12 +377,10 @@ function TileBadge({ tone, children }: { tone: PillTone; children: ReactNode }) 
   );
 }
 
-// SlicesBar — the REAL-progress hero for an epic tile. One chip per slice,
-// done-first (server-ordered), so the row reads left-to-right as progress:
-// filled emerald + ✓ = done, teal (subtle pulse) = in progress, muted outline
-// = pending. Uses the shared Hermes accent vars — no per-surface palette.
-// Focused slice line: shows ONLY the slice we're working on (or the next up) +
-// the stage — not all N chips. "Slice 3/4 · ▶ Bidirectional Jira sync · implement".
+// SlicesBar — the REAL-progress hero for an epic tile. Focused slice line: shows
+// ONLY the slice we're working on (or the next up) + the stage — not all N
+// chips. "Slice 3/4 · ▶ Bidirectional Jira sync · implement". Uses the shared
+// Hermes accent vars — no per-surface palette.
 function SlicesBar({ subtasks, stage, reduced }: {
   subtasks: { id: string; title: string; status: string }[];
   stage?: string;
@@ -424,61 +422,128 @@ function SlicesBar({ subtasks, stage, reduced }: {
   );
 }
 
-// SdlcDots — the animated SDLC stepper. One node per WORKFLOW_STEPS_ORDERED
-// step (circle for an agent/intake step, rounded square for a gate); nodes
-// before the current step read "done" (emerald), the current node pulses
-// teal with a ring, later nodes are muted. Color/size transition on advance
-// so a task visibly moves between phases (motion suppressed under reduced).
-function SdlcDots({ step, phase, reduced }: { step?: string; phase?: PhaseProgress | null; reduced: boolean | null }) {
+// TileHero — the completion RING (done SDLC steps / total over the REAL
+// WORKFLOW_STEPS_ORDERED) beside a 2×2 metric grid. Every value is sourced from
+// LIVE task.phase_progress / task.activity (never mock/hardcoded): current
+// phase from workflow_step, time-left from eta_s (only while working with work
+// left, else "—" so a paused tile shows no frozen lie), throughput from the
+// token-turn series, idle from the honest motion clock.
+function TileHero({ task, sinceFetchS }: { task: ManagedTask; sinceFetchS: number }) {
+  const steps = WORKFLOW_STEPS_ORDERED;
+  const stepId = task.workflow_step ?? "";
+  const status = (task.status ?? "").toLowerCase();
+  const actState = (task.activity?.state ?? status).toLowerCase();
+  const working = actState === "working";
+  const curIdx = steps.findIndex((s) => s.id === stepId);
+  const total = steps.length;
+  const done = curIdx < 0 ? (status === "done" ? total : 0) : curIdx;
+  const frac = total > 0 ? done / total : 0;
+
+  const pp = task.phase_progress;
+  const _ct = pp?.children_total ?? 0;
+  const workLeft = _ct === 0 || (pp?.children_done ?? 0) < _ct;
+  const curPhase = stepId ? stepLabel(stepId) : status === "done" ? "done" : "queued";
+  // Honest time-left: only while actually working with work left.
+  const timeLeft = working && workLeft && (pp?.eta_s ?? 0) > 0 ? `~${fmtEtaTile(pp!.eta_s!)}` : "—";
+  const turns = pp?.turns ?? pp?.token_turns?.length ?? 0;
+  const throughput = turns > 0 ? `${turns} turns` : "—";
+  // Honest idle: the live motion clock when the server serves activity;
+  // "active" while working; else the time since the last board motion.
+  const liveMotionS = task.activity?.task_motion_s != null ? task.activity.task_motion_s + sinceFetchS : null;
+  const idle = working ? "active"
+    : liveMotionS != null ? fmtIdle(liveMotionS)
+    : relativeTime(task.updated_at || task.created_at || "");
+
+  const R = 20, STROKE = 5, CIRC = 2 * Math.PI * R;
+  return (
+    <div className="mt-1 flex items-center gap-3">
+      <div className="relative shrink-0" style={{ width: 52, height: 52 }} title={`${done} of ${total} SDLC phases complete`}>
+        <svg width="52" height="52" viewBox="0 0 52 52" role="img" aria-label={`${done} of ${total} phases complete`}>
+          <circle cx="26" cy="26" r={R} fill="none" stroke="var(--surface-3)" strokeWidth={STROKE} />
+          <circle
+            cx="26" cy="26" r={R} fill="none"
+            stroke="var(--accent-emerald-fg)" strokeWidth={STROKE} strokeLinecap="round"
+            strokeDasharray={CIRC} strokeDashoffset={CIRC * (1 - frac)}
+            transform="rotate(-90 26 26)"
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center leading-none">
+          <span className="text-[12px] font-mono font-semibold tabular-nums text-[color:var(--text-primary)]">{done}/{total}</span>
+          <span className="text-[7px] uppercase tracking-[0.14em] text-[color:var(--text-muted)]">phases</span>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-1.5 flex-1 min-w-0">
+        <MetricCell label="Current phase" value={curPhase} />
+        <MetricCell label="Time left" value={timeLeft} />
+        <MetricCell label="Throughput" value={throughput} />
+        <MetricCell label="Idle" value={idle} />
+      </div>
+    </div>
+  );
+}
+
+// One cell of the hero's 2×2 live-metric grid: a muted uppercase label over a
+// single value, all in canonical --text-* tokens.
+function MetricCell({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded bg-[color:var(--surface-3)]/50 px-1.5 py-1 min-w-0">
+      <div className="text-[8px] uppercase tracking-[0.12em] font-mono text-[color:var(--text-muted)] truncate">{label}</div>
+      <div className="text-[11px] font-mono tabular-nums text-[color:var(--text-secondary)] truncate">{value}</div>
+    </div>
+  );
+}
+
+// LabeledTimeline — the variant-D phase index: one node per real
+// WORKFLOW_STEPS_ORDERED step with a VISIBLE stepLabel caption under each
+// (circle for an agent/intake step, rounded square for a gate). Steps before
+// the current read done (emerald ✓), the current node is teal and pulses ONLY
+// while the task is live (working), later nodes are muted. When the current
+// step dispatched sub-agents, its node SUBDIVIDES into one cell per unit
+// (returned filled teal) so "5 of 8 back" is visible inline.
+function LabeledTimeline({ step, phase, reduced, live }: { step?: string; phase?: PhaseProgress | null; reduced: boolean | null; live: boolean }) {
   const steps = WORKFLOW_STEPS_ORDERED;
   const curIdx = steps.findIndex((s) => s.id === (step ?? ""));
-  // Fanout mode: when the CURRENT step dispatched sub-agents, subdivide its node
-  // into one cell per unit (returned filled) so "5 of 8 back" is visible inline.
   const fd = phase?.fanout_dispatched ?? 0;
   const fr = phase?.fanout_returned ?? 0;
   return (
     <div
-      className="flex items-center"
+      className="mt-1 flex items-start gap-0.5 overflow-x-auto"
       role="img"
       aria-label={curIdx < 0 ? "SDLC not started" : `SDLC phase ${curIdx + 1} of ${steps.length}: ${stepLabel(steps[curIdx].id)}`}
     >
       {steps.map((s, i) => {
         const done = curIdx >= 0 && i < curIdx;
         const current = i === curIdx;
-        const reached = done || current;
         const isGate = s.type === "gate";
         return (
-          <div key={s.id} className="flex items-center" title={stepLabel(s.id) || s.id}>
-            {i > 0 && (
-              <span
-                className={reduced ? "" : "transition-colors duration-500"}
-                style={{ height: "1px", width: "0.55rem", background: reached ? "var(--accent-emerald-fg)" : "var(--border-default)" }}
-              />
-            )}
+          <div key={s.id} className="flex flex-col items-center gap-1 flex-1 min-w-[26px]" title={stepLabel(s.id) || s.id}>
             {current && fd > 0 ? (
-              <span className="inline-flex items-center gap-[1.5px] mx-0.5" title={`fanout: ${fr}/${fd} sub-agents back`}>
-                {Array.from({ length: Math.min(fd, 12) }).map((_, k) => (
+              <span className="inline-flex items-center gap-[1.5px] h-2.5" title={`fanout: ${fr}/${fd} sub-agents back`}>
+                {Array.from({ length: Math.min(fd, 8) }).map((_, k) => (
                   <span key={k} style={{
                     width: "3px", height: "10px", borderRadius: "1px",
                     background: k < fr ? "var(--accent-teal-fg)" : "var(--surface-3)",
                     boxShadow: k < fr ? "none" : "inset 0 0 0 1px var(--border-default)",
                   }} />
                 ))}
-                <span className="ml-0.5 text-[8px] font-mono tabular-nums" style={{ color: "var(--accent-teal-fg)" }}>{fr}/{fd}</span>
               </span>
             ) : (
-              <span
-                className={[
-                  isGate ? "rounded-[2px]" : "rounded-full",
-                  current ? "w-2.5 h-2.5" : "w-2 h-2",
-                  reduced ? "" : "transition-all duration-500",
-                ].join(" ")}
+              <motion.span
+                className={[isGate ? "rounded-[2px]" : "rounded-full", "w-2.5 h-2.5"].join(" ")}
                 style={{
                   background: current ? "var(--accent-teal-fg)" : done ? "var(--accent-emerald-fg)" : "var(--surface-3)",
                   boxShadow: current ? "0 0 0 2px var(--accent-teal-ring)" : "none",
                 }}
+                animate={!reduced && current && live ? { opacity: [1, 0.4, 1] } : { opacity: 1 }}
+                transition={!reduced && current && live ? { duration: 1.2, repeat: Infinity, ease: "easeInOut" } : { duration: 0.2 }}
               />
             )}
+            <span
+              className="text-[7px] leading-tight text-center w-full truncate"
+              style={{ color: done || current ? "var(--text-secondary)" : "var(--text-muted)" }}
+            >
+              {stepLabel(s.id) || s.id}
+            </span>
           </div>
         );
       })}

--- a/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
+++ b/services/prism-service/prism_service/web/src/pages/TaskDetailPage.tsx
@@ -7,7 +7,7 @@ import { Page, Card, SectionLabel, Empty, toneFromLabel, type PillTone } from "@
 import { domainTone, priorityTone } from "@/lib/domainTone";
 import PlanView from "@/components/plan/PlanView";
 import Markdown from "@/components/Markdown";
-import { type PhaseProgress } from "@/components/conductor/SdlcProgress";
+import { type PhaseProgress, type Activity } from "@/components/conductor/SdlcProgress";
 import { type Timeline } from "@/components/conductor/TaskActivityGantt";
 import { EASE_OUT, DUR, SPRING_SNAPPY, staggerDelay } from "@/lib/motion";
 // "2.9B" / "476.9k" / "512" — compact token count (shared k/M/B formatter).
@@ -44,6 +44,8 @@ type Task = {
   plan_doc?: string;
   plan_diagram?: string;
   phase_progress?: PhaseProgress | null;
+  // Honest work state — rides top-level on the detail response (see load()).
+  activity?: Activity | null;
   has_prototype?: boolean;
 };
 
@@ -400,13 +402,13 @@ export default function TaskDetailPage() {
   const load = useCallback(async () => {
     if (!id) return;
     try {
-      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; timeline?: Timeline | null; has_prototype?: boolean }>(
+      const d = await api.get<{ task: Task; history: HistoryRow[]; sessions?: SessionRow[]; phase_progress?: PhaseProgress | null; activity?: Activity | null; timeline?: Timeline | null; has_prototype?: boolean }>(
         `/api/tasks/${id}?project=${project}`,
       );
-      // phase_progress + has_prototype ride at the TOP LEVEL of the response
-      // (not nested in task) — merge onto the task so the SDLC bar and the
-      // prototype iframe read them off task.*.
-      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, has_prototype: d.has_prototype ?? false } : d.task);
+      // phase_progress + activity + has_prototype ride at the TOP LEVEL of the
+      // response (not nested in task) — merge onto the task so the SDLC bar, the
+      // honest work-state pill, and the prototype iframe read them off task.*.
+      setTask(d.task ? { ...d.task, phase_progress: d.phase_progress ?? d.task.phase_progress ?? null, activity: d.activity ?? d.task.activity ?? null, has_prototype: d.has_prototype ?? false } : d.task);
       setHistory(d.history ?? []);
       setSessions(d.sessions ?? []);
       setTimeline(d.timeline ?? null);
@@ -683,6 +685,7 @@ export default function TaskDetailPage() {
               gateReason: task.gate_reason,
               phase: task.phase_progress,
               status: task.status,
+              activity: task.activity,
               timeline,
             } : null}
             gate={{

--- a/services/prism-service/tests/integration/test_conductor_tile_ring_timeline_production.py
+++ b/services/prism-service/tests/integration/test_conductor_tile_ring_timeline_production.py
@@ -1,0 +1,117 @@
+"""RED scaffold — Conductor PRODUCTION tile: completion ring + labeled phase
+timeline (task 696cacf5).
+
+The dependency task 24ea4027 shipped the approved Timeline-D MOCK prototype
+(pinned by test_conductor_card_ring_timeline_prototype.py). THIS task ports it
+into the REAL production React component customers get via `prism update`:
+prism_service/web/src/pages/ConductorPage.tsx > TaskTile.
+
+These tests scan the real SPA source on disk — the same USER-FACING render
+seam the sibling test_ui_first_conductor_gate_admin_surfaces.py uses (the
+pytest suite has no JS runner). They FAIL today because TaskTile still leads
+with the abstract SdlcDots stepper and has no completion ring, no 2x2 metric
+grid, no labeled timeline, and no peak-marked sparkline.
+
+Scope note (verified on disk): honest-activity (task.activity.state /
+task_motion_s / adrift) is NOT served by ConductorService.managed_tasks() on
+this branch and conductor_service.py is outside this task's allowed_files, so
+AC-6 liveness stays on the in-scope per-task signal already served
+(status/phase_progress) rather than a field that does not exist end-to-end.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401  (registers the integration test module)
+
+_HERE = Path(__file__).resolve()
+_SERVICE_ROOT = _HERE.parent.parent.parent  # .../services/prism-service
+if str(_SERVICE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SERVICE_ROOT))
+
+_WEB_SRC = _SERVICE_ROOT / "prism_service" / "web" / "src"
+_CONDUCTOR_PAGE = _WEB_SRC / "pages" / "ConductorPage.tsx"
+_TOKEN_TURNS = _WEB_SRC / "components" / "conductor" / "TokenTurns.tsx"
+
+
+def _page() -> str:
+    assert _CONDUCTOR_PAGE.exists(), f"missing {_CONDUCTOR_PAGE}"
+    return _CONDUCTOR_PAGE.read_text(encoding="utf-8")
+
+
+def _token_turns() -> str:
+    assert _TOKEN_TURNS.exists(), f"missing {_TOKEN_TURNS}"
+    return _TOKEN_TURNS.read_text(encoding="utf-8")
+
+
+# ── AC-4: the abstract SdlcDots stepper is gone from the tile render ─────────
+def test_tasktile_no_longer_renders_abstract_sdlcdots():
+    src = _page()
+    assert "<SdlcDots" not in src, (
+        "TaskTile must replace the abstract SdlcDots stepper with the labeled "
+        "phase timeline (AC-4) — no <SdlcDots .../> usage may remain in the tile"
+    )
+
+
+# ── AC-1: completion RING = done steps / total, center label 'n/N phases' ────
+def test_tasktile_renders_completion_ring():
+    src = _page()
+    assert "phases" in src, (
+        "completion-ring center label ('n/N phases') is missing — the hero must "
+        "lead with a ring reading done SDLC steps / total (AC-1)"
+    )
+    assert ("<svg" in src) or ("conic-gradient" in src), (
+        "the completion ring must render as an SVG arc (or conic-gradient) — the "
+        "tile has no ring element today (AC-1)"
+    )
+    # Denominator = the REAL step order, not the mock's 8 friendly names.
+    assert "WORKFLOW_STEPS_ORDERED" in src
+
+
+# ── AC-2: 2x2 metric grid, values sourced from live phase_progress ───────────
+def test_tasktile_renders_2x2_metric_grid_from_phase_progress():
+    src = _page()
+    for label in ("Current phase", "Time left", "Throughput", "Idle"):
+        assert label in src, f"metric-grid cell '{label}' missing from hero (AC-2)"
+    # Values must be wired to LIVE phase_progress, not hardcoded/mock (misfire).
+    assert "phase_progress" in src, (
+        "metric grid must read task.phase_progress, not hardcoded mock values"
+    )
+
+
+# ── AC-3: labeled timeline — a VISIBLE stepLabel caption per real step ───────
+def test_tasktile_labeled_timeline_captions_each_step():
+    src = _page()
+    # A stepLabel rendered as a JSX *child* (visible node caption), NOT merely
+    # inside a title=/aria-label attribute the way SdlcDots does today.
+    visible = re.findall(r"(?:^|[>\s])\{stepLabel\(", src, re.M)
+    assert visible, (
+        "the labeled timeline must render stepLabel() as a VISIBLE caption "
+        "under each WORKFLOW_STEPS_ORDERED node (AC-3) — today stepLabel only "
+        "appears inside title=/aria-label attributes on SdlcDots"
+    )
+
+
+# ── AC-5: throughput sparkline MARKS the peak bar (not just a numeric readout)
+def test_tokenturns_marks_the_peak_bar():
+    src = _token_turns()
+    assert re.search(r"isPeak|peakIdx|peakIndex", src), (
+        "TokenTurns must visually MARK which bar is the window peak (AC-5) — "
+        "today it computes a scalar `peak` and only prints a numeric readout, "
+        "with no per-bar peak marker"
+    )
+
+
+# ── NFR-1 (green guard): canonical Hermes --accent-* tokens, no per-surface
+#    palette — keeps the token doctrine from regressing through the rebuild.
+def test_new_surfaces_use_canonical_accent_tokens_no_invented_palette():
+    both = _page() + "\n" + _token_turns()
+    assert "var(--accent-" in both, "tiles must use the canonical --accent-* tokens"
+    # No bespoke per-surface custom-property DECLARATIONS (e.g. `--teal-500:`).
+    for tone in ("teal", "emerald", "amber", "rose"):
+        assert not re.search(rf"--{tone}-\w+\s*:", both), (
+            f"invented per-surface --{tone}-* custom property declared — all "
+            "color must derive from the single-source --accent-* palette (NFR-1)"
+        )

--- a/services/prism-service/tests/integration/test_task_activity_gantt.py
+++ b/services/prism-service/tests/integration/test_task_activity_gantt.py
@@ -241,13 +241,19 @@ def test_gantt_component_exists_and_exports_timeline_type():
 
 
 def test_taskdetail_threads_timeline_and_renders_activity_card():
+    # v6.7.30 folded the Conductor+Activity panel into PlanView's Implementation
+    # tab: TaskDetailPage still owns the timeline STATE (imports the Timeline
+    # type, threads d.timeline via setTimeline, passes it down), while the
+    # actual <TaskActivityGantt> render + its "Activity"/Timeline surface moved
+    # to the render owner PlanView. Re-pointed to both real owners.
     src = _read("pages/TaskDetailPage.tsx")
-    assert "TaskActivityGantt" in src
+    assert "TaskActivityGantt" in src    # Timeline type imported here
     assert "import" in src and "TaskActivityGantt" in src
     assert "timeline" in src              # state threaded from d.timeline
     assert "setTimeline" in src
-    assert "Activity" in src              # the new Card label
-    assert "<TaskActivityGantt" in src
+    plan = _read("components/plan/PlanView.tsx")
+    assert "Activity" in plan             # the Card / sub-view label
+    assert "<TaskActivityGantt" in plan   # the wall-clock Gantt render
 
 
 def test_taskdetail_sessions_list_filters_to_real_uuid_sessions():

--- a/services/prism-service/tests/integration/test_ui_first_conductor_gate_admin_surfaces.py
+++ b/services/prism-service/tests/integration/test_ui_first_conductor_gate_admin_surfaces.py
@@ -258,15 +258,23 @@ def test_brain_and_graph_pages_deleted():
 
 
 def test_task_detail_page_has_operable_gate_controls():
-    src = _read("TaskDetailPage.tsx")
+    # v6.7.30 folded the gate controls into PlanView's Implementation tab:
+    # TaskDetailPage still owns the /api/conductor/gate WIRING (gateDecide) and
+    # delegates the operable Approve/Reject + required reason textarea + override
+    # checkbox to the render owner PlanView via the `gate` prop. Re-pointed the
+    # control assertions to PlanView, keeping the endpoint wiring on TaskDetail.
+    plan = (_WEB_SRC / "components" / "plan" / "PlanView.tsx").read_text(
+        encoding="utf-8"
+    )
     # Approve / Reject controls.
-    assert re.search(r"[Aa]pprove", src), "missing Approve control"
-    assert re.search(r"[Rr]eject", src), "missing Reject control"
+    assert re.search(r"[Aa]pprove", plan), "missing Approve control"
+    assert re.search(r"[Rr]eject", plan), "missing Reject control"
     # A reason textarea (required) + an override checkbox.
-    assert "textarea" in src.lower(), "missing required reason textarea"
-    assert re.search(r"override", src, re.IGNORECASE), "missing override checkbox"
+    assert "textarea" in plan.lower(), "missing required reason textarea"
+    assert re.search(r"override", plan, re.IGNORECASE), "missing override checkbox"
     # Wired to the new HTTP endpoint, not the bare status PATCH.
-    assert "/api/conductor/gate" in src or "conductor/gate" in src, (
+    detail = _read("TaskDetailPage.tsx")
+    assert "/api/conductor/gate" in detail or "conductor/gate" in detail, (
         "gate controls must POST to the conductor gate endpoint"
     )
 

--- a/services/prism-service/tests/test_activity_state.py
+++ b/services/prism-service/tests/test_activity_state.py
@@ -1,0 +1,107 @@
+"""Honest per-task activity classifier — ConductorService.activity_for.
+
+The /conductor tile used to read the raw task STATUS ("in_progress" + a live
+burn graph) even when nothing was driving the task — a lie. activity_for
+computes the REAL work state from two signals: task_motion_s (recency of the
+last conductor transition on THIS task, from task_history) and session_quiet_s
+(recency of the linked session's live transcript, carried on phase_progress).
+
+state table (see conductor_service.activity_for):
+  done / blocked / pending          <- straight from status
+  in_progress:
+    awaiting_gate  at a *_gate with gate_state pending/failed  (a WAIT)
+    working        a conductor transition moved THIS task <=120s ago
+    adrift         session alive (<=90s) but task idle >120s
+    stalled        both stale — nothing is driving it
+"""
+
+from datetime import datetime, timezone, timedelta
+
+
+def _cond(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    scores_db = str(tmp_path / "scores.db")
+    task_svc = TaskService(str(tmp_path / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    return cond, task_svc
+
+
+def _old_transition(task_svc, task_id, seconds_ago):
+    """Insert an advance_task history row dated `seconds_ago` in the past so
+    task_motion_s reads stale (real transitions write `now`; we can't)."""
+    ts = (datetime.now(timezone.utc) - timedelta(seconds=seconds_ago)).isoformat()
+    task_svc._db.execute(
+        "INSERT INTO task_history (task_id, actor, action, details, timestamp) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (task_id, "", "advance_task", "to=implement_tasks", ts),
+    )
+    task_svc._db.commit()
+
+
+def test_working_recent_transition(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="being driven")
+    task_svc.update(t.id, status="in_progress", workflow_step="implement_tasks")
+    # A conductor transition on THIS task just now → motion ~0s.
+    task_svc.record_history(t.id, action="advance_task", details="to=implement_tasks")
+    act = cond.activity_for(task_svc.get(t.id), {"session_quiet_s": None})
+    assert act["state"] == "working"
+    assert act["task_motion_s"] is not None and act["task_motion_s"] <= 120
+
+
+def test_awaiting_gate(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="at a gate")
+    task_svc.update(t.id, status="in_progress",
+                    workflow_step="green_gate", gate_state="pending")
+    # Recent motion must NOT mask the gate wait.
+    task_svc.record_history(t.id, action="advance_task", details="to=green_gate")
+    act = cond.activity_for(task_svc.get(t.id), {"session_quiet_s": 5})
+    assert act["state"] == "awaiting_gate"
+
+
+def test_adrift_session_alive_task_idle(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="session busy elsewhere")
+    task_svc.update(t.id, status="in_progress", workflow_step="implement_tasks")
+    _old_transition(task_svc, t.id, seconds_ago=600)   # task idle > 120s
+    act = cond.activity_for(task_svc.get(t.id), {"session_quiet_s": 30})  # alive
+    assert act["state"] == "adrift"
+    assert act["task_motion_s"] > 120
+
+
+def test_stalled_both_stale(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="nothing driving it")
+    task_svc.update(t.id, status="in_progress", workflow_step="implement_tasks")
+    _old_transition(task_svc, t.id, seconds_ago=600)   # task idle > 120s
+    act = cond.activity_for(task_svc.get(t.id), {"session_quiet_s": None})  # quiet
+    assert act["state"] == "stalled"
+
+
+def test_stalled_when_session_also_quiet(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="session quiet too")
+    task_svc.update(t.id, status="in_progress", workflow_step="implement_tasks")
+    _old_transition(task_svc, t.id, seconds_ago=600)
+    act = cond.activity_for(task_svc.get(t.id), {"session_quiet_s": 300})  # >90
+    assert act["state"] == "stalled"
+
+
+def test_done_and_blocked(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    d = task_svc.create(title="shipped")
+    task_svc.update(d.id, status="done")
+    assert cond.activity_for(task_svc.get(d.id), {})["state"] == "done"
+
+    b = task_svc.create(title="blocked on dep")
+    task_svc.update(b.id, status="blocked")
+    assert cond.activity_for(task_svc.get(b.id), {})["state"] == "blocked"
+
+
+def test_pending_stays_pending(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    p = task_svc.create(title="backlog")
+    assert cond.activity_for(task_svc.get(p.id), {})["state"] == "pending"

--- a/services/prism-service/tests/test_step_fanout.py
+++ b/services/prism-service/tests/test_step_fanout.py
@@ -1,0 +1,43 @@
+"""Per-step fanout telemetry — set_step_fanout UPSERT + phase_progress basis.
+
+The fanout signal counts EPHEMERAL sub-agent units dispatched vs returned for
+the CURRENT workflow step (e.g. "8 test-writers handed out, 3 back") — distinct
+from phase_progress' CHILD-TASK 'children' basis. With no child tasks (as for
+write_failing_tests) fanout must win over the wall-clock 'time' estimate.
+"""
+
+
+def _cond(tmp_path):
+    from prism_service.services.task_service import TaskService
+    from prism_service.services.conductor_service import ConductorService
+
+    scores_db = str(tmp_path / "scores.db")
+    task_svc = TaskService(str(tmp_path / "tasks.db"), scores_db=scores_db)
+    cond = ConductorService(scores_db, enable_engine=False, task_svc=task_svc)
+    return cond, task_svc
+
+
+def test_set_step_fanout_upserts_and_phase_progress_prefers_fanout(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="fanout task")
+    task_svc.update(t.id, workflow_step="write_failing_tests")
+
+    row = cond.set_step_fanout(t.id, "write_failing_tests", 8, 3)
+    assert row["dispatched"] == 8 and row["returned"] == 3
+
+    pp = cond.phase_progress(t.id)
+    assert pp["fanout_dispatched"] == 8
+    assert pp["fanout_returned"] == 3
+    assert pp["basis"] == "fanout"
+    assert abs(pp["pct"] - 3 / 8) < 1e-6
+
+
+def test_set_step_fanout_upsert_overwrites(tmp_path):
+    cond, task_svc = _cond(tmp_path)
+    t = task_svc.create(title="fanout upsert")
+    task_svc.update(t.id, workflow_step="write_failing_tests")
+
+    cond.set_step_fanout(t.id, "write_failing_tests", 8, 3)
+    row = cond.set_step_fanout(t.id, "write_failing_tests", 8, 8)
+    assert row["dispatched"] == 8 and row["returned"] == 8
+    assert cond._step_fanout(t.id, "write_failing_tests") == (8, 8)

--- a/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
+++ b/services/prism-service/tests/unit/test_conductor_page_animated_cleanup_ui.py
@@ -82,14 +82,16 @@ def test_tile_autofill_grid_widens_and_gaps_for_progress_bar():
 
 def test_tile_renders_animated_stepper_and_phase_label():
     src = _read(_CONDUCTOR)
-    # SUPERSEDED by v6.3.19: the SDLC bar + "SDLC" text label were replaced by
-    # an animated dot stepper (SdlcDots) plus the current-phase label moved to
-    # the tile's top-right. The tile must render BOTH so progress still reads
-    # at a glance. Scope to the TaskTile function (the SdlcDots definition also
-    # lives later in the file, but the JSX <SdlcDots/> usage is in the tile).
+    # RE-POINTED by v6.8.18 (task 696cacf5): the abstract SdlcDots dot stepper
+    # is REPLACED by the LabeledTimeline (a node per real WORKFLOW_STEPS_ORDERED
+    # step with a visible stepLabel caption) — AC-4 of the production ring+
+    # timeline tile. The at-a-glance progress invariant this test guards is now
+    # owned by <LabeledTimeline/>; the current-phase label (top-right) is
+    # unchanged. Scope to the TaskTile function (the LabeledTimeline definition
+    # also lives later in the file, but the JSX usage is in the tile).
     tile = src[src.index("function TaskTile"):]
-    assert "<SdlcDots" in tile, \
-        "the TaskTile must render the animated SDLC dot stepper (<SdlcDots/>)"
+    assert "<LabeledTimeline" in tile, \
+        "the TaskTile must render the labeled phase timeline (<LabeledTimeline/>)"
     assert "stepChipClass(stepId)" in tile and "{phaseLabel}" in tile, \
         "the TaskTile must render the current-phase label (top-right) so the " \
         "information hierarchy reads at a glance"


### PR DESCRIPTION
## What & why

Ships the approved **ring + labeled-timeline** conductor tile design to production, **combined with the honest-activity conductor** work that had been stranded on an unmerged branch. Customers get both in one build.

Two lines of conductor work were both cut off an old `main` (6.8.0) and never merged:
- **Honest-activity** (v6.8.2–6.8.15): working/awaiting_gate/adrift/stalled pill, per-step fanout subdivision, focused-slice hero, tile liveness heartbeat, honest ETA (no frozen "N left" lie), wider landscape tiles.
- **Ring + timeline** (the approved Timeline-D design, task `696cacf5`): completion ring + 2×2 live metric grid + a labeled timeline over the real `WORKFLOW_STEPS_ORDERED`, peak-marked burn.

This branch cherry-picks the 9 conductor commits onto `main` (no Jira code) and **hand-merges** the tile so it has **both**: the ring/metrics/labeled-timeline visuals *and* the honest-activity signals (pill reads `task.activity.state`, current node pulses only when working + subdivides in fanout, idle ticks only when paused/adrift, ETA gated on real motion).

## Verification
- ✅ TypeScript typecheck clean
- ✅ 175 conductor/tile tests green (incl. the production `ring_timeline` test + 2 previously-stale TaskDetail assertions, now re-pointed to PlanView)
- ✅ Rendered live on the dev daemon (:8888, v6.8.18): ring, 2×2 metric grid, labeled real-step timeline, WORKING pill, burn sparkline — driven by live `phase_progress`/`activity`

## Notes
- Version set to **6.8.18**, reconciled past the stranded 6.8.1–6.8.17 range (those were never tagged/released).
- Pure SPA change on the unified conductor base; no backend touched beyond the cherry-picked conductor service work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)